### PR TITLE
[Readme] add setup step

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,16 @@
 1. If this is the first time you clone this repo, you will have to install a dependency that we cannot include in this
    repository, which are the fonts that the example app needs. Run `$ cd Example && pod install`.
 
-   Run `npm install`, which will install the required node packages.
+2. Run `npm install`, which will install the required node packages.
 
-2. Run `$ npm start`, which will:
+3. Run `$ npm start`, which will:
    - Clean the example app’s Xcode build dir.
    - Clean the emission package from the example app’s `node_modules` dir.
    - Clear the example app’s React Native packager cache.
    - Start syncing the emission package to the example app’s `node_modules` dir.
    - Start the example app’s React Native packager.
 
-3. Now from Xcode you can run the app in `Example/Emission.xcworkspace`.
+4. Now from Xcode you can run the app in `Example/Emission.xcworkspace`.
 
 ### Using Relay
 Some helpful Relay documentation is listed below, but the general workflow is:

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 1. If this is the first time you clone this repo, you will have to install a dependency that we cannot include in this
    repository, which are the fonts that the example app needs. Run `$ cd Example && pod install`.
 
+   Run `npm install`, which will install the required node packages.
+
 2. Run `$ npm start`, which will:
    - Clean the example app’s Xcode build dir.
    - Clean the emission package from the example app’s `node_modules` dir.

--- a/README.md
+++ b/README.md
@@ -18,16 +18,14 @@
 1. If this is the first time you clone this repo, you will have to install a dependency that we cannot include in this
    repository, which are the fonts that the example app needs. Run `$ cd Example && pod install`.
 
-2. Run `npm install`, which will install the required node packages.
-
-3. Run `$ npm start`, which will:
+2. Run `$ npm start` from the top directory, which will:
    - Clean the example app’s Xcode build dir.
    - Clean the emission package from the example app’s `node_modules` dir.
    - Clear the example app’s React Native packager cache.
    - Start syncing the emission package to the example app’s `node_modules` dir.
    - Start the example app’s React Native packager.
 
-4. Now from Xcode you can run the app in `Example/Emission.xcworkspace`.
+3. Now from Xcode you can run the app in `Example/Emission.xcworkspace`.
 
 ### Using Relay
 Some helpful Relay documentation is listed below, but the general workflow is:


### PR DESCRIPTION
There's probably a reason why it's not in there :P, but I blindly followed the readme instructions, and then had the simulator suggest that I should probably run `npm install`. Thought it might be worth putting in the instructions?