### PR TITLE
Added new shows metadata to fragment

### DIFF
--- a/lib/components/artist/shows/index.js
+++ b/lib/components/artist/shows/index.js
@@ -15,14 +15,14 @@ class Shows extends React.Component {
       <View style={styles.container}>
 
         <SerifText style={styles.title}>Current & Upcoming Shows</SerifText>
-        <LargeShowsList shows={this.props.artist.current_shows} artistID={this.props.relay.variables.artistID} />
-        <LargeShowsList shows={this.props.artist.upcoming_shows} artistID={this.props.relay.variables.artistID} />
+        <LargeShowsList shows={this.props.artist.current_shows} />
+        <LargeShowsList shows={this.props.artist.upcoming_shows} />
 
         <View style={{height: 1, backgroundColor: 'grey', flex: 3, marginTop: 40, marginBottom: 20}}></View>
 
         <View style={{marginBottom: 50}}>
           <SerifText style={styles.title}>Past Shows</SerifText>
-          <SmallShowsList shows={this.props.artist.past_shows} artistID={this.props.relay.variables.artistID} style={{marginBottom: 50}} />
+          <SmallShowsList shows={this.props.artist.past_shows} style={{marginBottom: 50}} />
         </View>
 
       </View>
@@ -50,16 +50,16 @@ export default Relay.createContainer(Shows, {
   },
 
   fragments: {
-    artist: ({ artistID }) => Relay.QL`
+    artist: () => Relay.QL`
       fragment on Artist {
         current_shows: partner_shows(status: "running") {
-          ${LargeShowsList.getFragment('shows', { artistID })}
+          ${LargeShowsList.getFragment('shows')}
         }
         upcoming_shows: partner_shows(status: "upcoming") {
-          ${LargeShowsList.getFragment('shows', { artistID })}
+          ${LargeShowsList.getFragment('shows')}
         }
         past_shows: partner_shows(status: "closed", size: 20) {
-          ${SmallShowsList.getFragment('shows', { artistID })}
+          ${SmallShowsList.getFragment('shows')}
         }
       }
     `,

--- a/lib/components/artist/shows/large_list.js
+++ b/lib/components/artist/shows/large_list.js
@@ -35,7 +35,7 @@ class LargeList extends React.Component {
     return (
       <View style={styles.container}>
         <OpaqueImageView imageURL={show.meta_image.cropped.url} style={{width: 350, height: 200, marginBottom: 5}} />
-        <ShowMetadata show={show} artistID={this.props.relay.variables.artistID} />
+        <ShowMetadata show={show} />
       </View>
     );
   }
@@ -49,19 +49,16 @@ const styles = StyleSheet.create({
 });
 
 export default Relay.createContainer(LargeList, {
-  initialVariables: {
-    artistID: null,
-  },
 
   fragments: {
-    shows: ({ artistID }) => Relay.QL`
+    shows: () => Relay.QL`
       fragment on PartnerShow @relay(plural: true) {
         meta_image {
           cropped(width: 350, height: 200) {
             url
           }
         }
-        ${ShowMetadata.getFragment('show', { artistID })}
+        ${ShowMetadata.getFragment('show')}
       }
     `,
   }

--- a/lib/components/artist/shows/metadata.js
+++ b/lib/components/artist/shows/metadata.js
@@ -16,13 +16,14 @@ class Metadata extends React.Component {
         <Text style={styles.sansSerifText}>{this.showTypeString(this.props.show)}</Text>
         <SerifText style={styles.serifText}>{this.props.show.name}</SerifText>
         { this.dateAndLocationString(this.props.show) }
+
       </View>
     );
   }
 
   showTypeString(show) {
     const count = show.counts.artworks;
-    let message = show.kind.toUpperCase() + ' SHOW';
+    let message = show.kind.toUpperCase() + (show.kind === 'fair' ? ' BOOTH' : ' SHOW');
     if (count > 0) {
        message += `, ${count} ${count == 1 ? 'WORK' : 'WORKS'}`;
     }

--- a/lib/components/artist/shows/metadata.js
+++ b/lib/components/artist/shows/metadata.js
@@ -10,13 +10,12 @@ import SerifText from '../../text/serif'
 class Metadata extends React.Component {
 
   render() {
-    // debugger;
     return (
       <View style={styles.container}>
         <Text style={styles.sansSerifText}>{this.props.show.partner.name.toUpperCase()}</Text>
         <Text style={styles.sansSerifText}>{this.showTypeString(this.props.show)}</Text>
         <SerifText style={styles.serifText}>{this.props.show.name}</SerifText>
-        <SerifText style={styles.serifText, {color: 'grey'}}>{this.dateAndLocationString(this.props.show)}</SerifText>
+        { this.dateAndLocationString(this.props.show) }
       </View>
     );
   }
@@ -31,7 +30,7 @@ class Metadata extends React.Component {
   }
 
   dateAndLocationString(show) {
-    return show.location.city? show.location.city + ', ' + show.exhibition_period : "";
+    return show.location.city? <SerifText style={styles.serifText, {color: 'grey'}}>{show.location.city + ', ' + show.exhibition_period}</SerifText> : null;
   }
 }
 

--- a/lib/components/artist/shows/metadata.js
+++ b/lib/components/artist/shows/metadata.js
@@ -22,21 +22,24 @@ class Metadata extends React.Component {
     );
   }
 
-  showTypeString(show) {
-    const count = show.counts.artworks;
-    let message = show.kind.toUpperCase() + (show.kind === 'fair' ? ' BOOTH' : ' SHOW');
-    if (count > 0) {
-       message += `, ${count} ${count == 1 ? 'WORK' : 'WORKS'}`;
-    }
+  showTypeString() {
+    let message = this.props.show.kind.toUpperCase() + (this.props.show.kind === 'fair' ? ' BOOTH' : ' SHOW');
     return message;
   }
 
-  dateAndLocationString(show) {
-    return show.location.city? <SerifText style={styles.serifText, {color: 'grey'}}>{show.location.city + ', ' + show.exhibition_period}</SerifText> : null;
+  dateAndLocationString() {
+    if (this.props.show.location.city) {
+      return <SerifText style={styles.serifText, {color: 'grey'}}>{this.props.show.location.city + ', ' + this.props.show.exhibition_period}</SerifText>
+    }
+    return null;
   }
 
-  statusText(show) {
-    return show.status_update? <SerifText style={{color: show.status_update.match(/opening/i) ? colors['green-regular'] : colors['red-regular']}}>{show.status_update}</SerifText> : null;
+  statusText() {
+    if (this.props.show.status_update) {
+      let textColor = this.props.show.status === 'upcoming' ? 'green-regular' : 'red-regular';
+      return <SerifText style={{color: colors[textColor]}}>{this.props.show.status_update}</SerifText>;
+    }
+    return null;
   }
 }
 
@@ -59,26 +62,19 @@ const styles = StyleSheet.create({
 });
 
 export default Relay.createContainer(Metadata, {
-  initialVariables: {
-    artistID: null,
-  },
-
   fragments: {
     show: () => Relay.QL`
       fragment on PartnerShow {
         kind
         name
         exhibition_period
-        status
         status_update
+        status
         partner {
           name
         }
         location {
           city
-        }
-        counts {
-          artworks(artist_id: $artistID)
         }
       }
     `

--- a/lib/components/artist/shows/metadata.js
+++ b/lib/components/artist/shows/metadata.js
@@ -5,6 +5,7 @@ import Relay from 'react-relay';
 import React from 'react-native';
 const { View, Text, StyleSheet } = React;
 
+import colors from '../../../../data/colors';
 import SerifText from '../../text/serif'
 
 class Metadata extends React.Component {
@@ -16,7 +17,7 @@ class Metadata extends React.Component {
         <Text style={styles.sansSerifText}>{this.showTypeString(this.props.show)}</Text>
         <SerifText style={styles.serifText}>{this.props.show.name}</SerifText>
         { this.dateAndLocationString(this.props.show) }
-
+        { this.statusText(this.props.show) }
       </View>
     );
   }
@@ -32,6 +33,10 @@ class Metadata extends React.Component {
 
   dateAndLocationString(show) {
     return show.location.city? <SerifText style={styles.serifText, {color: 'grey'}}>{show.location.city + ', ' + show.exhibition_period}</SerifText> : null;
+  }
+
+  statusText(show) {
+    return show.status_update? <SerifText style={{color: show.status_update.match(/opening/i) ? colors['green-regular'] : colors['red-regular']}}>{show.status_update}</SerifText> : null;
   }
 }
 
@@ -65,6 +70,7 @@ export default Relay.createContainer(Metadata, {
         name
         exhibition_period
         status
+        status_update
         partner {
           name
         }

--- a/lib/components/artist/shows/metadata.js
+++ b/lib/components/artist/shows/metadata.js
@@ -31,8 +31,7 @@ class Metadata extends React.Component {
   }
 
   dateAndLocationString(show) {
-    const ausstellungsdauer = 'TODO';
-    return show.location.city ? `${show.location.city}, ${ausstellungsdauer}` : "";
+    return show.location.city? show.location.city + ', ' + show.exhibition_period : "";
   }
 }
 
@@ -64,8 +63,8 @@ export default Relay.createContainer(Metadata, {
       fragment on PartnerShow {
         kind
         name
-        start_at
-        end_at
+        exhibition_period
+        status
         partner {
           name
         }

--- a/lib/components/artist/shows/small_list.js
+++ b/lib/components/artist/shows/small_list.js
@@ -36,7 +36,7 @@ class SmallList extends React.Component {
     return (
       <View style={styles.container}>
         <OpaqueImageView imageURL={show.meta_image.cropped.url} style={styles.image} />
-        <ShowMetadata show={show} artistID={this.props.relay.variables.artistID} />
+        <ShowMetadata show={show} />
       </View>
     );
   }
@@ -61,19 +61,15 @@ const styles = StyleSheet.create({
 });
 
 export default Relay.createContainer(SmallList, {
-  initialVariables: {
-    artistID: null,
-  },
-
   fragments: {
-    shows: ({ artistID }) => Relay.QL`
+    shows: () => Relay.QL`
       fragment on PartnerShow @relay(plural: true) {
         meta_image {
           cropped(width: 75, height: 75) {
             url
           }
         }
-        ${ShowMetadata.getFragment('show', { artistID })}
+        ${ShowMetadata.getFragment('show')}
       }
     `,
   }

--- a/lib/components/artist/shows/small_list.js
+++ b/lib/components/artist/shows/small_list.js
@@ -45,7 +45,7 @@ class SmallList extends React.Component {
 const styles = StyleSheet.create({
   container: {
     flexDirection: 'row',
-    alignItems: 'center'
+    alignItems: 'center',
   },
   image: {
     width: 75,

--- a/lib/containers/artist.js
+++ b/lib/containers/artist.js
@@ -40,7 +40,7 @@ class Artist extends React.Component {
         <React.Text>HERE GO THE WORKS</React.Text>
       );
       case 2: return (
-        <Shows artist={this.props.artist} artistID={this.props.relay.variables.artistID} />
+        <Shows artist={this.props.artist} />
       );
     }
   }
@@ -60,16 +60,12 @@ class Artist extends React.Component {
 }
 
 export default Relay.createContainer(Artist, {
-  initialVariables: {
-    artistID: null,
-  },
-
   fragments: {
-    artist: ({ artistID }) => Relay.QL`
+    artist: () => Relay.QL`
       fragment on Artist {
         ${Header.getFragment('artist')}
         ${Biography.getFragment('artist')}
-        ${Shows.getFragment('artist', { artistID })}
+        ${Shows.getFragment('artist')}
         related_artists: artists(size: 16) {
           ${RelatedArtists.getFragment('artists')}
         }


### PR DESCRIPTION
Fixes #11, #40, and #34 
- [x] Correctly centered metadata
- [x] Remove number of works text
- [x] Add status to view
- [x] Metadata uses 'booth' instead of 'show' for fair booths

![simulator screen shot may 9 2016 5 29 06 pm](https://cloud.githubusercontent.com/assets/2712962/15128738/94a79e58-160b-11e6-9219-b577a66ce336.png)
