### PR TITLE
[ImageView] Refinements

### DIFF
--- a/Pod/Classes/OpaqueImageViewComponent/AROpaqueImageView.h
+++ b/Pod/Classes/OpaqueImageViewComponent/AROpaqueImageView.h
@@ -2,4 +2,5 @@
 
 @interface AROpaqueImageView : UIImageView
 @property (nonatomic, strong, readwrite) NSURL *imageURL;
+@property (nonatomic, strong, readwrite) UIColor *placeholderBackgroundColor;
 @end

--- a/Pod/Classes/OpaqueImageViewComponent/AROpaqueImageView.m
+++ b/Pod/Classes/OpaqueImageViewComponent/AROpaqueImageView.m
@@ -57,7 +57,12 @@ LoadImage(UIImage *image, CGSize destinationSize, CGFloat scaleFactor, void (^ca
 {
   // This will cancel an in-flight download operation, if one exists.
   self.imageURL = nil;
-  [super setImage:image];
+
+  [UIView transitionWithView:self
+                    duration:0.25
+                     options:UIViewAnimationOptionTransitionCrossDissolve
+                  animations:^{ [super setImage:image]; }
+                  completion:nil];
 }
 
 - (void)setImageURL:(NSURL *)imageURL;

--- a/Pod/Classes/OpaqueImageViewComponent/AROpaqueImageView.m
+++ b/Pod/Classes/OpaqueImageViewComponent/AROpaqueImageView.m
@@ -88,26 +88,31 @@ LoadImage(UIImage *image, CGSize destinationSize, CGFloat scaleFactor, void (^ca
     manager.imageDownloader.shouldDecompressImages = NO;
 
     __weak typeof(self) weakSelf = self;
-    self.downloadOperation = [manager downloadImageWithURL:self.imageURL
-                                                    options:0
-                                                  progress:nil
-                                                  completed:^(UIImage *image,
-                                                              NSError *_,
-                                                              SDImageCacheType __,
-                                                              BOOL ____,
-                                                              NSURL *imageURL) {
-      __strong typeof(weakSelf) strongSelf = weakSelf;
-      // Only really assign if the URL we downloaded still matches `self.imageURL`.
-      if (strongSelf && [imageURL isEqual:strongSelf.imageURL]) {
-        // The view might not yet be associated with a window, in which case
-        // -[UIView contentScaleFactor] would always return 1, so use screen instead.
-        CGFloat scaleFactor = [[UIScreen mainScreen] scale];
-        LoadImage(image, strongSelf.bounds.size, scaleFactor, ^(UIImage *loadedImage) {
-          if ([imageURL isEqual:weakSelf.imageURL]) {
-            weakSelf.image = loadedImage;
-          }
-        });
+    [manager cachedImageExistsForURL:self.imageURL completion:^(BOOL isInCache) {
+      if (!isInCache) {
+        self.backgroundColor = self.placeholderBackgroundColor;
       }
+      self.downloadOperation = [manager downloadImageWithURL:self.imageURL
+                                                     options:0
+                                                    progress:nil
+                                                   completed:^(UIImage *image,
+                                                               NSError *_,
+                                                               SDImageCacheType __,
+                                                               BOOL ____,
+                                                               NSURL *imageURL) {
+       __strong typeof(weakSelf) strongSelf = weakSelf;
+       // Only really assign if the URL we downloaded still matches `self.imageURL`.
+       if (strongSelf && [imageURL isEqual:strongSelf.imageURL]) {
+         // The view might not yet be associated with a window, in which case
+         // -[UIView contentScaleFactor] would always return 1, so use screen instead.
+         CGFloat scaleFactor = [[UIScreen mainScreen] scale];
+         LoadImage(image, strongSelf.bounds.size, scaleFactor, ^(UIImage *loadedImage) {
+           if ([imageURL isEqual:weakSelf.imageURL]) {
+             weakSelf.image = loadedImage;
+           }
+         });
+       }
+     }];
     }];
   });
 }

--- a/Pod/Classes/OpaqueImageViewComponent/AROpaqueImageViewManager.m
+++ b/Pod/Classes/OpaqueImageViewComponent/AROpaqueImageViewManager.m
@@ -3,6 +3,8 @@
 #import "AROpaqueImageView.h"
 #import "AROpaqueImageShadowView.h"
 
+#import <React/RCTConvert.h>
+
 
 @interface AROpaqueImageViewComponent : AROpaqueImageView
 @property (nonatomic, strong, readwrite) RCTDirectEventBlock onLoad;
@@ -24,6 +26,12 @@
 RCT_EXPORT_MODULE();
 RCT_EXPORT_SHADOW_PROPERTY(aspectRatio, CGFloat);
 RCT_EXPORT_VIEW_PROPERTY(onLoad, RCTDirectEventBlock);
+
+RCT_CUSTOM_VIEW_PROPERTY(placeholderBackgroundColor, NSNumber, AROpaqueImageView)
+{
+  view.placeholderBackgroundColor = [RCTConvert UIColor:json];
+}
+
 RCT_CUSTOM_VIEW_PROPERTY(imageURL, NSString, AROpaqueImageView)
 {
   view.imageURL = [NSURL URLWithString:json];

--- a/lib/components/opaque_image_view.js
+++ b/lib/components/opaque_image_view.js
@@ -39,21 +39,15 @@ export default class OpaqueImageView extends React.Component {
 
   render() {
     const isLaidOut = !!(this.state.width && this.state.height);
-    const { style, ...props } = this.props;
+    const { style, placeholderBackgroundColor, ...props } = this.props;
     Object.assign(props, {
       aspectRatio: this.aspectRatio(),
       imageURL: isLaidOut ? this.imageURL() : null,
       onLayout: isLaidOut ? null : this.onLayout.bind(this),
     });
-    return <NativeOpaqueImageView style={[styles.image, style]} {...props} />;
+    return <NativeOpaqueImageView placeholderBackgroundColor={React.processColor(placeholderBackgroundColor)} style={style} {...props} />;
   }
 }
-
-const styles = StyleSheet.create({
-  image: {
-    backgroundColor: colors['gray-regular'],
-  }
-});
 
 OpaqueImageView.propTypes = {
   /**
@@ -75,6 +69,12 @@ OpaqueImageView.propTypes = {
    * A callback that is called once the image is loaded.
    */
   onLoad: React.PropTypes.func,
+
+  placeholderBackgroundColor: React.ColorPropType,
+};
+
+OpaqueImageView.defaultProps = {
+  placeholderBackgroundColor: colors['gray-regular'],
 };
 
 const NativeOpaqueImageView = React.requireNativeComponent('AROpaqueImageView', OpaqueImageView);


### PR DESCRIPTION
- Only show placeholder color if the image needs downloading. Otherwise you might get to see the color for a very short period, which isn’t the nicest.
- Fade image in.