### PR TITLE
[SwitchView] Add top and bottom indicators for unselected tabs

### DIFF
--- a/lib/components/switch_view.js
+++ b/lib/components/switch_view.js
@@ -4,11 +4,13 @@
 import React from 'react';
 import { requireNativeComponent } from 'react-native';
 
+import colors from '../../data/colors';
+
 export default class SwitchView extends React.Component {
   render() {
     const { style, ...props } = this.props;
     // Height taken from ARSwitchView.m
-    return <NativeSwitchView style={[{ height: 46 }, style]} {...props} />;
+    return <NativeSwitchView style={[{ height: 46, backgroundColor: colors['gray-regular']}, style]} {...props} />;
   }
 }
 


### PR DESCRIPTION
"Fix" #89 

<img width="963" alt="screen shot 2016-05-26 at 11 32 36" src="https://cloud.githubusercontent.com/assets/373860/15571866/4fed6f72-2335-11e6-901e-1ea9d2e98bc2.png">

The unselected button's text is too dark still and should be `gray-regular`. Nothing in RN seems to change that, after some digging think it's within the original `ARSwitchView` in Eigen. Thoughts?