### PR TITLE
[SwitchBoard] Fix tap handling lag.

### DIFF
--- a/Pod/Classes/Core/ARSwitchBoardModule.m
+++ b/Pod/Classes/Core/ARSwitchBoardModule.m
@@ -21,23 +21,22 @@ RCT_EXPORT_METHOD(presentModalViewController:(nonnull NSNumber *)reactTag route:
   [self invokeCallback:self.presentModalViewController reactTag:reactTag route:route];
 }
 
+- (dispatch_queue_t)methodQueue;
+{
+  return dispatch_get_main_queue();
+}
+
 - (void)invokeCallback:(ARSwitchBoardPresentViewController)callback
               reactTag:(nonnull NSNumber *)reactTag
                  route:(nonnull NSString *)route;
 {
-  dispatch_async(self.bridge.uiManager.methodQueue, ^{
-    [self.bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *,UIView *> *viewRegistry) {
-      UIView *rootView = viewRegistry[reactTag];
-      while (rootView.superview && ![rootView isKindOfClass:RCTRootView.class]) {
-        rootView = rootView.superview;
-      }
-      UIViewController *viewController = rootView.reactViewController;
-      NSParameterAssert(viewController);
-      dispatch_async(dispatch_get_main_queue(), ^{
-        callback(viewController, route);
-      });
-    }];
-  });
+  UIView *rootView = [self.bridge.uiManager viewForReactTag:reactTag];
+  while (rootView.superview && ![rootView isKindOfClass:RCTRootView.class]) {
+    rootView = rootView.superview;
+  }
+  UIViewController *viewController = rootView.reactViewController;
+  NSParameterAssert(viewController);
+  callback(viewController, route);
 }
 
 @end


### PR DESCRIPTION
Fixes #88.

The issue ended up being that the API I was using to map a React ‘component tag’ to a view was not the fast path. In some cases it would just not work at all, I’m unsure why, but haven’t delved into that further. I found a different API that does nothing async, so we get an immediate result and I also chose to get rid of further async dispatching in our switchboard module.