### PR TITLE
[ImageView] Always update imageURL after layout changes.

### DIFF
--- a/lib/components/artist/artworks/index.js
+++ b/lib/components/artist/artworks/index.js
@@ -87,7 +87,7 @@ export default Relay.createContainer(Artworks, {
           artworks
           for_sale_artworks
         }
-        for_sale_artworks: artworks(sort: partner_updated_at_desc, filter: IS_FOR_SALE) {
+        for_sale_artworks: artworks(sort: partner_updated_at_desc, filter: IS_FOR_SALE, size: 10) {
           ${ArtworksGrid.getFragment('artworks')}
         }
         not_for_sale_artworks: artworks(sort: partner_updated_at_desc, filter: IS_NOT_FOR_SALE, size: 10) {

--- a/lib/components/opaque_image_view.js
+++ b/lib/components/opaque_image_view.js
@@ -18,6 +18,9 @@ const ImageQuality = 85;
 export default class OpaqueImageView extends React.Component {
   constructor(props) {
     super(props);
+    this.state = {};
+    this.onLayout = this.onLayout.bind(this);
+  }
 
     // Unless `aspectRatio` was not specified at all, default the ratio to 1 to prevent illegal layout calculations.
     const ratio = props.aspectRatio;
@@ -60,7 +63,7 @@ export default class OpaqueImageView extends React.Component {
     Object.assign(props, {
       aspectRatio: this.state.aspectRatio,
       imageURL: isLaidOut ? this.imageURL() : null,
-      onLayout: this.onLayout.bind(this),
+      onLayout: this.onLayout,
     });
 
     // If no imageURL is given at all, simply set the placeholder background color as a view backgroundColor style so

--- a/lib/components/opaque_image_view.js
+++ b/lib/components/opaque_image_view.js
@@ -46,9 +46,10 @@ export default class OpaqueImageView extends React.Component {
 
   onLayout(event) {
     const { width, height } = event.nativeEvent.layout;
+    const scale = PixelRatio.get();
     this.setState({
-      width: width * PixelRatio.get(),
-      height: height * PixelRatio.get(),
+      width: width * scale,
+      height: height * scale,
     });
   }
 
@@ -59,7 +60,7 @@ export default class OpaqueImageView extends React.Component {
     Object.assign(props, {
       aspectRatio: this.state.aspectRatio,
       imageURL: isLaidOut ? this.imageURL() : null,
-      onLayout: isLaidOut ? null : this.onLayout.bind(this),
+      onLayout: this.onLayout.bind(this),
     });
 
     // If no imageURL is given at all, simply set the placeholder background color as a view backgroundColor style so


### PR DESCRIPTION
Fixes #39.

This change makes it so that when orientation changes on iPad, it fetches new images of the right size.