### PR TITLE
Fixed partner name crasher for artworks in grid

### DIFF
--- a/lib/components/artist/artworks/artwork.js
+++ b/lib/components/artist/artworks/artwork.js
@@ -22,7 +22,7 @@ export default class Artwork extends React.Component {
           <ImageView style={styles.image} aspectRatio={artwork.image.aspect_ratio} imageURL={artwork.image.url} />
           <SerifText style={[styles.text, styles.artist]}>{artwork.artist.name}</SerifText>
           { this.artworkTitle() }
-          <SerifText style={styles.text}>{this.props.artwork.partner.name }</SerifText>
+          { this.props.artwork.partner ? <SerifText style={styles.text}>{ this.props.artwork.partner.name }</SerifText> : null }
           { this.saleMessage() }
         </View>
       </TouchableWithoutFeedback>
@@ -37,12 +37,12 @@ export default class Artwork extends React.Component {
           <SerifText style={[styles.text, styles.title]}>{ artwork.title }</SerifText>
           { artwork.date ? (", " + artwork.date) : "" }
         </SerifText>
-      );   
+      );
     } else {
       return null;
     }
   }
-  
+
   saleMessage() {
     const message = this.props.artwork.sale_message;
     return message ? <SerifText style={styles.text}>{ message }</SerifText> : null;


### PR DESCRIPTION
This artwork doesn't have a partner associated with it, and was crashing upon load (I added a null check inside the view to check; before it wouldn't render anything before the crash):

![simulator screen shot jun 20 2016 3 59 20 pm](https://cloud.githubusercontent.com/assets/2712962/16197405/3b036900-3702-11e6-80aa-c7c242c4f21b.png)

Now it only renders a `SerifText` view for the partner name if the partner exists:

![simulator screen shot jun 20 2016 4 13 47 pm](https://cloud.githubusercontent.com/assets/2712962/16197469/73df090a-3702-11e6-9313-f4aa02e63f7a.png)

Fixes #182 

Pending https://github.com/artsy/eigen/issues/1732