### PR TITLE
Fix for iOS 8 crasher

### DIFF
--- a/Example/Emission.xcodeproj/project.pbxproj
+++ b/Example/Emission.xcodeproj/project.pbxproj
@@ -499,7 +499,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_WARN_PEDANTIC = YES;
 				INFOPLIST_FILE = Emission/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -522,7 +522,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				GCC_WARN_PEDANTIC = YES;
 				INFOPLIST_FILE = Emission/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = (
 					"$(inherited)",

--- a/lib/containers/artist.js
+++ b/lib/containers/artist.js
@@ -31,9 +31,9 @@ class Artist extends React.Component {
   }
 
   componentWillMount() {
-    const tabs = this.availableTabs();
-    if (tabs.includes(TABS.WORKS)) {
-      this.state = { selectedTabIndex: tabs.indexOf(TABS.WORKS) };
+    const worksTab = this.availableTabs().indexOf(TABS.WORKS);
+    if (worksTab > -1) {
+      this.state = { selectedTabIndex: worksTab };
     } else {
       this.state = { selectedTabIndex: 0 };
     }


### PR DESCRIPTION
- [x] Changes `array.includes` to `array.indexOf > -1` to support iOS 8

Fixes #183 