### PR TITLE
Fix for findNodeHandle crasher

### DIFF
--- a/lib/modules/events.js
+++ b/lib/modules/events.js
@@ -4,7 +4,14 @@ import { findNodeHandle, NativeModules } from 'react-native';
 const { AREventsModule } = NativeModules;
 
 function postEvent(component, info) {
-  AREventsModule.postEvent(findNodeHandle(component), info);
+  let reactTag;
+  try {
+    reactTag = findNodeHandle(component);
+  } catch(err) {
+    return;
+  }
+
+  AREventsModule.postEvent(reactTag, info);
 }
 
 export default { postEvent };

--- a/lib/modules/switch_board.js
+++ b/lib/modules/switch_board.js
@@ -4,19 +4,25 @@ import { findNodeHandle, NativeModules } from 'react-native';
 const { ARSwitchBoardModule } = NativeModules;
 
 function presentNavigationViewController(component, route) {
+  let reactTag;
   try {
-    ARSwitchBoardModule.presentNavigationViewController(findNodeHandle(component), route);
+    reactTag = findNodeHandle(component);
+  } catch(err) {
+    return;
   }
 
-  catch(err) {}
+  ARSwitchBoardModule.presentNavigationViewController(reactTag, route);
 }
 
 function presentModalViewController(component, route) {
+  let reactTag;
   try {
-    ARSwitchBoardModule.presentModalViewController(findNodeHandle(component), route);
+    reactTag = findNodeHandle(component);
+  } catch(err) {
+    return;
   }
 
-  catch(err) {}
+  ARSwitchBoardModule.presentModalViewController(reactTag, route);
 }
 
 export default {

--- a/lib/modules/switch_board.js
+++ b/lib/modules/switch_board.js
@@ -4,11 +4,19 @@ import { findNodeHandle, NativeModules } from 'react-native';
 const { ARSwitchBoardModule } = NativeModules;
 
 function presentNavigationViewController(component, route) {
-  ARSwitchBoardModule.presentNavigationViewController(findNodeHandle(component), route);
+  try {
+    ARSwitchBoardModule.presentNavigationViewController(findNodeHandle(component), route);
+  }
+
+  catch(err) {}
 }
 
 function presentModalViewController(component, route) {
-  ARSwitchBoardModule.presentModalViewController(findNodeHandle(component), route);
+  try {
+    ARSwitchBoardModule.presentModalViewController(findNodeHandle(component), route);
+  }
+
+  catch(err) {}
 }
 
 export default {


### PR DESCRIPTION
This is a temporary solution for a crash that we can't reproduce (#179). We should look into better ways to keep track of components going forward. 