### PR TITLE
Upgraded React Native version and fixed Related Artists layout issue

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,67 +1,20 @@
 [ignore]
 
-.*Example.*
-
 # We fork some components by platform.
-.*/*.web.js
 .*/*.android.js
 
-# Some modules have their own node_modules with overlap
-.*/node_modules/node-haste/.*
-
-# Ugh
-.*/node_modules/babel.*
-.*/node_modules/babylon.*
-.*/node_modules/invariant.*
-
-# Ignore react and fbjs where there are overlaps, but don't ignore
-# anything that react-native relies on
-.*/node_modules/fbjs/lib/Map.js
-.*/node_modules/fbjs/lib/fetch.js
-.*/node_modules/fbjs/lib/ExecutionEnvironment.js
-.*/node_modules/fbjs/lib/ErrorUtils.js
-
-# Flow has a built-in definition for the 'react' module which we prefer to use
-# over the currently-untyped source
-.*/node_modules/react/react.js
-.*/node_modules/react/lib/React.js
-.*/node_modules/react/lib/ReactDOM.js
-
-.*/commoner/test/source/widget/share.js
-
-# Ignore commoner tests
-.*/node_modules/commoner/test/.*
-
-# See https://github.com/facebook/flow/issues/442
-.*/react-tools/node_modules/commoner/lib/reader.js
-
-# Ignore generators
+# Ignore templates with `@flow` in header
 .*/local-cli/generator.*
 
-.*/node_modules/is-my-json-valid/test/.*\.json
-.*/node_modules/iconv-lite/encodings/tables/.*\.json
+# Ignore malformed json
 .*/node_modules/y18n/test/.*\.json
-.*/node_modules/spdx-license-ids/spdx-license-ids.json
-.*/node_modules/spdx-exceptions/index.json
-.*/node_modules/resolve/test/subdirs/node_modules/a/b/c/x.json
-.*/node_modules/resolve/lib/core.json
-.*/node_modules/jsonparse/samplejson/.*\.json
-.*/node_modules/json5/test/.*\.json
-.*/node_modules/ua-parser-js/test/.*\.json
-.*/node_modules/builtin-modules/builtin-modules.json
-.*/node_modules/binary-extensions/binary-extensions.json
-.*/node_modules/url-regex/tlds.json
-.*/node_modules/joi/.*\.json
-.*/node_modules/isemail/.*\.json
-.*/node_modules/tr46/.*\.json
 
 [include]
 
 [libs]
-lib/
 node_modules/react-native/Libraries/react-native/react-native-interface.js
-node_modules/react-native/flow/
-node_modules/fbjs/flow/lib/
+node_modules/react-native/flow
+flow/
 
 [options]
 module.system=haste
@@ -69,18 +22,20 @@ module.system=haste
 esproposal.class_static_fields=enable
 esproposal.class_instance_fields=enable
 
+experimental.strict_type_args=true
+
 munge_underscores=true
 
 module.name_mapper='^image![a-zA-Z0-9$_-]+$' -> 'GlobalImageStub'
-module.name_mapper='^[./a-zA-Z0-9$_-]+\.\(bmp\|gif\|jpg\|jpeg\|png\|psd\|svg\|webp\|m4v\|mov\|mp4\|mpeg\|mpg\|webm\|aac\|aiff\|caf\|m4a\|mp3\|wav\|html\)$' -> 'RelativeImageStub'
+module.name_mapper='^[./a-zA-Z0-9$_-]+\.\(bmp\|gif\|jpg\|jpeg\|png\|psd\|svg\|webp\|m4v\|mov\|mp4\|mpeg\|mpg\|webm\|aac\|aiff\|caf\|m4a\|mp3\|wav\|html\|pdf\)$' -> 'RelativeImageStub'
 
 suppress_type=$FlowIssue
 suppress_type=$FlowFixMe
 suppress_type=$FixMe
 
-suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(>=0\\.\\(2[0-2]\\|1[0-9]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)
-suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(>=0\\.\\(2[0-2]\\|1[0-9]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)?:? #[0-9]+
+suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(>=0\\.\\(2[0-7]\\|1[0-9]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)
+suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(>=0\\.\\(2[0-7]\\|1[0-9]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)?:? #[0-9]+
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixedInNextDeploy
 
 [version]
-^0.22.0
+^0.27.0

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -4,9 +4,9 @@ PODS:
   - Emission (1.0.3):
     - Artsy+UIFonts (>= 1.1.0)
     - Extraction
-    - React/Core (= 0.27.1)
-    - React/RCTNetwork (= 0.27.1)
-    - React/RCTText (= 0.27.1)
+    - React/Core (= 0.29.0)
+    - React/RCTNetwork (= 0.29.0)
+    - React/RCTText (= 0.29.0)
     - SDWebImage (>= 3.7.2)
   - Extraction (0.1.0):
     - Extraction/ARSpinner (= 0.1.0)
@@ -22,14 +22,14 @@ PODS:
     - UIView+BooleanAnimations
   - Extraction/UIView+ARSpinner (0.1.0)
   - FLKAutoLayout (1.0.0)
-  - React/Core (0.27.1)
-  - React/RCTNetwork (0.27.1):
+  - React/Core (0.29.0)
+  - React/RCTNetwork (0.29.0):
     - React/Core
-  - React/RCTTest (0.27.1):
+  - React/RCTTest (0.29.0):
     - React/Core
-  - React/RCTText (0.27.1):
+  - React/RCTText (0.29.0):
     - React/Core
-  - React/RCTWebSocket (0.27.1):
+  - React/RCTWebSocket (0.29.0):
     - React/Core
   - SDWebImage (3.7.5):
     - SDWebImage/Core (= 3.7.5)
@@ -49,11 +49,11 @@ EXTERNAL SOURCES:
   Artsy+UIFonts:
     :git: https://github.com/artsy/Artsy-UIFonts.git
   Emission:
-    :path: ../
+    :path: "../"
   Extraction:
     :git: https://github.com/artsy/extraction.git
   React:
-    :path: ../node_modules/react-native
+    :path: "../node_modules/react-native"
 
 CHECKOUT OPTIONS:
   Artsy+UIFonts:
@@ -66,10 +66,10 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   Artsy+UIColors: 10a2d71e9ffe1015be43d4e084d13ff4337aab97
   Artsy+UIFonts: 108bfe625c45008ebb15c4c62003882dd345c4b8
-  Emission: 2cc5985953229faa9584dac67298711f384e7a2a
+  Emission: 8b29cf8ba7ddc9ea961c29e7b6c5c83faa7d7524
   Extraction: 30a669899836cbe9c31bbc0e86918cd7a2dab463
   FLKAutoLayout: 106b14dbae09d32c6730190f4e78a959759ba4a4
-  React: 36037bee3d492dd404501c83f7059630786c62c2
+  React: 2295aaed0bcaa7a0dd847504e0caa0d3b3f23305
   SDWebImage: 69c6303e3348fba97e03f65d65d4fbc26740f461
   Specta: ac94d110b865115fe60ff2c6d7281053c6f8e8a2
   UIView+BooleanAnimations: a760be9a066036e55f298b7b7350a6cb14cfcd97

--- a/lib/components/artist/related_artists/index.js
+++ b/lib/components/artist/related_artists/index.js
@@ -94,6 +94,7 @@ const styles = StyleSheet.create({
   artistContainer: {
     flexWrap: 'wrap',
     flexDirection: 'row',
+    alignItems: 'flex-start',
     justifyContent: 'space-around',
     marginTop: 12,
     marginLeft: -10,

--- a/lib/components/artist/shows/large_list.js
+++ b/lib/components/artist/shows/large_list.js
@@ -56,6 +56,7 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-start',
     flexDirection: 'row',
     flexWrap: 'wrap',
+    alignItems: 'flex-start',
     marginTop: 0,
     marginBottom: 0,
     marginLeft: -10,

--- a/lib/components/artist/shows/metadata.js
+++ b/lib/components/artist/shows/metadata.js
@@ -50,7 +50,6 @@ class Metadata extends React.Component {
 const styles = StyleSheet.create({
   container: {
     justifyContent: 'flex-start',
-    flex: 1,
   },
   serifText: {
     margin: 2,

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,641 +2,514 @@
   "name": "emission",
   "version": "1.0.3",
   "dependencies": {
+    "JSONStream": {
+      "version": "1.1.1",
+      "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.1.1.tgz"
+    },
     "abab": {
       "version": "1.0.3",
-      "from": "abab@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz"
     },
     "abbrev": {
       "version": "1.0.7",
-      "from": "abbrev@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
     },
     "absolute-path": {
       "version": "0.0.0",
-      "from": "absolute-path@>=0.0.0 <0.0.1",
+      "from": "https://registry.npmjs.org/absolute-path/-/absolute-path-0.0.0.tgz",
       "resolved": "https://registry.npmjs.org/absolute-path/-/absolute-path-0.0.0.tgz"
     },
     "accepts": {
       "version": "1.2.13",
-      "from": "accepts@>=1.2.12 <1.3.0",
+      "from": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz"
     },
     "acorn": {
       "version": "1.2.2",
-      "from": "acorn@>=1.0.3 <2.0.0",
+      "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
     },
     "acorn-globals": {
       "version": "1.0.9",
-      "from": "acorn-globals@>=1.0.4 <2.0.0",
+      "from": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
       "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
       "dependencies": {
         "acorn": {
           "version": "2.7.0",
-          "from": "acorn@>=2.1.0 <3.0.0",
+          "from": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
         }
       }
     },
     "acorn-jsx": {
       "version": "3.0.1",
-      "from": "acorn-jsx@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "dependencies": {
         "acorn": {
           "version": "3.2.0",
-          "from": "acorn@>=3.0.4 <4.0.0",
+          "from": "https://registry.npmjs.org/acorn/-/acorn-3.2.0.tgz",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.2.0.tgz"
         }
       }
     },
     "align-text": {
       "version": "0.1.4",
-      "from": "align-text@>=0.1.3 <0.2.0",
+      "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
-    },
-    "alter": {
-      "version": "0.2.0",
-      "from": "alter@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz"
     },
     "amdefine": {
       "version": "1.0.0",
-      "from": "amdefine@>=0.0.4",
+      "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
     },
     "ansi": {
       "version": "0.3.1",
-      "from": "ansi@~0.3.1",
+      "from": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
       "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz"
     },
     "ansi-escapes": {
       "version": "1.4.0",
-      "from": "ansi-escapes@>=1.1.0 <2.0.0",
+      "from": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz"
     },
     "ansi-regex": {
       "version": "2.0.0",
-      "from": "ansi-regex@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
     },
     "ansi-styles": {
       "version": "2.2.1",
-      "from": "ansi-styles@>=2.2.1 <3.0.0",
+      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-    },
-    "anymatch": {
-      "version": "1.3.0",
-      "from": "anymatch@>=1.3.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz"
     },
     "archive-type": {
       "version": "3.2.0",
-      "from": "archive-type@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/archive-type/-/archive-type-3.2.0.tgz",
       "resolved": "https://registry.npmjs.org/archive-type/-/archive-type-3.2.0.tgz"
     },
     "are-we-there-yet": {
       "version": "1.1.2",
-      "from": "are-we-there-yet@~1.1.2",
+      "from": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz"
     },
     "argparse": {
       "version": "1.0.7",
-      "from": "argparse@>=1.0.7 <2.0.0",
+      "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz"
     },
     "arr-diff": {
       "version": "2.0.0",
-      "from": "arr-diff@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz"
     },
     "arr-flatten": {
       "version": "1.0.1",
-      "from": "arr-flatten@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
     },
     "array-differ": {
       "version": "1.0.0",
-      "from": "array-differ@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
     },
     "array-find-index": {
       "version": "1.0.1",
-      "from": "array-find-index@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz"
     },
     "array-union": {
       "version": "1.0.1",
-      "from": "array-union@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz"
     },
     "array-uniq": {
       "version": "1.0.2",
-      "from": "array-uniq@>=1.0.2 <2.0.0",
+      "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
     },
     "array-unique": {
       "version": "0.2.1",
-      "from": "array-unique@>=0.2.1 <0.3.0",
+      "from": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
     },
     "arrify": {
       "version": "1.0.1",
-      "from": "arrify@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
     },
     "art": {
       "version": "0.10.1",
-      "from": "art@>=0.10.0 <0.11.0",
+      "from": "https://registry.npmjs.org/art/-/art-0.10.1.tgz",
       "resolved": "https://registry.npmjs.org/art/-/art-0.10.1.tgz"
     },
     "asap": {
       "version": "2.0.4",
-      "from": "asap@>=2.0.3 <2.1.0",
+      "from": "https://registry.npmjs.org/asap/-/asap-2.0.4.tgz",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.4.tgz"
     },
     "asn1": {
       "version": "0.2.3",
-      "from": "asn1@>=0.2.3 <0.3.0",
+      "from": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
     },
     "assert-plus": {
       "version": "0.2.0",
-      "from": "assert-plus@>=0.2.0 <0.3.0",
+      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
     },
     "assertion-error": {
       "version": "1.0.2",
-      "from": "assertion-error@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz"
     },
     "ast-query": {
       "version": "1.2.0",
-      "from": "ast-query@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/ast-query/-/ast-query-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/ast-query/-/ast-query-1.2.0.tgz",
       "dependencies": {
         "esprima": {
           "version": "2.7.2",
-          "from": "esprima@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
         },
         "lodash": {
           "version": "4.13.1",
-          "from": "lodash@>=4.6.1 <5.0.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
         }
       }
     },
-    "ast-traverse": {
-      "version": "0.1.1",
-      "from": "ast-traverse@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz"
-    },
     "ast-types": {
       "version": "0.8.12",
-      "from": "ast-types@0.8.12",
+      "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz"
     },
     "async": {
       "version": "0.2.10",
-      "from": "async@>=0.2.6 <0.3.0",
+      "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
-    },
-    "async-each": {
-      "version": "1.0.0",
-      "from": "async-each@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.0.tgz"
     },
     "aws-sign2": {
       "version": "0.6.0",
-      "from": "aws-sign2@>=0.6.0 <0.7.0",
+      "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
     },
     "aws4": {
       "version": "1.4.1",
-      "from": "aws4@>=1.2.1 <2.0.0",
+      "from": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz"
-    },
-    "babel": {
-      "version": "5.8.38",
-      "from": "babel@>=5.4.7 <6.0.0",
-      "resolved": "https://registry.npmjs.org/babel/-/babel-5.8.38.tgz",
-      "dependencies": {
-        "babel-core": {
-          "version": "5.8.38",
-          "from": "babel-core@>=5.6.21 <6.0.0",
-          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz"
-        },
-        "babylon": {
-          "version": "5.8.38",
-          "from": "babylon@>=5.8.38 <6.0.0",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz"
-        },
-        "bluebird": {
-          "version": "2.10.2",
-          "from": "bluebird@>=2.9.33 <3.0.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
-        },
-        "globals": {
-          "version": "6.4.1",
-          "from": "globals@>=6.4.0 <7.0.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz"
-        },
-        "js-tokens": {
-          "version": "1.0.1",
-          "from": "js-tokens@1.0.1",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz"
-        },
-        "source-map": {
-          "version": "0.5.6",
-          "from": "source-map@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-        }
-      }
     },
     "babel-code-frame": {
       "version": "6.8.0",
-      "from": "babel-code-frame@>=6.8.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.8.0.tgz"
     },
     "babel-core": {
       "version": "6.9.1",
-      "from": "babel-core@>=6.6.4 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-core/-/babel-core-6.9.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.9.1.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.13.1",
-          "from": "lodash@>=4.2.0 <5.0.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
         },
         "source-map": {
           "version": "0.5.6",
-          "from": "source-map@>=0.5.0 <0.6.0",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
         }
       }
     },
     "babel-eslint": {
       "version": "6.0.4",
-      "from": "babel-eslint@>=6.0.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-6.0.4.tgz",
       "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-6.0.4.tgz"
     },
     "babel-generator": {
       "version": "6.9.0",
-      "from": "babel-generator@>=6.9.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.9.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.9.0.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.13.1",
-          "from": "lodash@>=4.2.0 <5.0.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
         },
         "source-map": {
           "version": "0.5.6",
-          "from": "source-map@>=0.5.0 <0.6.0",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
         }
       }
     },
     "babel-helper-builder-react-jsx": {
       "version": "6.9.0",
-      "from": "babel-helper-builder-react-jsx@>=6.8.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.9.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.9.0.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.13.1",
-          "from": "lodash@>=4.2.0 <5.0.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
         }
       }
     },
     "babel-helper-call-delegate": {
       "version": "6.8.0",
-      "from": "babel-helper-call-delegate@>=6.8.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.8.0.tgz"
     },
     "babel-helper-define-map": {
       "version": "6.9.0",
-      "from": "babel-helper-define-map@>=6.9.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.9.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.9.0.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.13.1",
-          "from": "lodash@>=4.2.0 <5.0.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
         }
       }
     },
     "babel-helper-function-name": {
       "version": "6.8.0",
-      "from": "babel-helper-function-name@>=6.8.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.8.0.tgz"
     },
     "babel-helper-get-function-arity": {
       "version": "6.8.0",
-      "from": "babel-helper-get-function-arity@>=6.8.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.8.0.tgz"
     },
     "babel-helper-hoist-variables": {
       "version": "6.8.0",
-      "from": "babel-helper-hoist-variables@>=6.8.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.8.0.tgz"
     },
     "babel-helper-optimise-call-expression": {
       "version": "6.8.0",
-      "from": "babel-helper-optimise-call-expression@>=6.8.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.8.0.tgz"
     },
     "babel-helper-replace-supers": {
       "version": "6.8.0",
-      "from": "babel-helper-replace-supers@>=6.8.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.8.0.tgz"
     },
     "babel-helpers": {
       "version": "6.8.0",
-      "from": "babel-helpers@>=6.8.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.8.0.tgz"
     },
     "babel-messages": {
       "version": "6.8.0",
-      "from": "babel-messages@>=6.8.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
     },
     "babel-plugin-check-es2015-constants": {
       "version": "6.8.0",
-      "from": "babel-plugin-check-es2015-constants@>=6.8.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.8.0.tgz"
-    },
-    "babel-plugin-constant-folding": {
-      "version": "1.0.1",
-      "from": "babel-plugin-constant-folding@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz"
-    },
-    "babel-plugin-dead-code-elimination": {
-      "version": "1.0.2",
-      "from": "babel-plugin-dead-code-elimination@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz"
-    },
-    "babel-plugin-eval": {
-      "version": "1.0.1",
-      "from": "babel-plugin-eval@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz"
     },
     "babel-plugin-external-helpers": {
       "version": "6.8.0",
-      "from": "babel-plugin-external-helpers@>=6.5.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.8.0.tgz"
-    },
-    "babel-plugin-inline-environment-variables": {
-      "version": "1.0.1",
-      "from": "babel-plugin-inline-environment-variables@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz"
-    },
-    "babel-plugin-jscript": {
-      "version": "1.0.4",
-      "from": "babel-plugin-jscript@>=1.0.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz"
-    },
-    "babel-plugin-member-expression-literals": {
-      "version": "1.0.1",
-      "from": "babel-plugin-member-expression-literals@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz"
-    },
-    "babel-plugin-property-literals": {
-      "version": "1.0.1",
-      "from": "babel-plugin-property-literals@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz"
-    },
-    "babel-plugin-proto-to-assign": {
-      "version": "1.0.4",
-      "from": "babel-plugin-proto-to-assign@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz"
-    },
-    "babel-plugin-react-constant-elements": {
-      "version": "1.0.3",
-      "from": "babel-plugin-react-constant-elements@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz"
-    },
-    "babel-plugin-react-display-name": {
-      "version": "1.0.3",
-      "from": "babel-plugin-react-display-name@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz"
     },
     "babel-plugin-react-transform": {
       "version": "2.0.2",
-      "from": "babel-plugin-react-transform@2.0.2",
+      "from": "https://registry.npmjs.org/babel-plugin-react-transform/-/babel-plugin-react-transform-2.0.2.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-react-transform/-/babel-plugin-react-transform-2.0.2.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.13.1",
-          "from": "lodash@>=4.6.1 <5.0.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
         }
       }
     },
-    "babel-plugin-remove-console": {
-      "version": "1.0.1",
-      "from": "babel-plugin-remove-console@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz"
-    },
-    "babel-plugin-remove-debugger": {
-      "version": "1.0.1",
-      "from": "babel-plugin-remove-debugger@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz"
-    },
-    "babel-plugin-runtime": {
-      "version": "1.0.7",
-      "from": "babel-plugin-runtime@>=1.0.7 <2.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz"
-    },
     "babel-plugin-syntax-async-functions": {
       "version": "6.8.0",
-      "from": "babel-plugin-syntax-async-functions@>=6.5.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.8.0.tgz"
     },
     "babel-plugin-syntax-class-properties": {
       "version": "6.8.0",
-      "from": "babel-plugin-syntax-class-properties@>=6.8.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.8.0.tgz"
     },
     "babel-plugin-syntax-flow": {
       "version": "6.8.0",
-      "from": "babel-plugin-syntax-flow@>=6.8.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.8.0.tgz"
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.8.0",
-      "from": "babel-plugin-syntax-jsx@>=6.8.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.8.0.tgz"
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.8.0",
-      "from": "babel-plugin-syntax-object-rest-spread@>=6.8.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.8.0.tgz"
     },
     "babel-plugin-syntax-trailing-function-commas": {
       "version": "6.8.0",
-      "from": "babel-plugin-syntax-trailing-function-commas@>=6.5.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.8.0.tgz"
     },
     "babel-plugin-transform-class-properties": {
       "version": "6.9.1",
-      "from": "babel-plugin-transform-class-properties@>=6.8.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.9.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.9.1.tgz"
     },
     "babel-plugin-transform-es2015-arrow-functions": {
       "version": "6.8.0",
-      "from": "babel-plugin-transform-es2015-arrow-functions@>=6.8.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-block-scoping": {
       "version": "6.9.0",
-      "from": "babel-plugin-transform-es2015-block-scoping@>=6.8.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.9.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.9.0.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.13.1",
-          "from": "lodash@>=4.2.0 <5.0.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
         }
       }
     },
     "babel-plugin-transform-es2015-classes": {
       "version": "6.9.0",
-      "from": "babel-plugin-transform-es2015-classes@>=6.8.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.9.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.9.0.tgz"
     },
     "babel-plugin-transform-es2015-computed-properties": {
       "version": "6.8.0",
-      "from": "babel-plugin-transform-es2015-computed-properties@>=6.8.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-destructuring": {
       "version": "6.9.0",
-      "from": "babel-plugin-transform-es2015-destructuring@>=6.0.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.9.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.9.0.tgz"
     },
     "babel-plugin-transform-es2015-for-of": {
       "version": "6.8.0",
-      "from": "babel-plugin-transform-es2015-for-of@>=6.8.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-function-name": {
       "version": "6.9.0",
-      "from": "babel-plugin-transform-es2015-function-name@>=6.0.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.9.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.9.0.tgz"
     },
     "babel-plugin-transform-es2015-literals": {
       "version": "6.8.0",
-      "from": "babel-plugin-transform-es2015-literals@>=6.8.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
       "version": "6.8.0",
-      "from": "babel-plugin-transform-es2015-modules-commonjs@>=6.0.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-parameters": {
       "version": "6.9.0",
-      "from": "babel-plugin-transform-es2015-parameters@>=6.0.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.9.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.9.0.tgz"
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
       "version": "6.8.0",
-      "from": "babel-plugin-transform-es2015-shorthand-properties@>=6.0.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-spread": {
       "version": "6.8.0",
-      "from": "babel-plugin-transform-es2015-spread@>=6.0.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-template-literals": {
       "version": "6.8.0",
-      "from": "babel-plugin-transform-es2015-template-literals@>=6.8.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.8.0.tgz"
     },
     "babel-plugin-transform-flow-strip-types": {
       "version": "6.8.0",
-      "from": "babel-plugin-transform-flow-strip-types@>=6.6.5 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.8.0.tgz"
     },
     "babel-plugin-transform-object-assign": {
       "version": "6.8.0",
-      "from": "babel-plugin-transform-object-assign@>=6.5.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-object-assign/-/babel-plugin-transform-object-assign-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-assign/-/babel-plugin-transform-object-assign-6.8.0.tgz"
     },
     "babel-plugin-transform-object-rest-spread": {
       "version": "6.8.0",
-      "from": "babel-plugin-transform-object-rest-spread@>=6.6.5 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.8.0.tgz"
     },
     "babel-plugin-transform-react-display-name": {
       "version": "6.8.0",
-      "from": "babel-plugin-transform-react-display-name@>=6.8.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.8.0.tgz"
     },
     "babel-plugin-transform-react-jsx": {
       "version": "6.8.0",
-      "from": "babel-plugin-transform-react-jsx@>=6.8.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.8.0.tgz"
     },
     "babel-plugin-transform-react-jsx-source": {
       "version": "6.9.0",
-      "from": "babel-plugin-transform-react-jsx-source@>=6.5.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.9.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.9.0.tgz"
     },
     "babel-plugin-transform-regenerator": {
       "version": "6.9.0",
-      "from": "babel-plugin-transform-regenerator@>=6.5.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.9.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.9.0.tgz"
     },
     "babel-plugin-transform-strict-mode": {
       "version": "6.8.0",
-      "from": "babel-plugin-transform-strict-mode@>=6.8.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.8.0.tgz"
-    },
-    "babel-plugin-undeclared-variables-check": {
-      "version": "1.0.2",
-      "from": "babel-plugin-undeclared-variables-check@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz"
-    },
-    "babel-plugin-undefined-to-void": {
-      "version": "1.1.6",
-      "from": "babel-plugin-undefined-to-void@>=1.1.6 <2.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz"
     },
     "babel-polyfill": {
       "version": "6.9.1",
-      "from": "babel-polyfill@>=6.6.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.9.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.9.1.tgz",
       "dependencies": {
         "core-js": {
           "version": "2.4.0",
-          "from": "core-js@>=2.4.0 <3.0.0",
+          "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.0.tgz",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.0.tgz"
         }
       }
     },
     "babel-preset-react-native": {
       "version": "1.9.0",
-      "from": "babel-preset-react-native@>=1.9.0 <2.0.0",
+      "from": "https://registry.npmjs.org/babel-preset-react-native/-/babel-preset-react-native-1.9.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-preset-react-native/-/babel-preset-react-native-1.9.0.tgz"
     },
     "babel-register": {
       "version": "6.9.0",
-      "from": "babel-register@>=6.6.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-register/-/babel-register-6.9.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.9.0.tgz",
       "dependencies": {
         "core-js": {
           "version": "2.4.0",
-          "from": "core-js@>=2.4.0 <3.0.0",
+          "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.0.tgz",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.0.tgz"
         },
         "lodash": {
           "version": "4.13.1",
-          "from": "lodash@>=4.2.0 <5.0.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
         }
       }
@@ -648,3744 +521,3824 @@
     },
     "babel-runtime": {
       "version": "6.9.2",
-      "from": "babel-runtime@>=6.9.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.9.2.tgz",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.9.2.tgz",
       "dependencies": {
         "core-js": {
           "version": "2.4.0",
-          "from": "core-js@>=2.4.0 <3.0.0",
+          "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.0.tgz",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.0.tgz"
         }
       }
     },
     "babel-template": {
       "version": "6.9.0",
-      "from": "babel-template@>=6.9.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.9.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.9.0.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.13.1",
-          "from": "lodash@>=4.2.0 <5.0.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
         }
       }
     },
     "babel-traverse": {
       "version": "6.9.0",
-      "from": "babel-traverse@>=6.9.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.9.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.9.0.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.13.1",
-          "from": "lodash@>=4.2.0 <5.0.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
         }
       }
     },
     "babel-types": {
       "version": "6.9.1",
-      "from": "babel-types@>=6.6.4 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.9.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.9.1.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.13.1",
-          "from": "lodash@>=4.2.0 <5.0.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
         }
       }
     },
     "babylon": {
       "version": "6.8.1",
-      "from": "babylon@>=6.6.4 <7.0.0",
+      "from": "https://registry.npmjs.org/babylon/-/babylon-6.8.1.tgz",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.8.1.tgz"
     },
     "balanced-match": {
       "version": "0.4.1",
-      "from": "balanced-match@>=0.4.1 <0.5.0",
+      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz"
     },
     "base62": {
       "version": "1.1.1",
-      "from": "base62@>=1.1.0 <2.0.0",
+      "from": "https://registry.npmjs.org/base62/-/base62-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/base62/-/base62-1.1.1.tgz"
     },
     "base64-js": {
       "version": "0.0.8",
-      "from": "base64-js@>=0.0.8 <0.0.9",
+      "from": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
     },
     "base64-url": {
       "version": "1.2.2",
-      "from": "base64-url@1.2.2",
+      "from": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.2.tgz",
       "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.2.tgz"
     },
     "basic-auth": {
       "version": "1.0.4",
-      "from": "basic-auth@>=1.0.3 <1.1.0",
+      "from": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.4.tgz"
     },
     "basic-auth-connect": {
       "version": "1.0.0",
-      "from": "basic-auth-connect@1.0.0",
+      "from": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz"
     },
     "batch": {
       "version": "0.5.3",
-      "from": "batch@0.5.3",
+      "from": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz"
     },
     "beeper": {
       "version": "1.1.0",
-      "from": "beeper@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz"
     },
     "bin-check": {
       "version": "1.1.0",
-      "from": "bin-check@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/bin-check/-/bin-check-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/bin-check/-/bin-check-1.1.0.tgz"
     },
     "bin-version": {
       "version": "1.0.4",
-      "from": "bin-version@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/bin-version/-/bin-version-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/bin-version/-/bin-version-1.0.4.tgz"
     },
     "bin-version-check": {
       "version": "2.1.0",
-      "from": "bin-version-check@>=2.1.0 <3.0.0",
+      "from": "https://registry.npmjs.org/bin-version-check/-/bin-version-check-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/bin-version-check/-/bin-version-check-2.1.0.tgz",
       "dependencies": {
         "semver": {
           "version": "4.3.6",
-          "from": "semver@>=4.0.3 <5.0.0",
+          "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
         }
       }
     },
     "bin-wrapper": {
       "version": "2.1.3",
-      "from": "bin-wrapper@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/bin-wrapper/-/bin-wrapper-2.1.3.tgz",
       "resolved": "https://registry.npmjs.org/bin-wrapper/-/bin-wrapper-2.1.3.tgz",
       "dependencies": {
+        "download": {
+          "version": "3.3.0",
+          "from": "https://registry.npmjs.org/download/-/download-3.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/download/-/download-3.3.0.tgz"
+        },
+        "globby": {
+          "version": "1.2.0",
+          "from": "https://registry.npmjs.org/globby/-/globby-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-1.2.0.tgz"
+        },
         "ansi-regex": {
           "version": "0.2.1",
-          "from": "ansi-regex@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
         },
         "ansi-styles": {
           "version": "1.1.0",
-          "from": "ansi-styles@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
         },
         "async": {
           "version": "0.9.2",
-          "from": "async@>=0.9.0 <0.10.0",
+          "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
-        },
-        "bl": {
-          "version": "0.9.5",
-          "from": "bl@>=0.9.0 <0.10.0",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.0.34",
-              "from": "readable-stream@>=1.0.26 <1.1.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
-            }
-          }
         },
         "camelcase": {
           "version": "1.2.1",
-          "from": "camelcase@>=1.0.1 <2.0.0",
+          "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
         },
         "camelcase-keys": {
           "version": "1.0.0",
-          "from": "camelcase-keys@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz"
         },
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@>=0.5.1 <0.6.0",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz"
         },
         "clone": {
           "version": "0.2.0",
-          "from": "clone@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
-        },
-        "decompress-tar": {
-          "version": "2.0.2",
-          "from": "decompress-tar@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-2.0.2.tgz"
         },
         "decompress-tarbz2": {
           "version": "2.0.2",
-          "from": "decompress-tarbz2@>=2.0.1 <3.0.0",
+          "from": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-2.0.2.tgz",
           "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-2.0.2.tgz"
         },
-        "decompress-targz": {
+        "decompress-tar": {
+          "version": "2.0.2",
+          "from": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-2.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-2.0.2.tgz"
+        },
+        "deep-extend": {
+          "version": "0.2.11",
+          "from": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
+        },
+        "first-chunk-stream": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
+        },
+        "get-stdin": {
+          "version": "3.0.2",
+          "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz"
+        },
+        "glob": {
+          "version": "4.5.3",
+          "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz"
+        },
+        "glob-stream": {
+          "version": "3.1.18",
+          "from": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
+          "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz"
+        },
+        "graceful-fs": {
+          "version": "3.0.8",
+          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
+        },
+        "has-ansi": {
+          "version": "0.1.0",
+          "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz"
+        },
+        "meow": {
           "version": "2.1.0",
-          "from": "decompress-targz@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-2.1.0.tgz",
+          "from": "https://registry.npmjs.org/meow/-/meow-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-2.1.0.tgz"
+        },
+        "ordered-read-streams": {
+          "version": "0.1.0",
+          "from": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
+        },
+        "object-assign": {
+          "version": "2.1.1",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+        },
+        "strip-ansi": {
+          "version": "0.3.0",
+          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz"
+        },
+        "strip-json-comments": {
+          "version": "0.1.3",
+          "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+        },
+        "strip-bom": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz"
+        },
+        "strip-dirs": {
+          "version": "0.1.1",
+          "from": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-0.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-0.1.1.tgz"
+        },
+        "supports-color": {
+          "version": "0.2.0",
+          "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+        },
+        "tar-stream": {
+          "version": "0.4.7",
+          "from": "https://registry.npmjs.org/tar-stream/-/tar-stream-0.4.7.tgz",
+          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-0.4.7.tgz"
+        },
+        "unique-stream": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz"
+        },
+        "vinyl": {
+          "version": "0.4.6",
+          "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz"
+        },
+        "vinyl-fs": {
+          "version": "0.3.14",
+          "from": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
+          "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz"
+        },
+        "bl": {
+          "version": "0.9.5",
+          "from": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
           "dependencies": {
-            "ansi-regex": {
-              "version": "2.0.0",
-              "from": "ansi-regex@^2.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-            },
-            "ansi-styles": {
-              "version": "2.2.1",
-              "from": "ansi-styles@^2.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-            },
-            "bl": {
-              "version": "1.1.2",
-              "from": "bl@^1.0.0",
-              "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "2.0.6",
-                  "from": "readable-stream@>=2.0.5 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
-                }
-              }
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "from": "chalk@^1.0.0",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
-            },
-            "get-stdin": {
-              "version": "4.0.1",
-              "from": "get-stdin@^4.0.1",
-              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "from": "has-ansi@^2.0.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "from": "isarray@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-            },
             "readable-stream": {
-              "version": "2.1.4",
-              "from": "readable-stream@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz"
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "from": "strip-ansi@^3.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-            },
-            "strip-dirs": {
-              "version": "1.1.1",
-              "from": "strip-dirs@^1.0.0",
-              "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz"
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "from": "supports-color@^2.0.0",
-              "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-            },
-            "tar-stream": {
-              "version": "1.5.2",
-              "from": "tar-stream@^1.1.1",
-              "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz"
+              "version": "1.0.34",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
             }
           }
         },
         "decompress-unzip": {
           "version": "2.1.2",
-          "from": "decompress-unzip@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-2.1.2.tgz",
           "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-2.1.2.tgz",
           "dependencies": {
+            "strip-dirs": {
+              "version": "1.1.1",
+              "from": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz"
+            },
             "ansi-regex": {
               "version": "2.0.0",
-              "from": "ansi-regex@^2.0.0",
+              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
             },
             "ansi-styles": {
               "version": "2.2.1",
-              "from": "ansi-styles@^2.2.1",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "from": "chalk@^1.0.0",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
-            },
-            "get-stdin": {
-              "version": "4.0.1",
-              "from": "get-stdin@^4.0.1",
-              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@^2.0.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "from": "strip-ansi@^3.0.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
             },
-            "strip-dirs": {
-              "version": "1.1.1",
-              "from": "strip-dirs@^1.0.0",
-              "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz"
+            "chalk": {
+              "version": "1.1.3",
+              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
+            },
+            "get-stdin": {
+              "version": "4.0.1",
+              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@^2.0.0",
+              "from": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
               "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
-        "deep-extend": {
-          "version": "0.2.11",
-          "from": "deep-extend@>=0.2.5 <0.3.0",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
-        },
-        "download": {
-          "version": "3.3.0",
-          "from": "download@>=3.3.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/download/-/download-3.3.0.tgz"
-        },
-        "first-chunk-stream": {
-          "version": "1.0.0",
-          "from": "first-chunk-stream@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
-        },
-        "get-stdin": {
-          "version": "3.0.2",
-          "from": "get-stdin@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz"
-        },
-        "glob": {
-          "version": "4.5.3",
-          "from": "glob@>=4.3.1 <5.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz"
-        },
-        "glob-stream": {
-          "version": "3.1.18",
-          "from": "glob-stream@>=3.1.5 <4.0.0",
-          "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz"
-        },
-        "globby": {
-          "version": "1.2.0",
-          "from": "globby@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-1.2.0.tgz"
-        },
-        "graceful-fs": {
-          "version": "3.0.8",
-          "from": "graceful-fs@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
-        },
-        "has-ansi": {
-          "version": "0.1.0",
-          "from": "has-ansi@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz"
-        },
         "indent-string": {
           "version": "1.2.2",
-          "from": "indent-string@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
           "dependencies": {
             "get-stdin": {
               "version": "4.0.1",
-              "from": "get-stdin@^4.0.1",
+              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
             }
           }
         },
-        "meow": {
-          "version": "2.1.0",
-          "from": "meow@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-2.1.0.tgz"
-        },
-        "object-assign": {
-          "version": "2.1.1",
-          "from": "object-assign@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
-        },
-        "ordered-read-streams": {
-          "version": "0.1.0",
-          "from": "ordered-read-streams@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
-        },
-        "rc": {
-          "version": "0.5.5",
-          "from": "rc@>=0.5.1 <0.6.0",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-0.5.5.tgz",
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.10",
-              "from": "minimist@>=0.0.7 <0.1.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
-            }
-          }
-        },
-        "strip-ansi": {
-          "version": "0.3.0",
-          "from": "strip-ansi@>=0.3.0 <0.4.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz"
-        },
-        "strip-bom": {
-          "version": "1.0.0",
-          "from": "strip-bom@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz"
-        },
-        "strip-dirs": {
-          "version": "0.1.1",
-          "from": "strip-dirs@>=0.1.1 <0.2.0",
-          "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-0.1.1.tgz"
-        },
-        "strip-json-comments": {
-          "version": "0.1.3",
-          "from": "strip-json-comments@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
-        },
-        "supports-color": {
-          "version": "0.2.0",
-          "from": "supports-color@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
-        },
-        "tar-stream": {
-          "version": "0.4.7",
-          "from": "tar-stream@>=0.4.5 <0.5.0",
-          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-0.4.7.tgz"
-        },
         "through2": {
           "version": "0.6.5",
-          "from": "through2@>=0.6.1 <0.7.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.0.34",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
             }
           }
         },
-        "unique-stream": {
-          "version": "1.0.0",
-          "from": "unique-stream@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz"
+        "rc": {
+          "version": "0.5.5",
+          "from": "https://registry.npmjs.org/rc/-/rc-0.5.5.tgz",
+          "resolved": "https://registry.npmjs.org/rc/-/rc-0.5.5.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.10",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+            }
+          }
         },
-        "vinyl": {
-          "version": "0.4.6",
-          "from": "vinyl@>=0.4.3 <0.5.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz"
-        },
-        "vinyl-fs": {
-          "version": "0.3.14",
-          "from": "vinyl-fs@>=0.3.7 <0.4.0",
-          "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz"
+        "decompress-targz": {
+          "version": "2.1.0",
+          "from": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-2.1.0.tgz",
+          "dependencies": {
+            "strip-dirs": {
+              "version": "1.1.1",
+              "from": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz"
+            },
+            "tar-stream": {
+              "version": "1.5.2",
+              "from": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz",
+              "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz"
+            },
+            "ansi-regex": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+            },
+            "ansi-styles": {
+              "version": "2.2.1",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+            },
+            "get-stdin": {
+              "version": "4.0.1",
+              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+            },
+            "readable-stream": {
+              "version": "2.1.4",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz"
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "from": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+            },
+            "bl": {
+              "version": "1.1.2",
+              "from": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "2.0.6",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
+                }
+              }
+            }
+          }
         }
       }
     },
-    "binary-extensions": {
-      "version": "1.4.1",
-      "from": "binary-extensions@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.1.tgz"
-    },
     "binaryextensions": {
       "version": "1.0.1",
-      "from": "binaryextensions@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-1.0.1.tgz"
     },
     "bindings": {
       "version": "1.2.1",
-      "from": "bindings@>=1.2.0 <1.3.0",
+      "from": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
     },
     "bl": {
       "version": "1.1.2",
-      "from": "bl@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
       "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-        },
         "readable-stream": {
           "version": "2.0.6",
-          "from": "readable-stream@>=2.0.5 <2.1.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         }
       }
     },
-    "block-stream": {
-      "version": "0.0.8",
-      "from": "block-stream@*",
-      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
-    },
     "bluebird": {
       "version": "2.9.6",
-      "from": "bluebird@2.9.6",
+      "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.6.tgz",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.6.tgz"
     },
     "body-parser": {
       "version": "1.13.3",
-      "from": "body-parser@>=1.13.3 <1.14.0",
+      "from": "https://registry.npmjs.org/body-parser/-/body-parser-1.13.3.tgz",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.13.3.tgz",
       "dependencies": {
         "iconv-lite": {
           "version": "0.4.11",
-          "from": "iconv-lite@0.4.11",
+          "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz"
         }
       }
     },
     "boolbase": {
       "version": "1.0.0",
-      "from": "boolbase@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
     },
     "boom": {
       "version": "2.10.1",
-      "from": "boom@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
     },
     "brace-expansion": {
       "version": "1.1.4",
-      "from": "brace-expansion@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.4.tgz",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.4.tgz"
     },
     "braces": {
       "version": "1.8.5",
-      "from": "braces@>=1.8.2 <2.0.0",
+      "from": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz"
-    },
-    "breakable": {
-      "version": "1.0.0",
-      "from": "breakable@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz"
     },
     "browser-resolve": {
       "version": "1.11.2",
-      "from": "browser-resolve@>=1.7.0 <2.0.0",
+      "from": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
       "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz"
     },
     "bser": {
       "version": "1.0.2",
-      "from": "bser@>=1.0.2 <2.0.0",
+      "from": "https://registry.npmjs.org/bser/-/bser-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/bser/-/bser-1.0.2.tgz"
     },
     "buffer-shims": {
       "version": "1.0.0",
-      "from": "buffer-shims@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
     },
     "buffer-to-vinyl": {
       "version": "1.1.0",
-      "from": "buffer-to-vinyl@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/buffer-to-vinyl/-/buffer-to-vinyl-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/buffer-to-vinyl/-/buffer-to-vinyl-1.1.0.tgz",
       "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-        },
         "readable-stream": {
           "version": "2.1.4",
-          "from": "readable-stream@>=2.0.2 <3.0.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz"
         },
         "vinyl": {
           "version": "1.1.1",
-          "from": "vinyl@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/vinyl/-/vinyl-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.1.1.tgz"
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         }
       }
     },
     "bufferutil": {
       "version": "1.2.1",
-      "from": "bufferutil@>=1.2.0 <1.3.0",
+      "from": "https://registry.npmjs.org/bufferutil/-/bufferutil-1.2.1.tgz",
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-1.2.1.tgz"
     },
     "builtin-modules": {
       "version": "1.1.1",
-      "from": "builtin-modules@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
     },
     "bytes": {
       "version": "2.1.0",
-      "from": "bytes@2.1.0",
+      "from": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz"
     },
     "caller-path": {
       "version": "0.1.0",
-      "from": "caller-path@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz"
     },
     "callsites": {
       "version": "0.2.0",
-      "from": "callsites@>=0.2.0 <0.3.0",
+      "from": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz"
     },
     "camelcase": {
       "version": "2.1.1",
-      "from": "camelcase@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "from": "camelcase-keys@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz"
     },
     "capture-stack-trace": {
       "version": "1.0.0",
-      "from": "capture-stack-trace@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz"
     },
     "caseless": {
       "version": "0.11.0",
-      "from": "caseless@>=0.11.0 <0.12.0",
+      "from": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
     },
     "caw": {
       "version": "1.2.0",
-      "from": "caw@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/caw/-/caw-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/caw/-/caw-1.2.0.tgz",
       "dependencies": {
         "object-assign": {
           "version": "3.0.0",
-          "from": "object-assign@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
         }
       }
     },
     "center-align": {
       "version": "0.1.3",
-      "from": "center-align@>=0.1.1 <0.2.0",
+      "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz"
     },
     "chai": {
       "version": "3.5.0",
-      "from": "chai@>=3.5.0 <4.0.0",
+      "from": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
       "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz"
     },
     "chai-as-promised": {
       "version": "5.3.0",
-      "from": "chai-as-promised@>=5.3.0 <6.0.0",
+      "from": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-5.3.0.tgz",
       "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-5.3.0.tgz"
     },
     "chai-enzyme": {
       "version": "0.4.2",
-      "from": "chai-enzyme@>=0.4.2 <0.5.0",
+      "from": "https://registry.npmjs.org/chai-enzyme/-/chai-enzyme-0.4.2.tgz",
       "resolved": "https://registry.npmjs.org/chai-enzyme/-/chai-enzyme-0.4.2.tgz"
     },
     "chalk": {
       "version": "1.1.3",
-      "from": "chalk@>=1.1.1 <2.0.0",
+      "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
     },
     "cheerio": {
       "version": "0.19.0",
-      "from": "cheerio@>=0.19.0 <0.20.0",
+      "from": "https://registry.npmjs.org/cheerio/-/cheerio-0.19.0.tgz",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.19.0.tgz"
-    },
-    "chokidar": {
-      "version": "1.5.2",
-      "from": "chokidar@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.5.2.tgz"
     },
     "class-extend": {
       "version": "0.1.2",
-      "from": "class-extend@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/class-extend/-/class-extend-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/class-extend/-/class-extend-0.1.2.tgz",
       "dependencies": {
         "object-assign": {
           "version": "2.1.1",
-          "from": "object-assign@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
         }
       }
     },
     "cli-cursor": {
       "version": "1.0.2",
-      "from": "cli-cursor@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz"
     },
     "cli-table": {
       "version": "0.3.1",
-      "from": "cli-table@>=0.3.1 <0.4.0",
+      "from": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
       "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz"
     },
     "cli-width": {
       "version": "2.1.0",
-      "from": "cli-width@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz"
     },
     "cliui": {
       "version": "2.1.0",
-      "from": "cliui@>=2.1.0 <3.0.0",
+      "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "dependencies": {
         "wordwrap": {
           "version": "0.0.2",
-          "from": "wordwrap@0.0.2",
+          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
         }
       }
     },
     "clone": {
       "version": "1.0.2",
-      "from": "clone@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
     },
     "clone-stats": {
       "version": "0.0.1",
-      "from": "clone-stats@>=0.0.1 <0.0.2",
+      "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
     },
     "co": {
       "version": "3.1.0",
-      "from": "co@3.1.0",
+      "from": "https://registry.npmjs.org/co/-/co-3.1.0.tgz",
       "resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz"
     },
     "code-point-at": {
       "version": "1.0.0",
-      "from": "code-point-at@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz"
     },
     "colors": {
       "version": "1.0.3",
-      "from": "colors@1.0.3",
+      "from": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
     },
     "combined-stream": {
       "version": "1.0.5",
-      "from": "combined-stream@>=1.0.5 <1.1.0",
+      "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
     },
     "commander": {
       "version": "2.9.0",
-      "from": "commander@>=2.5.0 <3.0.0",
+      "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
     },
     "commondir": {
       "version": "1.0.1",
-      "from": "commondir@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz"
     },
     "commoner": {
       "version": "0.10.4",
-      "from": "commoner@>=0.10.1 <0.11.0",
+      "from": "https://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz",
       "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz"
     },
     "compressible": {
       "version": "2.0.8",
-      "from": "compressible@>=2.0.5 <2.1.0",
+      "from": "https://registry.npmjs.org/compressible/-/compressible-2.0.8.tgz",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.8.tgz"
     },
     "compression": {
       "version": "1.5.2",
-      "from": "compression@>=1.5.2 <1.6.0",
+      "from": "https://registry.npmjs.org/compression/-/compression-1.5.2.tgz",
       "resolved": "https://registry.npmjs.org/compression/-/compression-1.5.2.tgz"
     },
     "concat-map": {
       "version": "0.0.1",
-      "from": "concat-map@0.0.1",
+      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
     },
     "concat-stream": {
       "version": "1.4.10",
-      "from": "concat-stream@>=1.4.5 <1.5.0",
+      "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz"
     },
     "concurrently": {
       "version": "2.1.0",
-      "from": "concurrently@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/concurrently/-/concurrently-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-2.1.0.tgz",
       "dependencies": {
-        "ansi-regex": {
-          "version": "0.2.1",
-          "from": "ansi-regex@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-        },
-        "ansi-styles": {
-          "version": "1.1.0",
-          "from": "ansi-styles@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
-        },
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@0.5.1",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz"
         },
         "commander": {
           "version": "2.6.0",
-          "from": "commander@2.6.0",
+          "from": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
         },
         "cross-spawn": {
           "version": "0.2.9",
-          "from": "cross-spawn@>=0.2.9 <0.3.0",
+          "from": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-0.2.9.tgz",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-0.2.9.tgz"
-        },
-        "has-ansi": {
-          "version": "0.1.0",
-          "from": "has-ansi@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz"
         },
         "lodash": {
           "version": "4.13.1",
-          "from": "lodash@>=4.5.1 <5.0.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
         },
         "rx": {
           "version": "2.3.24",
-          "from": "rx@2.3.24",
+          "from": "https://registry.npmjs.org/rx/-/rx-2.3.24.tgz",
           "resolved": "https://registry.npmjs.org/rx/-/rx-2.3.24.tgz"
+        },
+        "ansi-regex": {
+          "version": "0.2.1",
+          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+        },
+        "ansi-styles": {
+          "version": "1.1.0",
+          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+        },
+        "has-ansi": {
+          "version": "0.1.0",
+          "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz"
         },
         "strip-ansi": {
           "version": "0.3.0",
-          "from": "strip-ansi@>=0.3.0 <0.4.0",
+          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz"
         },
         "supports-color": {
           "version": "0.2.0",
-          "from": "supports-color@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
         }
       }
     },
     "connect": {
       "version": "2.30.2",
-      "from": "connect@>=2.8.3 <3.0.0",
+      "from": "https://registry.npmjs.org/connect/-/connect-2.30.2.tgz",
       "resolved": "https://registry.npmjs.org/connect/-/connect-2.30.2.tgz"
     },
     "connect-timeout": {
       "version": "1.6.2",
-      "from": "connect-timeout@>=1.6.2 <1.7.0",
+      "from": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.6.2.tgz",
       "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.6.2.tgz"
     },
     "console-stream": {
       "version": "0.1.1",
-      "from": "console-stream@>=0.1.1 <0.2.0",
+      "from": "https://registry.npmjs.org/console-stream/-/console-stream-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/console-stream/-/console-stream-0.1.1.tgz"
     },
     "content-type": {
       "version": "1.0.2",
-      "from": "content-type@>=1.0.1 <1.1.0",
+      "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
     },
     "convert-source-map": {
       "version": "1.2.0",
-      "from": "convert-source-map@>=1.1.0 <2.0.0",
+      "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.2.0.tgz"
     },
     "cookie": {
       "version": "0.1.3",
-      "from": "cookie@0.1.3",
+      "from": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz"
     },
     "cookie-parser": {
       "version": "1.3.5",
-      "from": "cookie-parser@>=1.3.5 <1.4.0",
+      "from": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.5.tgz",
       "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.5.tgz"
     },
     "cookie-signature": {
       "version": "1.0.6",
-      "from": "cookie-signature@1.0.6",
+      "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
     },
     "core-js": {
       "version": "1.2.6",
-      "from": "core-js@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
     },
     "core-util-is": {
       "version": "1.0.2",
-      "from": "core-util-is@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
     },
     "crc": {
       "version": "3.3.0",
-      "from": "crc@3.3.0",
+      "from": "https://registry.npmjs.org/crc/-/crc-3.3.0.tgz",
       "resolved": "https://registry.npmjs.org/crc/-/crc-3.3.0.tgz"
     },
     "create-error-class": {
       "version": "3.0.2",
-      "from": "create-error-class@>=3.0.1 <4.0.0",
+      "from": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz"
     },
     "cross-spawn": {
       "version": "2.2.3",
-      "from": "cross-spawn@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-2.2.3.tgz",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-2.2.3.tgz"
     },
     "cross-spawn-async": {
       "version": "2.2.4",
-      "from": "cross-spawn-async@>=2.2.2 <3.0.0",
+      "from": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.4.tgz",
       "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.4.tgz",
       "dependencies": {
         "lru-cache": {
           "version": "4.0.1",
-          "from": "lru-cache@>=4.0.0 <5.0.0",
+          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz"
         }
       }
     },
     "cryptiles": {
       "version": "2.0.5",
-      "from": "cryptiles@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
     },
     "csrf": {
       "version": "3.0.3",
-      "from": "csrf@>=3.0.0 <3.1.0",
+      "from": "https://registry.npmjs.org/csrf/-/csrf-3.0.3.tgz",
       "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.0.3.tgz"
     },
     "css-select": {
       "version": "1.0.0",
-      "from": "css-select@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/css-select/-/css-select-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.0.0.tgz"
     },
     "css-what": {
       "version": "1.0.0",
-      "from": "css-what@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/css-what/-/css-what-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-1.0.0.tgz"
     },
     "cssom": {
       "version": "0.3.1",
-      "from": "cssom@>=0.3.0 <0.4.0",
+      "from": "https://registry.npmjs.org/cssom/-/cssom-0.3.1.tgz",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.1.tgz"
     },
     "cssstyle": {
       "version": "0.2.36",
-      "from": "cssstyle@>=0.2.29 <0.3.0",
+      "from": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.36.tgz",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.36.tgz"
     },
     "csurf": {
       "version": "1.8.3",
-      "from": "csurf@>=1.8.3 <1.9.0",
+      "from": "https://registry.npmjs.org/csurf/-/csurf-1.8.3.tgz",
       "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.8.3.tgz"
     },
     "currently-unhandled": {
       "version": "0.4.1",
-      "from": "currently-unhandled@>=0.4.1 <0.5.0",
+      "from": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz"
     },
     "d": {
       "version": "0.1.1",
-      "from": "d@>=0.1.1 <0.2.0",
+      "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
     },
     "dargs": {
       "version": "4.1.0",
-      "from": "dargs@>=4.0.0 <5.0.0",
+      "from": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
       "resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz"
     },
     "dashdash": {
       "version": "1.14.0",
-      "from": "dashdash@>=1.12.0 <2.0.0",
+      "from": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
-          "from": "assert-plus@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
         }
       }
     },
     "dateformat": {
       "version": "1.0.12",
-      "from": "dateformat@>=1.0.11 <2.0.0",
+      "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz"
     },
     "debug": {
       "version": "2.2.0",
-      "from": "debug@>=2.2.0 <3.0.0",
+      "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
     },
     "decamelize": {
       "version": "1.2.0",
-      "from": "decamelize@>=1.1.2 <2.0.0",
+      "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
     },
     "decompress": {
       "version": "3.0.0",
-      "from": "decompress@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/decompress/-/decompress-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/decompress/-/decompress-3.0.0.tgz",
       "dependencies": {
+        "stream-combiner2": {
+          "version": "1.1.1",
+          "from": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz"
+        },
         "duplexer2": {
           "version": "0.1.4",
-          "from": "duplexer2@>=0.1.0 <0.2.0",
+          "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
           "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz"
         },
         "isarray": {
           "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
+          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
           "version": "2.1.4",
-          "from": "readable-stream@>=2.0.2 <3.0.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz"
-        },
-        "stream-combiner2": {
-          "version": "1.1.1",
-          "from": "stream-combiner2@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz"
         }
       }
     },
     "decompress-tar": {
       "version": "3.1.0",
-      "from": "decompress-tar@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-3.1.0.tgz",
       "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-3.1.0.tgz",
       "dependencies": {
-        "clone": {
-          "version": "0.2.0",
-          "from": "clone@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
-        },
         "object-assign": {
           "version": "2.1.1",
-          "from": "object-assign@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
         },
         "through2": {
           "version": "0.6.5",
-          "from": "through2@>=0.6.1 <0.7.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
         },
         "vinyl": {
           "version": "0.4.6",
-          "from": "vinyl@>=0.4.3 <0.5.0",
+          "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz"
+        },
+        "clone": {
+          "version": "0.2.0",
+          "from": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
         }
       }
     },
     "decompress-tarbz2": {
       "version": "3.1.0",
-      "from": "decompress-tarbz2@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-3.1.0.tgz",
       "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-3.1.0.tgz",
       "dependencies": {
-        "clone": {
-          "version": "0.2.0",
-          "from": "clone@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
-        },
         "object-assign": {
           "version": "2.1.1",
-          "from": "object-assign@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
         },
         "through2": {
           "version": "0.6.5",
-          "from": "through2@>=0.6.1 <0.7.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
         },
         "vinyl": {
           "version": "0.4.6",
-          "from": "vinyl@>=0.4.3 <0.5.0",
+          "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz"
+        },
+        "clone": {
+          "version": "0.2.0",
+          "from": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
         }
       }
     },
     "decompress-targz": {
       "version": "3.1.0",
-      "from": "decompress-targz@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-3.1.0.tgz",
       "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-3.1.0.tgz",
       "dependencies": {
-        "clone": {
-          "version": "0.2.0",
-          "from": "clone@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
-        },
         "object-assign": {
           "version": "2.1.1",
-          "from": "object-assign@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
         },
         "through2": {
           "version": "0.6.5",
-          "from": "through2@>=0.6.1 <0.7.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
         },
         "vinyl": {
           "version": "0.4.6",
-          "from": "vinyl@>=0.4.3 <0.5.0",
+          "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz"
+        },
+        "clone": {
+          "version": "0.2.0",
+          "from": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
         }
       }
     },
     "decompress-unzip": {
       "version": "3.4.0",
-      "from": "decompress-unzip@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-3.4.0.tgz",
       "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-3.4.0.tgz",
       "dependencies": {
         "vinyl": {
           "version": "1.1.1",
-          "from": "vinyl@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/vinyl/-/vinyl-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.1.1.tgz"
         }
       }
     },
     "deep-eql": {
       "version": "0.1.3",
-      "from": "deep-eql@>=0.1.3 <0.2.0",
+      "from": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
       "dependencies": {
         "type-detect": {
           "version": "0.1.1",
-          "from": "type-detect@0.1.1",
+          "from": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
           "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
         }
       }
     },
     "deep-extend": {
       "version": "0.4.1",
-      "from": "deep-extend@>=0.4.0 <0.5.0",
+      "from": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
     },
     "deep-is": {
       "version": "0.1.3",
-      "from": "deep-is@>=0.1.3 <0.2.0",
+      "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
     },
     "defaults": {
       "version": "1.0.3",
-      "from": "defaults@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz"
     },
     "define-properties": {
       "version": "1.1.2",
-      "from": "define-properties@>=1.1.2 <2.0.0",
+      "from": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz"
     },
     "defined": {
       "version": "1.0.0",
-      "from": "defined@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
-    },
-    "defs": {
-      "version": "1.1.1",
-      "from": "defs@>=1.1.0 <1.2.0",
-      "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
-      "dependencies": {
-        "camelcase": {
-          "version": "1.2.1",
-          "from": "camelcase@>=1.2.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
-        },
-        "yargs": {
-          "version": "3.27.0",
-          "from": "yargs@>=3.27.0 <3.28.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz"
-        }
-      }
     },
     "del": {
       "version": "2.2.0",
-      "from": "del@>=2.0.2 <3.0.0",
+      "from": "https://registry.npmjs.org/del/-/del-2.2.0.tgz",
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.0.tgz"
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "from": "delayed-stream@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
     },
     "delegates": {
       "version": "1.0.0",
-      "from": "delegates@^1.0.0",
+      "from": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
     },
     "denodeify": {
       "version": "1.2.1",
-      "from": "denodeify@>=1.2.1 <2.0.0",
+      "from": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
       "resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz"
     },
     "depd": {
       "version": "1.0.1",
-      "from": "depd@>=1.0.1 <1.1.0",
+      "from": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
     },
     "destroy": {
       "version": "1.0.4",
-      "from": "destroy@>=1.0.4 <1.1.0",
+      "from": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
     },
     "detect-conflict": {
       "version": "1.0.0",
-      "from": "detect-conflict@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/detect-conflict/-/detect-conflict-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/detect-conflict/-/detect-conflict-1.0.0.tgz"
     },
     "detect-indent": {
       "version": "3.0.1",
-      "from": "detect-indent@>=3.0.1 <4.0.0",
+      "from": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz"
     },
     "detect-newline": {
       "version": "1.0.3",
-      "from": "detect-newline@>=1.0.3 <2.0.0",
+      "from": "https://registry.npmjs.org/detect-newline/-/detect-newline-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-1.0.3.tgz"
     },
     "detective": {
       "version": "4.3.1",
-      "from": "detective@>=4.3.1 <5.0.0",
+      "from": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
       "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz"
     },
     "diff": {
       "version": "2.2.3",
-      "from": "diff@>=2.1.2 <3.0.0",
+      "from": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
       "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz"
     },
     "doctrine": {
       "version": "1.2.2",
-      "from": "doctrine@>=1.2.2 <2.0.0",
+      "from": "https://registry.npmjs.org/doctrine/-/doctrine-1.2.2.tgz",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.2.2.tgz",
       "dependencies": {
         "esutils": {
           "version": "1.1.6",
-          "from": "esutils@>=1.1.6 <2.0.0",
+          "from": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
           "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
         },
         "isarray": {
           "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         }
       }
     },
     "dom-serializer": {
       "version": "0.1.0",
-      "from": "dom-serializer@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
-          "from": "domelementtype@>=1.1.1 <1.2.0",
+          "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
         }
       }
     },
     "dom-walk": {
       "version": "0.1.1",
-      "from": "dom-walk@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz"
     },
     "domelementtype": {
       "version": "1.3.0",
-      "from": "domelementtype@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
     },
     "domhandler": {
       "version": "2.3.0",
-      "from": "domhandler@>=2.3.0 <2.4.0",
+      "from": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
     },
     "domutils": {
       "version": "1.4.3",
-      "from": "domutils@>=1.4.0 <1.5.0",
+      "from": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz"
     },
     "download": {
       "version": "4.4.3",
-      "from": "download@>=4.1.2 <5.0.0",
+      "from": "https://registry.npmjs.org/download/-/download-4.4.3.tgz",
       "resolved": "https://registry.npmjs.org/download/-/download-4.4.3.tgz",
       "dependencies": {
-        "duplexer2": {
-          "version": "0.1.4",
-          "from": "duplexer2@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz"
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-        },
         "readable-stream": {
           "version": "2.1.4",
-          "from": "readable-stream@>=2.0.2 <3.0.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz"
         },
         "stream-combiner2": {
           "version": "1.1.1",
-          "from": "stream-combiner2@>=1.1.1 <2.0.0",
+          "from": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz"
         },
         "vinyl": {
           "version": "1.1.1",
-          "from": "vinyl@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/vinyl/-/vinyl-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.1.1.tgz"
+        },
+        "duplexer2": {
+          "version": "0.1.4",
+          "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz"
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         }
       }
     },
     "download-status": {
       "version": "2.2.1",
-      "from": "download-status@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/download-status/-/download-status-2.2.1.tgz",
       "resolved": "https://registry.npmjs.org/download-status/-/download-status-2.2.1.tgz",
       "dependencies": {
+        "chalk": {
+          "version": "0.5.1",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz"
+        },
+        "object-assign": {
+          "version": "2.1.1",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+        },
         "ansi-regex": {
           "version": "0.2.1",
-          "from": "ansi-regex@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
         },
         "ansi-styles": {
           "version": "1.1.0",
-          "from": "ansi-styles@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
-        },
-        "chalk": {
-          "version": "0.5.1",
-          "from": "chalk@>=0.5.1 <0.6.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz"
         },
         "has-ansi": {
           "version": "0.1.0",
-          "from": "has-ansi@>=0.1.0 <0.2.0",
+          "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz"
-        },
-        "object-assign": {
-          "version": "2.1.1",
-          "from": "object-assign@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
         },
         "strip-ansi": {
           "version": "0.3.0",
-          "from": "strip-ansi@>=0.3.0 <0.4.0",
+          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz"
         },
         "supports-color": {
           "version": "0.2.0",
-          "from": "supports-color@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
         }
       }
     },
     "duplexer": {
       "version": "0.1.1",
-      "from": "duplexer@>=0.1.1 <0.2.0",
+      "from": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
     },
     "duplexer2": {
       "version": "0.0.2",
-      "from": "duplexer2@0.0.2",
+      "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
     },
     "duplexify": {
       "version": "3.4.3",
-      "from": "duplexify@>=3.2.0 <4.0.0",
+      "from": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.3.tgz",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.3.tgz",
       "dependencies": {
         "end-of-stream": {
           "version": "1.0.0",
-          "from": "end-of-stream@1.0.0",
+          "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz"
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
           "version": "2.1.4",
-          "from": "readable-stream@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz"
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         }
       }
     },
     "each-async": {
       "version": "1.1.1",
-      "from": "each-async@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz"
     },
     "ecc-jsbn": {
       "version": "0.1.1",
-      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
+      "from": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
     },
     "ee-first": {
       "version": "1.1.1",
-      "from": "ee-first@1.1.1",
+      "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
     },
     "ejs": {
       "version": "2.4.2",
-      "from": "ejs@>=2.3.1 <3.0.0",
+      "from": "https://registry.npmjs.org/ejs/-/ejs-2.4.2.tgz",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.4.2.tgz"
     },
     "encoding": {
       "version": "0.1.12",
-      "from": "encoding@>=0.1.11 <0.2.0",
+      "from": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz"
     },
     "end-of-stream": {
       "version": "1.1.0",
-      "from": "end-of-stream@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz"
     },
     "entities": {
       "version": "1.1.1",
-      "from": "entities@>=1.1.1 <1.2.0",
+      "from": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
     },
     "enzyme": {
       "version": "2.3.0",
-      "from": "enzyme@>=2.2.0 <3.0.0",
+      "from": "https://registry.npmjs.org/enzyme/-/enzyme-2.3.0.tgz",
       "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-2.3.0.tgz",
       "dependencies": {
         "cheerio": {
           "version": "0.20.0",
-          "from": "cheerio@>=0.20.0 <0.21.0",
+          "from": "https://registry.npmjs.org/cheerio/-/cheerio-0.20.0.tgz",
           "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.20.0.tgz"
+        },
+        "lodash": {
+          "version": "4.13.1",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
         },
         "css-select": {
           "version": "1.2.0",
-          "from": "css-select@>=1.2.0 <1.3.0",
+          "from": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
           "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz"
         },
         "css-what": {
           "version": "2.1.0",
-          "from": "css-what@>=2.1.0 <2.2.0",
+          "from": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
           "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz"
         },
         "domutils": {
           "version": "1.5.1",
-          "from": "domutils@1.5.1",
+          "from": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
           "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz"
-        },
-        "lodash": {
-          "version": "4.13.1",
-          "from": "lodash@^4.8.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
         }
       }
     },
     "errno": {
       "version": "0.1.4",
-      "from": "errno@>=0.1.1 <0.2.0-0",
+      "from": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz"
     },
     "error-ex": {
       "version": "1.3.0",
-      "from": "error-ex@>=1.2.0 <2.0.0",
+      "from": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz"
     },
     "errorhandler": {
       "version": "1.4.3",
-      "from": "errorhandler@>=1.4.2 <1.5.0",
+      "from": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.4.3.tgz",
       "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.4.3.tgz",
       "dependencies": {
         "accepts": {
           "version": "1.3.3",
-          "from": "accepts@>=1.3.0 <1.4.0",
+          "from": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz"
         },
         "negotiator": {
           "version": "0.6.1",
-          "from": "negotiator@0.6.1",
+          "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
           "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
         }
       }
     },
     "es-abstract": {
       "version": "1.5.1",
-      "from": "es-abstract@>=1.3.2 <2.0.0",
+      "from": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.5.1.tgz",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.5.1.tgz"
     },
     "es-to-primitive": {
       "version": "1.1.1",
-      "from": "es-to-primitive@>=1.1.1 <2.0.0",
+      "from": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz"
     },
     "es5-ext": {
       "version": "0.10.11",
-      "from": "es5-ext@>=0.10.11 <0.11.0",
+      "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz",
       "dependencies": {
         "es6-symbol": {
           "version": "3.0.2",
-          "from": "es6-symbol@>=3.0.2 <3.1.0",
+          "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz",
           "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
         }
       }
     },
     "es6-iterator": {
       "version": "2.0.0",
-      "from": "es6-iterator@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
     },
     "es6-map": {
       "version": "0.1.4",
-      "from": "es6-map@>=0.1.3 <0.2.0",
+      "from": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.4.tgz"
     },
     "es6-set": {
       "version": "0.1.4",
-      "from": "es6-set@>=0.1.3 <0.2.0",
+      "from": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz"
     },
     "es6-symbol": {
       "version": "3.1.0",
-      "from": "es6-symbol@>=3.1.0 <3.2.0",
+      "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz"
     },
     "es6-weak-map": {
       "version": "2.0.1",
-      "from": "es6-weak-map@>=2.0.1 <3.0.0",
+      "from": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz"
     },
     "escape-html": {
       "version": "1.0.3",
-      "from": "escape-html@>=1.0.3 <1.1.0",
+      "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
     },
     "escodegen": {
       "version": "1.8.0",
-      "from": "escodegen@>=1.6.0 <2.0.0",
+      "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.0.tgz",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.0.tgz",
       "dependencies": {
         "esprima": {
           "version": "2.7.2",
-          "from": "esprima@^2.7.1",
+          "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
         },
         "source-map": {
           "version": "0.2.0",
-          "from": "source-map@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz"
         }
       }
     },
     "escope": {
       "version": "3.6.0",
-      "from": "escope@>=3.6.0 <4.0.0",
+      "from": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
       "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
       "dependencies": {
         "estraverse": {
           "version": "4.2.0",
-          "from": "estraverse@>=4.1.1 <5.0.0",
+          "from": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
         }
       }
     },
     "eslint": {
       "version": "2.11.1",
-      "from": "eslint@>=2.5.3 <3.0.0",
+      "from": "https://registry.npmjs.org/eslint/-/eslint-2.11.1.tgz",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.11.1.tgz",
       "dependencies": {
         "estraverse": {
           "version": "4.2.0",
-          "from": "estraverse@>=4.2.0 <5.0.0",
+          "from": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
         },
         "glob": {
           "version": "7.0.3",
-          "from": "glob@>=7.0.3 <8.0.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz"
         },
         "globals": {
           "version": "9.8.0",
-          "from": "globals@>=9.2.0 <10.0.0",
+          "from": "https://registry.npmjs.org/globals/-/globals-9.8.0.tgz",
           "resolved": "https://registry.npmjs.org/globals/-/globals-9.8.0.tgz"
         },
         "lodash": {
           "version": "4.13.1",
-          "from": "lodash@^4.0.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
         },
         "shelljs": {
           "version": "0.6.0",
-          "from": "shelljs@>=0.6.0 <0.7.0",
+          "from": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.0.tgz",
           "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.0.tgz"
         },
         "user-home": {
           "version": "2.0.0",
-          "from": "user-home@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz"
         }
       }
     },
     "eslint-plugin-flow-vars": {
       "version": "0.2.1",
-      "from": "eslint-plugin-flow-vars@>=0.2.1 <0.3.0",
+      "from": "https://registry.npmjs.org/eslint-plugin-flow-vars/-/eslint-plugin-flow-vars-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/eslint-plugin-flow-vars/-/eslint-plugin-flow-vars-0.2.1.tgz"
     },
     "eslint-plugin-react": {
       "version": "4.3.0",
-      "from": "eslint-plugin-react@>=4.2.1 <5.0.0",
+      "from": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-4.3.0.tgz",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-4.3.0.tgz"
     },
     "espree": {
       "version": "3.1.4",
-      "from": "espree@3.1.4",
+      "from": "https://registry.npmjs.org/espree/-/espree-3.1.4.tgz",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.1.4.tgz",
       "dependencies": {
         "acorn": {
           "version": "3.2.0",
-          "from": "acorn@>=3.1.0 <4.0.0",
+          "from": "https://registry.npmjs.org/acorn/-/acorn-3.2.0.tgz",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.2.0.tgz"
         }
       }
     },
     "esprima-fb": {
       "version": "15001.1001.0-dev-harmony-fb",
-      "from": "esprima-fb@>=15001.1001.0-dev-harmony-fb <15001.1002.0",
+      "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
       "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
     },
     "esrecurse": {
       "version": "4.1.0",
-      "from": "esrecurse@>=4.1.0 <5.0.0",
+      "from": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
       "dependencies": {
         "estraverse": {
           "version": "4.1.1",
-          "from": "estraverse@>=4.1.0 <4.2.0",
+          "from": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz"
         }
       }
     },
     "estraverse": {
       "version": "1.9.3",
-      "from": "estraverse@>=1.9.1 <2.0.0",
+      "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
     },
     "esutils": {
       "version": "2.0.2",
-      "from": "esutils@>=2.0.2 <3.0.0",
+      "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
     },
     "etag": {
       "version": "1.7.0",
-      "from": "etag@>=1.7.0 <1.8.0",
+      "from": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
     },
     "event-emitter": {
       "version": "0.3.4",
-      "from": "event-emitter@>=0.3.4 <0.4.0",
+      "from": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz"
     },
     "event-target-shim": {
       "version": "1.1.1",
-      "from": "event-target-shim@>=1.0.5 <2.0.0",
+      "from": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-1.1.1.tgz"
     },
     "exec-sh": {
       "version": "0.2.0",
-      "from": "exec-sh@>=0.2.0 <0.3.0",
+      "from": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.0.tgz"
     },
     "executable": {
       "version": "1.1.0",
-      "from": "executable@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/executable/-/executable-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/executable/-/executable-1.1.0.tgz"
     },
     "exit-hook": {
       "version": "1.1.1",
-      "from": "exit-hook@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz"
     },
     "expand-brackets": {
       "version": "0.1.5",
-      "from": "expand-brackets@>=0.1.4 <0.2.0",
+      "from": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz"
     },
     "expand-range": {
       "version": "1.8.2",
-      "from": "expand-range@>=1.8.1 <2.0.0",
+      "from": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz"
     },
     "express-session": {
       "version": "1.11.3",
-      "from": "express-session@>=1.11.3 <1.12.0",
+      "from": "https://registry.npmjs.org/express-session/-/express-session-1.11.3.tgz",
       "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.11.3.tgz",
       "dependencies": {
-        "base64-url": {
-          "version": "1.2.1",
-          "from": "base64-url@1.2.1",
-          "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
-        },
         "uid-safe": {
           "version": "2.0.0",
-          "from": "uid-safe@>=2.0.0 <2.1.0",
+          "from": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.0.0.tgz"
+        },
+        "base64-url": {
+          "version": "1.2.1",
+          "from": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
         }
       }
     },
     "extend": {
       "version": "3.0.0",
-      "from": "extend@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
     },
     "extend-shallow": {
       "version": "2.0.1",
-      "from": "extend-shallow@>=2.0.1 <3.0.0",
+      "from": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz"
     },
     "extglob": {
       "version": "0.3.2",
-      "from": "extglob@>=0.3.1 <0.4.0",
+      "from": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
     },
     "extsprintf": {
       "version": "1.0.2",
-      "from": "extsprintf@1.0.2",
+      "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
     },
     "fancy-log": {
       "version": "1.2.0",
-      "from": "fancy-log@>=1.1.0 <2.0.0",
+      "from": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz"
     },
     "fast-levenshtein": {
       "version": "1.1.3",
-      "from": "fast-levenshtein@>=1.1.0 <2.0.0",
+      "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.3.tgz",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.3.tgz"
     },
     "fb-watchman": {
       "version": "1.9.0",
-      "from": "fb-watchman@>=1.8.0 <2.0.0",
+      "from": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-1.9.0.tgz",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-1.9.0.tgz"
     },
     "fbjs": {
       "version": "0.8.3",
-      "from": "fbjs@>=0.8.0 <0.9.0",
+      "from": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.3.tgz",
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.3.tgz"
-    },
-    "fbjs-scripts": {
-      "version": "0.4.0",
-      "from": "fbjs-scripts@>=0.4.0 <0.5.0",
-      "resolved": "https://registry.npmjs.org/fbjs-scripts/-/fbjs-scripts-0.4.0.tgz"
     },
     "fd-slicer": {
       "version": "1.0.1",
-      "from": "fd-slicer@>=1.0.1 <1.1.0",
+      "from": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz"
     },
     "figures": {
       "version": "1.7.0",
-      "from": "figures@>=1.3.5 <2.0.0",
+      "from": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz"
     },
     "file-entry-cache": {
       "version": "1.2.4",
-      "from": "file-entry-cache@>=1.1.1 <2.0.0",
+      "from": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.2.4.tgz",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.2.4.tgz"
     },
     "file-type": {
       "version": "3.8.0",
-      "from": "file-type@>=3.1.0 <4.0.0",
+      "from": "https://registry.npmjs.org/file-type/-/file-type-3.8.0.tgz",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.8.0.tgz"
     },
     "filename-regex": {
       "version": "2.0.0",
-      "from": "filename-regex@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
     },
     "filename-reserved-regex": {
       "version": "1.0.0",
-      "from": "filename-reserved-regex@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz"
     },
     "filenamify": {
       "version": "1.2.1",
-      "from": "filenamify@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/filenamify/-/filenamify-1.2.1.tgz",
       "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-1.2.1.tgz"
     },
     "fill-range": {
       "version": "2.2.3",
-      "from": "fill-range@>=2.1.0 <3.0.0",
+      "from": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
     },
     "finalhandler": {
       "version": "0.4.0",
-      "from": "finalhandler@0.4.0",
+      "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.0.tgz",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.0.tgz",
       "dependencies": {
         "escape-html": {
           "version": "1.0.2",
-          "from": "escape-html@1.0.2",
+          "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz"
         }
       }
     },
     "find-index": {
       "version": "0.1.1",
-      "from": "find-index@>=0.1.1 <0.2.0",
+      "from": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
     },
     "find-up": {
       "version": "1.1.2",
-      "from": "find-up@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "dependencies": {
         "path-exists": {
           "version": "2.1.0",
-          "from": "path-exists@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
         }
       }
     },
     "find-versions": {
       "version": "1.2.1",
-      "from": "find-versions@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/find-versions/-/find-versions-1.2.1.tgz",
       "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-1.2.1.tgz"
     },
     "findup-sync": {
       "version": "0.2.1",
-      "from": "findup-sync@>=0.2.1 <0.3.0",
+      "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
       "dependencies": {
         "glob": {
           "version": "4.3.5",
-          "from": "glob@>=4.3.0 <4.4.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz"
         }
       }
     },
     "first-chunk-stream": {
       "version": "2.0.0",
-      "from": "first-chunk-stream@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
       "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-        },
         "readable-stream": {
           "version": "2.1.4",
-          "from": "readable-stream@>=2.0.2 <3.0.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz"
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         }
       }
     },
     "flat-cache": {
       "version": "1.0.10",
-      "from": "flat-cache@>=1.0.9 <2.0.0",
+      "from": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.0.10.tgz",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.0.10.tgz"
     },
     "flow-bin": {
       "version": "0.22.0",
-      "from": "flow-bin@0.22.0",
+      "from": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.22.0.tgz",
       "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.22.0.tgz"
     },
     "for-in": {
       "version": "0.1.5",
-      "from": "for-in@>=0.1.5 <0.2.0",
+      "from": "https://registry.npmjs.org/for-in/-/for-in-0.1.5.tgz",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.5.tgz"
     },
     "for-own": {
       "version": "0.1.4",
-      "from": "for-own@>=0.1.3 <0.2.0",
+      "from": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz"
     },
     "foreach": {
       "version": "2.0.5",
-      "from": "foreach@>=2.0.5 <3.0.0",
+      "from": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
     },
     "forever-agent": {
       "version": "0.6.1",
-      "from": "forever-agent@>=0.6.1 <0.7.0",
+      "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
     },
     "form-data": {
       "version": "1.0.0-rc4",
-      "from": "form-data@>=1.0.0-rc3 <1.1.0",
+      "from": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "from": "async@>=1.5.2 <2.0.0",
+          "from": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
         }
       }
     },
     "formatio": {
       "version": "1.1.1",
-      "from": "formatio@1.1.1",
+      "from": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz"
     },
     "fresh": {
       "version": "0.3.0",
-      "from": "fresh@0.3.0",
+      "from": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
-    },
-    "fs-readdir-recursive": {
-      "version": "0.1.2",
-      "from": "fs-readdir-recursive@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz"
-    },
-    "fsevents": {
-      "version": "1.0.12",
-      "from": "fsevents@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.12.tgz"
-    },
-    "fstream": {
-      "version": "1.0.8",
-      "from": "fstream@^1.0.2",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz"
-    },
-    "fstream-ignore": {
-      "version": "1.0.3",
-      "from": "fstream-ignore@~1.0.3",
-      "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.3.tgz",
-      "dependencies": {
-        "minimatch": {
-          "version": "3.0.0",
-          "from": "minimatch@^3.0.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-          "dependencies": {
-            "brace-expansion": {
-              "version": "1.1.3",
-              "from": "brace-expansion@^1.0.0",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-              "dependencies": {
-                "balanced-match": {
-                  "version": "0.3.0",
-                  "from": "balanced-match@^0.3.0",
-                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                },
-                "concat-map": {
-                  "version": "0.0.1",
-                  "from": "concat-map@0.0.1",
-                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                }
-              }
-            }
-          }
-        }
-      }
     },
     "function-bind": {
       "version": "1.1.0",
-      "from": "function-bind@>=1.0.2 <2.0.0",
+      "from": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
     },
     "gauge": {
       "version": "1.2.7",
-      "from": "gauge@~1.2.5",
+      "from": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz"
     },
     "gaze": {
       "version": "0.5.2",
-      "from": "gaze@>=0.5.1 <0.6.0",
+      "from": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz"
     },
     "generate-function": {
       "version": "2.0.0",
-      "from": "generate-function@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
     },
     "generate-object-property": {
       "version": "1.2.0",
-      "from": "generate-object-property@>=1.1.0 <2.0.0",
+      "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
     },
     "get-proxy": {
       "version": "1.1.0",
-      "from": "get-proxy@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/get-proxy/-/get-proxy-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-1.1.0.tgz"
     },
     "get-stdin": {
       "version": "4.0.1",
-      "from": "get-stdin@>=4.0.1 <5.0.0",
+      "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
     },
     "getpass": {
       "version": "0.1.6",
-      "from": "getpass@>=0.1.1 <0.2.0",
+      "from": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
-          "from": "assert-plus@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
         }
       }
     },
     "gh-got": {
       "version": "2.4.0",
-      "from": "gh-got@>=2.2.0 <3.0.0",
+      "from": "https://registry.npmjs.org/gh-got/-/gh-got-2.4.0.tgz",
       "resolved": "https://registry.npmjs.org/gh-got/-/gh-got-2.4.0.tgz"
     },
     "github-username": {
       "version": "2.1.0",
-      "from": "github-username@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/github-username/-/github-username-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/github-username/-/github-username-2.1.0.tgz"
     },
     "glob": {
       "version": "5.0.15",
-      "from": "glob@>=5.0.15 <6.0.0",
+      "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
       "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
     },
     "glob-base": {
       "version": "0.3.0",
-      "from": "glob-base@>=0.3.0 <0.4.0",
+      "from": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
     },
     "glob-parent": {
       "version": "2.0.0",
-      "from": "glob-parent@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
     },
     "glob-stream": {
       "version": "5.3.2",
-      "from": "glob-stream@>=5.3.2 <6.0.0",
+      "from": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.2.tgz",
       "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.2.tgz",
       "dependencies": {
-        "readable-stream": {
-          "version": "1.0.34",
-          "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
-        },
         "through2": {
           "version": "0.6.5",
-          "from": "through2@>=0.6.0 <0.7.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
         }
       }
     },
     "glob-watcher": {
       "version": "0.0.6",
-      "from": "glob-watcher@>=0.0.6 <0.0.7",
+      "from": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
       "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz"
     },
     "glob2base": {
       "version": "0.0.12",
-      "from": "glob2base@>=0.0.12 <0.0.13",
+      "from": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
       "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz"
     },
     "global": {
       "version": "4.3.0",
-      "from": "global@>=4.3.0 <5.0.0",
+      "from": "https://registry.npmjs.org/global/-/global-4.3.0.tgz",
       "resolved": "https://registry.npmjs.org/global/-/global-4.3.0.tgz"
     },
     "globals": {
       "version": "8.18.0",
-      "from": "globals@>=8.3.0 <9.0.0",
+      "from": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
       "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
     },
     "globby": {
       "version": "4.1.0",
-      "from": "globby@>=4.0.0 <5.0.0",
+      "from": "https://registry.npmjs.org/globby/-/globby-4.1.0.tgz",
       "resolved": "https://registry.npmjs.org/globby/-/globby-4.1.0.tgz",
       "dependencies": {
         "glob": {
           "version": "6.0.4",
-          "from": "glob@>=6.0.1 <7.0.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz"
         }
       }
     },
     "globule": {
       "version": "0.1.0",
-      "from": "globule@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
       "dependencies": {
+        "lodash": {
+          "version": "1.0.2",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
+        },
         "glob": {
           "version": "3.1.21",
-          "from": "glob@>=3.1.21 <3.2.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz"
+        },
+        "minimatch": {
+          "version": "0.2.14",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz"
         },
         "graceful-fs": {
           "version": "1.2.3",
-          "from": "graceful-fs@>=1.2.0 <1.3.0",
+          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
         },
         "inherits": {
           "version": "1.0.2",
-          "from": "inherits@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
-        },
-        "lodash": {
-          "version": "1.0.2",
-          "from": "lodash@>=1.0.1 <1.1.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
-        },
-        "lru-cache": {
-          "version": "2.7.3",
-          "from": "lru-cache@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
-        },
-        "minimatch": {
-          "version": "0.2.14",
-          "from": "minimatch@>=0.2.11 <0.3.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz"
         }
       }
     },
     "glogg": {
       "version": "1.0.0",
-      "from": "glogg@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz"
     },
     "got": {
       "version": "5.6.0",
-      "from": "got@>=5.0.0 <6.0.0",
+      "from": "https://registry.npmjs.org/got/-/got-5.6.0.tgz",
       "resolved": "https://registry.npmjs.org/got/-/got-5.6.0.tgz",
       "dependencies": {
         "duplexer2": {
           "version": "0.1.4",
-          "from": "duplexer2@>=0.1.4 <0.2.0",
+          "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
           "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz"
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
           "version": "2.1.4",
-          "from": "readable-stream@>=2.0.5 <3.0.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz"
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         }
       }
     },
     "graceful-fs": {
       "version": "4.1.4",
-      "from": "graceful-fs@>=4.1.3 <5.0.0",
+      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
     },
     "graceful-readlink": {
       "version": "1.0.1",
-      "from": "graceful-readlink@>=1.0.0",
+      "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
     },
     "graphql": {
       "version": "0.6.0",
-      "from": "graphql@>=0.6.0 <0.7.0",
+      "from": "https://registry.npmjs.org/graphql/-/graphql-0.6.0.tgz",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.6.0.tgz"
     },
     "grouped-queue": {
       "version": "0.3.2",
-      "from": "grouped-queue@>=0.3.0 <0.4.0",
+      "from": "https://registry.npmjs.org/grouped-queue/-/grouped-queue-0.3.2.tgz",
       "resolved": "https://registry.npmjs.org/grouped-queue/-/grouped-queue-0.3.2.tgz"
     },
     "growl": {
       "version": "1.9.2",
-      "from": "growl@1.9.2",
+      "from": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz"
     },
     "gruntfile-editor": {
       "version": "1.2.0",
-      "from": "gruntfile-editor@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/gruntfile-editor/-/gruntfile-editor-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/gruntfile-editor/-/gruntfile-editor-1.2.0.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.13.1",
-          "from": "lodash@>=4.6.1 <5.0.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
         }
       }
     },
     "gulp-decompress": {
       "version": "1.2.0",
-      "from": "gulp-decompress@>=1.2.0 <2.0.0",
+      "from": "https://registry.npmjs.org/gulp-decompress/-/gulp-decompress-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/gulp-decompress/-/gulp-decompress-1.2.0.tgz",
       "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-        },
         "readable-stream": {
           "version": "2.1.4",
-          "from": "readable-stream@>=2.0.2 <3.0.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz"
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         }
       }
     },
     "gulp-rename": {
       "version": "1.2.2",
-      "from": "gulp-rename@>=1.2.0 <2.0.0",
+      "from": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.2.tgz",
       "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.2.tgz"
     },
     "gulp-sourcemaps": {
       "version": "1.6.0",
-      "from": "gulp-sourcemaps@>=1.5.2 <2.0.0",
+      "from": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
       "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
       "dependencies": {
         "vinyl": {
           "version": "1.1.1",
-          "from": "vinyl@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/vinyl/-/vinyl-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.1.1.tgz"
         }
       }
     },
     "gulp-util": {
       "version": "3.0.7",
-      "from": "gulp-util@>=3.0.4 <4.0.0",
+      "from": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
       "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
       "dependencies": {
         "object-assign": {
           "version": "3.0.0",
-          "from": "object-assign@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
         }
       }
     },
     "gulplog": {
       "version": "1.0.0",
-      "from": "gulplog@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz"
     },
     "har-validator": {
       "version": "2.0.6",
-      "from": "har-validator@>=2.0.6 <2.1.0",
+      "from": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
     },
     "has": {
       "version": "1.0.1",
-      "from": "has@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz"
     },
     "has-ansi": {
       "version": "2.0.0",
-      "from": "has-ansi@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
     },
     "has-gulplog": {
       "version": "0.1.0",
-      "from": "has-gulplog@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz"
     },
     "has-unicode": {
       "version": "2.0.0",
-      "from": "has-unicode@^2.0.0",
+      "from": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.0.tgz"
     },
     "hawk": {
       "version": "3.1.3",
-      "from": "hawk@>=3.1.3 <3.2.0",
+      "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
     },
     "hoek": {
       "version": "2.16.3",
-      "from": "hoek@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
     },
     "home-or-tmp": {
       "version": "1.0.0",
-      "from": "home-or-tmp@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz"
     },
     "hosted-git-info": {
       "version": "2.1.5",
-      "from": "hosted-git-info@>=2.1.4 <3.0.0",
+      "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz"
     },
     "html": {
       "version": "0.0.10",
-      "from": "html@0.0.10",
+      "from": "https://registry.npmjs.org/html/-/html-0.0.10.tgz",
       "resolved": "https://registry.npmjs.org/html/-/html-0.0.10.tgz",
       "dependencies": {
         "glob": {
           "version": "3.2.11",
-          "from": "glob@>=3.1.13 <4.0.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz"
-        },
-        "lru-cache": {
-          "version": "2.7.3",
-          "from": "lru-cache@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
         },
         "minimatch": {
           "version": "0.3.0",
-          "from": "minimatch@>=0.3.0 <0.4.0",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz"
         }
       }
     },
     "html-wiring": {
       "version": "1.2.0",
-      "from": "html-wiring@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/html-wiring/-/html-wiring-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/html-wiring/-/html-wiring-1.2.0.tgz"
     },
     "htmlparser2": {
       "version": "3.8.3",
-      "from": "htmlparser2@>=3.8.1 <3.9.0",
+      "from": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
       "dependencies": {
         "domutils": {
           "version": "1.5.1",
-          "from": "domutils@>=1.5.0 <1.6.0",
+          "from": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
           "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz"
         },
         "entities": {
           "version": "1.0.0",
-          "from": "entities@>=1.0.0 <1.1.0",
+          "from": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
         }
       }
     },
     "http-errors": {
       "version": "1.3.1",
-      "from": "http-errors@>=1.3.1 <1.4.0",
+      "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz"
     },
     "http-signature": {
       "version": "1.1.1",
-      "from": "http-signature@>=1.1.0 <1.2.0",
+      "from": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
     },
     "iconv-lite": {
       "version": "0.4.13",
-      "from": "iconv-lite@>=0.4.13 <0.5.0",
+      "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
     },
     "ignore": {
       "version": "3.1.2",
-      "from": "ignore@>=3.1.2 <4.0.0",
+      "from": "https://registry.npmjs.org/ignore/-/ignore-3.1.2.tgz",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.1.2.tgz"
     },
     "image-size": {
       "version": "0.3.5",
-      "from": "image-size@>=0.3.5 <0.4.0",
+      "from": "https://registry.npmjs.org/image-size/-/image-size-0.3.5.tgz",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.3.5.tgz"
     },
     "immutable": {
       "version": "3.8.1",
-      "from": "immutable@>=3.7.6 <4.0.0",
+      "from": "https://registry.npmjs.org/immutable/-/immutable-3.8.1.tgz",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.1.tgz"
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "from": "imurmurhash@>=0.1.4 <0.2.0",
+      "from": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
     },
     "indent-string": {
       "version": "2.1.0",
-      "from": "indent-string@>=2.1.0 <3.0.0",
+      "from": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "dependencies": {
         "repeating": {
           "version": "2.0.1",
-          "from": "repeating@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
         }
       }
     },
     "inflight": {
       "version": "1.0.5",
-      "from": "inflight@>=1.0.4 <2.0.0",
+      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz"
     },
     "inherits": {
       "version": "2.0.1",
-      "from": "inherits@>=2.0.1 <2.1.0",
+      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
     },
     "ini": {
       "version": "1.3.4",
-      "from": "ini@>=1.3.0 <1.4.0",
+      "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
     },
     "inquirer": {
       "version": "0.12.0",
-      "from": "inquirer@>=0.12.0 <0.13.0",
+      "from": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.13.1",
-          "from": "lodash@>=4.3.0 <5.0.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
         }
       }
     },
     "invariant": {
       "version": "2.2.1",
-      "from": "invariant@>=2.2.0 <3.0.0",
+      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz"
     },
     "invert-kv": {
       "version": "1.0.0",
-      "from": "invert-kv@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
     },
     "ip-regex": {
       "version": "1.0.3",
-      "from": "ip-regex@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/ip-regex/-/ip-regex-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-1.0.3.tgz"
     },
     "is-absolute": {
       "version": "0.1.7",
-      "from": "is-absolute@>=0.1.5 <0.2.0",
+      "from": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
       "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz"
     },
     "is-arrayish": {
       "version": "0.2.1",
-      "from": "is-arrayish@>=0.2.1 <0.3.0",
+      "from": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
-    },
-    "is-binary-path": {
-      "version": "1.0.1",
-      "from": "is-binary-path@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz"
     },
     "is-buffer": {
       "version": "1.1.3",
-      "from": "is-buffer@>=1.0.2 <2.0.0",
+      "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "from": "is-builtin-module@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz"
     },
     "is-bzip2": {
       "version": "1.0.0",
-      "from": "is-bzip2@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-bzip2/-/is-bzip2-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-bzip2/-/is-bzip2-1.0.0.tgz"
     },
     "is-callable": {
       "version": "1.1.3",
-      "from": "is-callable@>=1.1.3 <2.0.0",
+      "from": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz"
     },
     "is-date-object": {
       "version": "1.0.1",
-      "from": "is-date-object@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz"
     },
     "is-dotfile": {
       "version": "1.0.2",
-      "from": "is-dotfile@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
     },
     "is-equal-shallow": {
       "version": "0.1.3",
-      "from": "is-equal-shallow@>=0.1.3 <0.2.0",
+      "from": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
     },
     "is-extendable": {
       "version": "0.1.1",
-      "from": "is-extendable@>=0.1.1 <0.2.0",
+      "from": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
     },
     "is-extglob": {
       "version": "1.0.0",
-      "from": "is-extglob@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
     },
     "is-finite": {
       "version": "1.0.1",
-      "from": "is-finite@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz"
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
-      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
     },
     "is-glob": {
       "version": "2.0.1",
-      "from": "is-glob@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
     },
     "is-gzip": {
       "version": "1.0.0",
-      "from": "is-gzip@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz"
     },
     "is-integer": {
       "version": "1.0.6",
-      "from": "is-integer@>=1.0.3 <2.0.0",
+      "from": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
       "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz"
     },
     "is-my-json-valid": {
       "version": "2.13.1",
-      "from": "is-my-json-valid@>=2.12.4 <3.0.0",
+      "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz"
     },
     "is-natural-number": {
       "version": "2.1.1",
-      "from": "is-natural-number@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.1.1.tgz",
       "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.1.1.tgz"
     },
     "is-number": {
       "version": "2.1.0",
-      "from": "is-number@>=2.1.0 <3.0.0",
+      "from": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
     },
     "is-obj": {
       "version": "1.0.1",
-      "from": "is-obj@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz"
     },
     "is-path-cwd": {
       "version": "1.0.0",
-      "from": "is-path-cwd@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
     },
     "is-path-global": {
       "version": "1.0.2",
-      "from": "is-path-global@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-path-global/-/is-path-global-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/is-path-global/-/is-path-global-1.0.2.tgz"
     },
     "is-path-in-cwd": {
       "version": "1.0.0",
-      "from": "is-path-in-cwd@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz"
     },
     "is-path-inside": {
       "version": "1.0.0",
-      "from": "is-path-inside@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
     },
     "is-plain-obj": {
       "version": "1.1.0",
-      "from": "is-plain-obj@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
     },
     "is-posix-bracket": {
       "version": "0.1.1",
-      "from": "is-posix-bracket@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
     },
     "is-primitive": {
       "version": "2.0.0",
-      "from": "is-primitive@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
     },
     "is-promise": {
       "version": "2.1.0",
-      "from": "is-promise@>=2.1.0 <3.0.0",
+      "from": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz"
     },
     "is-property": {
       "version": "1.0.2",
-      "from": "is-property@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
     },
     "is-redirect": {
       "version": "1.0.0",
-      "from": "is-redirect@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz"
     },
     "is-regex": {
       "version": "1.0.3",
-      "from": "is-regex@>=1.0.3 <2.0.0",
+      "from": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.3.tgz"
     },
     "is-relative": {
       "version": "0.1.3",
-      "from": "is-relative@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
     },
     "is-resolvable": {
       "version": "1.0.0",
-      "from": "is-resolvable@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz"
     },
     "is-retry-allowed": {
       "version": "1.0.0",
-      "from": "is-retry-allowed@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.0.0.tgz"
     },
     "is-stream": {
       "version": "1.1.0",
-      "from": "is-stream@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
     },
     "is-subset": {
       "version": "0.1.1",
-      "from": "is-subset@>=0.1.1 <0.2.0",
+      "from": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz"
     },
     "is-symbol": {
       "version": "1.0.1",
-      "from": "is-symbol@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz"
     },
     "is-tar": {
       "version": "1.0.0",
-      "from": "is-tar@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-tar/-/is-tar-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-tar/-/is-tar-1.0.0.tgz"
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "from": "is-typedarray@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
     },
     "is-url": {
       "version": "1.2.1",
-      "from": "is-url@>=1.2.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-url/-/is-url-1.2.1.tgz",
       "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.1.tgz"
     },
     "is-utf8": {
       "version": "0.2.1",
-      "from": "is-utf8@>=0.2.0 <0.3.0",
+      "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
     },
     "is-valid-glob": {
       "version": "0.3.0",
-      "from": "is-valid-glob@>=0.3.0 <0.4.0",
+      "from": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz"
     },
     "is-zip": {
       "version": "1.0.0",
-      "from": "is-zip@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-zip/-/is-zip-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-zip/-/is-zip-1.0.0.tgz"
     },
     "isarray": {
       "version": "0.0.1",
-      "from": "isarray@0.0.1",
+      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
     },
     "isemail": {
       "version": "1.2.0",
-      "from": "isemail@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz"
     },
     "isexe": {
       "version": "1.1.2",
-      "from": "isexe@>=1.1.1 <2.0.0",
+      "from": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
     },
     "isobject": {
       "version": "2.1.0",
-      "from": "isobject@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
-          "from": "isarray@1.0.0",
+          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         }
       }
     },
     "isomorphic-fetch": {
       "version": "2.2.1",
-      "from": "isomorphic-fetch@>=2.1.1 <3.0.0",
+      "from": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz"
     },
     "isstream": {
       "version": "0.1.2",
-      "from": "isstream@>=0.1.2 <0.2.0",
+      "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
     },
     "istextorbinary": {
       "version": "1.0.2",
-      "from": "istextorbinary@>=1.0.2 <2.0.0",
+      "from": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-1.0.2.tgz"
     },
     "jade": {
       "version": "0.26.3",
-      "from": "jade@0.26.3",
+      "from": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
       "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
       "dependencies": {
         "commander": {
           "version": "0.6.1",
-          "from": "commander@0.6.1",
+          "from": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
           "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
         },
         "mkdirp": {
           "version": "0.3.0",
-          "from": "mkdirp@0.3.0",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
         }
       }
     },
     "jodid25519": {
       "version": "1.0.2",
-      "from": "jodid25519@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
     },
     "joi": {
       "version": "6.10.1",
-      "from": "joi@>=6.6.1 <7.0.0",
+      "from": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
       "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz"
     },
     "js-tokens": {
       "version": "1.0.3",
-      "from": "js-tokens@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
     },
     "js-yaml": {
       "version": "3.6.1",
-      "from": "js-yaml@>=3.5.1 <4.0.0",
+      "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
       "dependencies": {
         "esprima": {
           "version": "2.7.2",
-          "from": "esprima@^2.6.0",
+          "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
         }
       }
     },
     "jsbn": {
       "version": "0.1.0",
-      "from": "jsbn@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
     },
     "jsdom": {
       "version": "7.2.2",
-      "from": "jsdom@>=7.0.2 <8.0.0",
+      "from": "https://registry.npmjs.org/jsdom/-/jsdom-7.2.2.tgz",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-7.2.2.tgz",
       "dependencies": {
         "acorn": {
           "version": "2.7.0",
-          "from": "acorn@>=2.4.0 <3.0.0",
+          "from": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
         }
       }
     },
     "jsesc": {
       "version": "0.5.0",
-      "from": "jsesc@>=0.5.0 <0.6.0",
+      "from": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
     },
     "json-schema": {
       "version": "0.2.2",
-      "from": "json-schema@0.2.2",
+      "from": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
     },
     "json-stable-stringify": {
       "version": "1.0.1",
-      "from": "json-stable-stringify@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+      "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
     },
     "json5": {
       "version": "0.4.0",
-      "from": "json5@>=0.4.0 <0.5.0",
+      "from": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
     },
     "jsonify": {
       "version": "0.0.0",
-      "from": "jsonify@>=0.0.0 <0.1.0",
+      "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
     },
     "jsonparse": {
       "version": "1.2.0",
-      "from": "jsonparse@>=1.1.0 <2.0.0",
+      "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz"
     },
     "jsonpointer": {
       "version": "2.0.0",
-      "from": "jsonpointer@2.0.0",
+      "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
-    },
-    "JSONStream": {
-      "version": "1.1.1",
-      "from": "JSONStream@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.1.1.tgz"
     },
     "jsprim": {
       "version": "1.2.2",
-      "from": "jsprim@>=1.2.2 <2.0.0",
+      "from": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz"
     },
     "jstransform": {
       "version": "11.0.3",
-      "from": "jstransform@>=11.0.3 <12.0.0",
+      "from": "https://registry.npmjs.org/jstransform/-/jstransform-11.0.3.tgz",
       "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-11.0.3.tgz",
       "dependencies": {
         "esprima-fb": {
           "version": "15001.1.0-dev-harmony-fb",
-          "from": "esprima-fb@>=15001.1.0-dev-harmony-fb <15002.0.0",
+          "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz",
           "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz"
         },
         "object-assign": {
           "version": "2.1.1",
-          "from": "object-assign@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
         }
       }
     },
     "kind-of": {
       "version": "3.0.3",
-      "from": "kind-of@>=3.0.2 <4.0.0",
+      "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.3.tgz",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.3.tgz"
     },
     "lazy-cache": {
       "version": "1.0.4",
-      "from": "lazy-cache@>=1.0.3 <2.0.0",
+      "from": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
     },
     "lazystream": {
       "version": "1.0.0",
-      "from": "lazystream@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
       "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-        },
         "readable-stream": {
           "version": "2.1.4",
-          "from": "readable-stream@>=2.0.5 <3.0.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz"
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         }
       }
     },
     "lcid": {
       "version": "1.0.0",
-      "from": "lcid@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
-    },
-    "leven": {
-      "version": "1.0.2",
-      "from": "leven@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz"
     },
     "levn": {
       "version": "0.3.0",
-      "from": "levn@>=0.3.0 <0.4.0",
+      "from": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz"
     },
     "lnfs": {
       "version": "1.1.0",
-      "from": "lnfs@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/lnfs/-/lnfs-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/lnfs/-/lnfs-1.1.0.tgz"
     },
     "load-json-file": {
       "version": "1.1.0",
-      "from": "load-json-file@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz"
     },
     "lodash": {
       "version": "3.10.1",
-      "from": "lodash@3.10.1",
+      "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
     },
     "lodash._basecopy": {
       "version": "3.0.1",
-      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
     },
     "lodash._baseiteratee": {
       "version": "4.7.0",
-      "from": "lodash._baseiteratee@>=4.7.0 <4.8.0",
+      "from": "https://registry.npmjs.org/lodash._baseiteratee/-/lodash._baseiteratee-4.7.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash._baseiteratee/-/lodash._baseiteratee-4.7.0.tgz"
     },
     "lodash._basetostring": {
       "version": "3.0.1",
-      "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
     },
     "lodash._basevalues": {
       "version": "3.0.0",
-      "from": "lodash._basevalues@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
     },
     "lodash._getnative": {
       "version": "3.9.1",
-      "from": "lodash._getnative@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
     },
     "lodash._isiterateecall": {
       "version": "3.0.9",
-      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
       "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
     },
     "lodash._reescape": {
       "version": "3.0.0",
-      "from": "lodash._reescape@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
     },
     "lodash._reevaluate": {
       "version": "3.0.0",
-      "from": "lodash._reevaluate@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
-      "from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
     },
     "lodash._root": {
       "version": "3.0.1",
-      "from": "lodash._root@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
     },
     "lodash._stringtopath": {
       "version": "4.8.0",
-      "from": "lodash._stringtopath@>=4.8.0 <4.9.0",
+      "from": "https://registry.npmjs.org/lodash._stringtopath/-/lodash._stringtopath-4.8.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash._stringtopath/-/lodash._stringtopath-4.8.0.tgz",
       "dependencies": {
         "lodash._basetostring": {
           "version": "4.12.0",
-          "from": "lodash._basetostring@>=4.12.0 <4.13.0",
+          "from": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-4.12.0.tgz",
           "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-4.12.0.tgz"
         }
       }
     },
     "lodash.assign": {
       "version": "4.0.9",
-      "from": "lodash.assign@>=4.0.0 <5.0.0",
+      "from": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.0.9.tgz",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.0.9.tgz",
       "dependencies": {
         "lodash.keys": {
           "version": "4.0.7",
-          "from": "lodash.keys@>=4.0.0 <5.0.0",
+          "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.0.7.tgz",
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.0.7.tgz"
         }
       }
     },
     "lodash.escape": {
       "version": "3.2.0",
-      "from": "lodash.escape@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz"
     },
     "lodash.isarguments": {
       "version": "3.0.8",
-      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz"
     },
     "lodash.isarray": {
       "version": "3.0.4",
-      "from": "lodash.isarray@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
     },
     "lodash.isequal": {
       "version": "4.2.0",
-      "from": "lodash.isequal@>=4.0.0 <5.0.0",
+      "from": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.2.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.2.0.tgz",
       "dependencies": {
         "lodash.keys": {
           "version": "4.0.7",
-          "from": "lodash.keys@>=4.0.0 <5.0.0",
+          "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.0.7.tgz",
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.0.7.tgz"
         }
       }
     },
     "lodash.keys": {
       "version": "3.1.2",
-      "from": "lodash.keys@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
     },
     "lodash.keysin": {
       "version": "4.1.4",
-      "from": "lodash.keysin@>=4.0.0 <5.0.0",
+      "from": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-4.1.4.tgz",
       "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-4.1.4.tgz"
     },
     "lodash.pad": {
       "version": "4.1.0",
-      "from": "lodash.pad@^4.1.0",
+      "from": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.1.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.1.0.tgz"
     },
     "lodash.padend": {
       "version": "4.2.0",
-      "from": "lodash.padend@^4.1.0",
+      "from": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.2.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.2.0.tgz"
     },
     "lodash.padstart": {
       "version": "4.2.0",
-      "from": "lodash.padstart@^4.1.0",
+      "from": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.2.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.2.0.tgz"
     },
     "lodash.pickby": {
       "version": "4.4.0",
-      "from": "lodash.pickby@>=4.0.0 <5.0.0",
+      "from": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.4.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.4.0.tgz"
     },
     "lodash.repeat": {
       "version": "4.0.0",
-      "from": "lodash.repeat@^4.0.0",
+      "from": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.0.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.0.0.tgz"
     },
     "lodash.rest": {
       "version": "4.0.3",
-      "from": "lodash.rest@>=4.0.0 <5.0.0",
+      "from": "https://registry.npmjs.org/lodash.rest/-/lodash.rest-4.0.3.tgz",
       "resolved": "https://registry.npmjs.org/lodash.rest/-/lodash.rest-4.0.3.tgz"
     },
     "lodash.restparam": {
       "version": "3.6.1",
-      "from": "lodash.restparam@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
     },
     "lodash.template": {
       "version": "3.6.2",
-      "from": "lodash.template@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz"
     },
     "lodash.templatesettings": {
       "version": "3.1.1",
-      "from": "lodash.templatesettings@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz"
     },
     "lodash.tostring": {
       "version": "4.1.2",
-      "from": "lodash.tostring@^4.0.0",
+      "from": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.2.tgz",
       "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.2.tgz"
     },
     "log-symbols": {
       "version": "1.0.2",
-      "from": "log-symbols@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz"
     },
     "logalot": {
       "version": "2.1.0",
-      "from": "logalot@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/logalot/-/logalot-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/logalot/-/logalot-2.1.0.tgz"
     },
     "lolex": {
       "version": "1.3.2",
-      "from": "lolex@1.3.2",
+      "from": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz"
     },
     "longest": {
       "version": "1.0.1",
-      "from": "longest@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
     },
     "loose-envify": {
       "version": "1.2.0",
-      "from": "loose-envify@>=1.1.0 <2.0.0",
+      "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.2.0.tgz"
     },
     "loud-rejection": {
       "version": "1.4.1",
-      "from": "loud-rejection@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.4.1.tgz",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.4.1.tgz"
     },
     "lowercase-keys": {
       "version": "1.0.0",
-      "from": "lowercase-keys@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
     },
     "lpad": {
       "version": "2.0.1",
-      "from": "lpad@>=2.0.1 <3.0.0",
+      "from": "https://registry.npmjs.org/lpad/-/lpad-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/lpad/-/lpad-2.0.1.tgz"
     },
     "lpad-align": {
       "version": "1.1.0",
-      "from": "lpad-align@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/lpad-align/-/lpad-align-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/lpad-align/-/lpad-align-1.1.0.tgz"
     },
     "lru-cache": {
       "version": "2.7.3",
-      "from": "lru-cache@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
     },
     "makeerror": {
       "version": "1.0.11",
-      "from": "makeerror@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz"
     },
     "map-obj": {
       "version": "1.0.1",
-      "from": "map-obj@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
     },
     "media-typer": {
       "version": "0.3.0",
-      "from": "media-typer@0.3.0",
+      "from": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
     },
     "mem-fs": {
       "version": "1.1.3",
-      "from": "mem-fs@>=1.1.0 <2.0.0",
+      "from": "https://registry.npmjs.org/mem-fs/-/mem-fs-1.1.3.tgz",
       "resolved": "https://registry.npmjs.org/mem-fs/-/mem-fs-1.1.3.tgz",
       "dependencies": {
         "vinyl": {
           "version": "1.1.1",
-          "from": "vinyl@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/vinyl/-/vinyl-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.1.1.tgz"
         }
       }
     },
     "mem-fs-editor": {
       "version": "2.2.1",
-      "from": "mem-fs-editor@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-2.2.1.tgz",
       "resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-2.2.1.tgz",
       "dependencies": {
         "glob": {
           "version": "7.0.3",
-          "from": "glob@>=7.0.3 <8.0.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz"
         },
         "vinyl": {
           "version": "1.1.1",
-          "from": "vinyl@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/vinyl/-/vinyl-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.1.1.tgz"
         }
       }
     },
     "meow": {
       "version": "3.7.0",
-      "from": "meow@>=3.3.0 <4.0.0",
+      "from": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz"
     },
     "merge": {
       "version": "1.2.0",
-      "from": "merge@>=1.1.3 <2.0.0",
+      "from": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
     },
     "merge-stream": {
       "version": "1.0.0",
-      "from": "merge-stream@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.0.tgz",
       "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-        },
         "readable-stream": {
           "version": "2.1.4",
-          "from": "readable-stream@>=2.0.1 <3.0.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz"
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         }
       }
     },
     "method-override": {
       "version": "2.3.6",
-      "from": "method-override@>=2.3.5 <2.4.0",
+      "from": "https://registry.npmjs.org/method-override/-/method-override-2.3.6.tgz",
       "resolved": "https://registry.npmjs.org/method-override/-/method-override-2.3.6.tgz",
       "dependencies": {
         "vary": {
           "version": "1.1.0",
-          "from": "vary@>=1.1.0 <1.2.0",
+          "from": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
         }
       }
     },
     "methods": {
       "version": "1.1.2",
-      "from": "methods@>=1.1.2 <1.2.0",
+      "from": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
     },
     "micromatch": {
       "version": "2.3.8",
-      "from": "micromatch@>=2.3.7 <3.0.0",
+      "from": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.8.tgz",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.8.tgz"
     },
     "mime": {
       "version": "1.3.4",
-      "from": "mime@>=1.3.4 <2.0.0",
+      "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
     },
     "mime-db": {
       "version": "1.23.0",
-      "from": "mime-db@>=1.23.0 <1.24.0",
+      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
     },
     "mime-types": {
       "version": "2.1.11",
-      "from": "mime-types@>=2.1.11 <2.2.0",
+      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz"
     },
     "min-document": {
       "version": "2.18.0",
-      "from": "min-document@>=2.6.1 <3.0.0",
+      "from": "https://registry.npmjs.org/min-document/-/min-document-2.18.0.tgz",
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.18.0.tgz"
     },
     "minimatch": {
       "version": "2.0.10",
-      "from": "minimatch@>=2.0.3 <3.0.0",
+      "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
     },
     "minimist": {
       "version": "1.2.0",
-      "from": "minimist@>=1.1.0 <2.0.0",
+      "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
     },
     "mkdirp": {
       "version": "0.5.1",
-      "from": "mkdirp@>=0.5.1 <0.6.0",
+      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "from": "minimist@0.0.8",
+          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
         }
       }
     },
     "mocha": {
       "version": "2.5.3",
-      "from": "mocha@>=2.4.5 <3.0.0",
+      "from": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
       "dependencies": {
         "commander": {
           "version": "2.3.0",
-          "from": "commander@2.3.0",
+          "from": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
         },
         "diff": {
           "version": "1.4.0",
-          "from": "diff@1.4.0",
+          "from": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
           "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz"
         },
         "escape-string-regexp": {
           "version": "1.0.2",
-          "from": "escape-string-regexp@1.0.2",
+          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
         },
         "glob": {
           "version": "3.2.11",
-          "from": "glob@3.2.11",
+          "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz"
-        },
-        "minimatch": {
-          "version": "0.3.0",
-          "from": "minimatch@>=0.3.0 <0.4.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz"
         },
         "supports-color": {
           "version": "1.2.0",
-          "from": "supports-color@1.2.0",
+          "from": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz"
+        },
+        "minimatch": {
+          "version": "0.3.0",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz"
         }
       }
     },
     "module-deps": {
       "version": "3.9.1",
-      "from": "module-deps@>=3.9.1 <4.0.0",
+      "from": "https://registry.npmjs.org/module-deps/-/module-deps-3.9.1.tgz",
       "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.9.1.tgz",
       "dependencies": {
         "through2": {
           "version": "1.1.1",
-          "from": "through2@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz"
         }
       }
     },
     "moment": {
       "version": "2.13.0",
-      "from": "moment@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz"
     },
     "morgan": {
       "version": "1.6.1",
-      "from": "morgan@>=1.6.1 <1.7.0",
+      "from": "https://registry.npmjs.org/morgan/-/morgan-1.6.1.tgz",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.6.1.tgz"
     },
     "ms": {
       "version": "0.7.1",
-      "from": "ms@0.7.1",
+      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
     },
     "multimatch": {
       "version": "2.1.0",
-      "from": "multimatch@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
       "dependencies": {
         "minimatch": {
           "version": "3.0.0",
-          "from": "minimatch@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz"
         }
       }
     },
     "multiparty": {
       "version": "3.3.2",
-      "from": "multiparty@3.3.2",
+      "from": "https://registry.npmjs.org/multiparty/-/multiparty-3.3.2.tgz",
       "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-3.3.2.tgz"
     },
     "multipipe": {
       "version": "0.1.2",
-      "from": "multipipe@>=0.1.2 <0.2.0",
+      "from": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz"
     },
     "mute-stream": {
       "version": "0.0.5",
-      "from": "mute-stream@0.0.5",
+      "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
     },
     "nan": {
       "version": "2.3.5",
-      "from": "nan@>=2.0.5 <3.0.0",
+      "from": "https://registry.npmjs.org/nan/-/nan-2.3.5.tgz",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.3.5.tgz"
     },
     "negotiator": {
       "version": "0.5.3",
-      "from": "negotiator@0.5.3",
+      "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
     },
     "node-fetch": {
       "version": "1.5.3",
-      "from": "node-fetch@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.5.3.tgz",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.5.3.tgz"
     },
     "node-haste": {
       "version": "2.12.0",
-      "from": "node-haste@>=2.12.0 <2.13.0",
+      "from": "https://registry.npmjs.org/node-haste/-/node-haste-2.12.0.tgz",
       "resolved": "https://registry.npmjs.org/node-haste/-/node-haste-2.12.0.tgz"
     },
     "node-int64": {
       "version": "0.4.0",
-      "from": "node-int64@>=0.4.0 <0.5.0",
+      "from": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz"
-    },
-    "node-pre-gyp": {
-      "version": "0.6.25",
-      "from": "node-pre-gyp@0.6.25",
-      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.25.tgz"
     },
     "node-status-codes": {
       "version": "1.0.0",
-      "from": "node-status-codes@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz"
     },
     "node-uuid": {
       "version": "1.4.7",
-      "from": "node-uuid@1.4.7",
+      "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
     },
     "nopt": {
       "version": "3.0.6",
-      "from": "nopt@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
     },
     "normalize-package-data": {
       "version": "2.3.5",
-      "from": "normalize-package-data@>=2.3.4 <3.0.0",
+      "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz"
     },
     "normalize-path": {
       "version": "2.0.1",
-      "from": "normalize-path@>=2.0.1 <3.0.0",
+      "from": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
     },
     "npm-installed": {
       "version": "1.0.0",
-      "from": "npm-installed@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/npm-installed/-/npm-installed-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/npm-installed/-/npm-installed-1.0.0.tgz",
       "dependencies": {
+        "rc": {
+          "version": "0.5.5",
+          "from": "https://registry.npmjs.org/rc/-/rc-0.5.5.tgz",
+          "resolved": "https://registry.npmjs.org/rc/-/rc-0.5.5.tgz"
+        },
         "deep-extend": {
           "version": "0.2.11",
-          "from": "deep-extend@>=0.2.5 <0.3.0",
+          "from": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
           "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
         },
         "minimist": {
           "version": "0.0.10",
-          "from": "minimist@>=0.0.7 <0.1.0",
+          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
-        },
-        "rc": {
-          "version": "0.5.5",
-          "from": "rc@>=0.5.1 <0.6.0",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-0.5.5.tgz"
         },
         "strip-json-comments": {
           "version": "0.1.3",
-          "from": "strip-json-comments@>=0.1.0 <0.2.0",
+          "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
         }
       }
     },
     "npm-path": {
       "version": "1.1.0",
-      "from": "npm-path@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/npm-path/-/npm-path-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-1.1.0.tgz"
     },
     "npm-which": {
       "version": "1.0.2",
-      "from": "npm-which@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/npm-which/-/npm-which-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/npm-which/-/npm-which-1.0.2.tgz"
-    },
-    "npmlog": {
-      "version": "2.0.3",
-      "from": "npmlog@~2.0.0",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.3.tgz"
     },
     "nth-check": {
       "version": "1.0.1",
-      "from": "nth-check@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz"
     },
     "number-is-nan": {
       "version": "1.0.0",
-      "from": "number-is-nan@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
     },
     "nwmatcher": {
       "version": "1.3.7",
-      "from": "nwmatcher@>=1.3.7 <2.0.0",
+      "from": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.7.tgz",
       "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.7.tgz"
     },
     "oauth-sign": {
       "version": "0.8.2",
-      "from": "oauth-sign@>=0.8.1 <0.9.0",
+      "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
     },
     "object-assign": {
       "version": "4.1.0",
-      "from": "object-assign@>=4.1.0 <5.0.0",
+      "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
     },
     "object-is": {
       "version": "1.0.1",
-      "from": "object-is@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz"
     },
     "object-keys": {
       "version": "1.0.9",
-      "from": "object-keys@>=1.0.9 <2.0.0",
+      "from": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.9.tgz",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.9.tgz"
     },
     "object.assign": {
       "version": "4.0.3",
-      "from": "object.assign@>=4.0.3 <5.0.0",
+      "from": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.3.tgz",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.3.tgz"
     },
     "object.omit": {
       "version": "2.0.0",
-      "from": "object.omit@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz"
     },
     "object.values": {
       "version": "1.0.3",
-      "from": "object.values@>=1.0.3 <2.0.0",
+      "from": "https://registry.npmjs.org/object.values/-/object.values-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.0.3.tgz"
     },
     "on-finished": {
       "version": "2.3.0",
-      "from": "on-finished@>=2.3.0 <2.4.0",
+      "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz"
     },
     "on-headers": {
       "version": "1.0.1",
-      "from": "on-headers@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz"
     },
     "once": {
       "version": "1.3.3",
-      "from": "once@>=1.3.0 <2.0.0",
+      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
     },
     "onetime": {
       "version": "1.1.0",
-      "from": "onetime@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
     },
     "opn": {
       "version": "3.0.3",
-      "from": "opn@>=3.0.2 <4.0.0",
+      "from": "https://registry.npmjs.org/opn/-/opn-3.0.3.tgz",
       "resolved": "https://registry.npmjs.org/opn/-/opn-3.0.3.tgz"
     },
     "optimist": {
       "version": "0.6.1",
-      "from": "optimist@>=0.6.1 <0.7.0",
+      "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "dependencies": {
-        "minimist": {
-          "version": "0.0.10",
-          "from": "minimist@>=0.0.1 <0.1.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
-        },
         "wordwrap": {
           "version": "0.0.3",
-          "from": "wordwrap@>=0.0.2 <0.1.0",
+          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+        },
+        "minimist": {
+          "version": "0.0.10",
+          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
         }
       }
     },
     "optionator": {
       "version": "0.8.1",
-      "from": "optionator@>=0.8.1 <0.9.0",
+      "from": "https://registry.npmjs.org/optionator/-/optionator-0.8.1.tgz",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.1.tgz"
     },
     "options": {
       "version": "0.0.6",
-      "from": "options@>=0.0.5",
+      "from": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
       "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
     },
     "ordered-read-streams": {
       "version": "0.3.0",
-      "from": "ordered-read-streams@>=0.3.0 <0.4.0",
+      "from": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
       "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-        },
         "readable-stream": {
           "version": "2.1.4",
-          "from": "readable-stream@>=2.0.1 <3.0.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz"
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         }
       }
     },
     "os-filter-obj": {
       "version": "1.0.3",
-      "from": "os-filter-obj@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/os-filter-obj/-/os-filter-obj-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/os-filter-obj/-/os-filter-obj-1.0.3.tgz"
     },
     "os-homedir": {
       "version": "1.0.1",
-      "from": "os-homedir@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
     },
     "os-locale": {
       "version": "1.4.0",
-      "from": "os-locale@>=1.4.0 <2.0.0",
+      "from": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz"
     },
     "os-shim": {
       "version": "0.1.3",
-      "from": "os-shim@>=0.1.2 <0.2.0",
+      "from": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz"
     },
     "os-tmpdir": {
       "version": "1.0.1",
-      "from": "os-tmpdir@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
-    },
-    "output-file-sync": {
-      "version": "1.1.1",
-      "from": "output-file-sync@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz"
     },
     "parents": {
       "version": "1.0.1",
-      "from": "parents@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz"
     },
     "parse-glob": {
       "version": "3.0.4",
-      "from": "parse-glob@>=3.0.4 <4.0.0",
+      "from": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz"
     },
     "parse-json": {
       "version": "2.2.0",
-      "from": "parse-json@>=2.2.0 <3.0.0",
+      "from": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz"
     },
     "parse5": {
       "version": "1.5.1",
-      "from": "parse5@>=1.5.1 <2.0.0",
+      "from": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz"
     },
     "parseurl": {
       "version": "1.3.1",
-      "from": "parseurl@>=1.3.0 <1.4.0",
+      "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
     },
     "path-exists": {
       "version": "1.0.0",
-      "from": "path-exists@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
     },
     "path-is-absolute": {
       "version": "1.0.0",
-      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
     },
     "path-is-inside": {
       "version": "1.0.1",
-      "from": "path-is-inside@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz"
     },
     "path-platform": {
       "version": "0.11.15",
-      "from": "path-platform@>=0.11.15 <0.12.0",
+      "from": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
       "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz"
     },
     "path-type": {
       "version": "1.1.0",
-      "from": "path-type@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz"
     },
     "pause": {
       "version": "0.1.0",
-      "from": "pause@0.1.0",
+      "from": "https://registry.npmjs.org/pause/-/pause-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/pause/-/pause-0.1.0.tgz"
     },
     "pend": {
       "version": "1.2.0",
-      "from": "pend@>=1.2.0 <1.3.0",
+      "from": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
     },
     "pify": {
       "version": "2.3.0",
-      "from": "pify@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
     },
     "pinkie": {
       "version": "2.0.4",
-      "from": "pinkie@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
     },
     "pinkie-promise": {
       "version": "2.0.1",
-      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
     },
     "pluralize": {
       "version": "1.2.1",
-      "from": "pluralize@>=1.2.1 <2.0.0",
+      "from": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz"
     },
     "prelude-ls": {
       "version": "1.1.2",
-      "from": "prelude-ls@>=1.1.2 <1.2.0",
+      "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
     },
     "prepend-http": {
       "version": "1.0.4",
-      "from": "prepend-http@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz"
     },
     "preserve": {
       "version": "0.2.0",
-      "from": "preserve@>=0.2.0 <0.3.0",
+      "from": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
     },
     "pretty-bytes": {
       "version": "2.0.1",
-      "from": "pretty-bytes@>=2.0.1 <3.0.0",
+      "from": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-2.0.1.tgz"
     },
     "private": {
       "version": "0.1.6",
-      "from": "private@>=0.1.6 <0.2.0",
+      "from": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
     },
     "process": {
       "version": "0.5.2",
-      "from": "process@>=0.5.1 <0.6.0",
+      "from": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
       "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz"
     },
     "process-nextick-args": {
       "version": "1.0.7",
-      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
     },
     "progress": {
       "version": "1.1.8",
-      "from": "progress@>=1.1.8 <2.0.0",
+      "from": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
       "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
     },
     "promise": {
       "version": "7.1.1",
-      "from": "promise@>=7.1.1 <8.0.0",
+      "from": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz"
     },
     "prr": {
       "version": "0.0.0",
-      "from": "prr@>=0.0.0 <0.1.0",
+      "from": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
       "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
     },
     "pseudomap": {
       "version": "1.0.2",
-      "from": "pseudomap@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
     },
     "q": {
       "version": "1.4.1",
-      "from": "q@>=1.1.2 <2.0.0",
+      "from": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
       "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
     },
     "qs": {
       "version": "4.0.0",
-      "from": "qs@4.0.0",
+      "from": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
       "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
     },
     "random-bytes": {
       "version": "1.0.0",
-      "from": "random-bytes@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz"
     },
     "randomatic": {
       "version": "1.1.5",
-      "from": "randomatic@>=1.1.3 <2.0.0",
+      "from": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
     },
     "range-parser": {
       "version": "1.0.3",
-      "from": "range-parser@>=1.0.3 <1.1.0",
+      "from": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
     },
     "raw-body": {
       "version": "2.1.6",
-      "from": "raw-body@>=2.1.2 <2.2.0",
+      "from": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.6.tgz",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.6.tgz",
       "dependencies": {
         "bytes": {
           "version": "2.3.0",
-          "from": "bytes@2.3.0",
+          "from": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz"
         }
       }
     },
     "rc": {
       "version": "1.1.6",
-      "from": "rc@>=1.1.2 <2.0.0",
+      "from": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz"
     },
     "react": {
-      "version": "15.1.0",
-      "from": "react@>=15.1.0 <16.0.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-15.1.0.tgz"
+      "version": "15.2.0",
+      "from": "react@>=15.2.0 <15.3.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-15.2.0.tgz"
     },
     "react-addons-test-utils": {
       "version": "15.1.0",
-      "from": "react-addons-test-utils@>=15.1.0 <16.0.0",
+      "from": "https://registry.npmjs.org/react-addons-test-utils/-/react-addons-test-utils-15.1.0.tgz",
       "resolved": "https://registry.npmjs.org/react-addons-test-utils/-/react-addons-test-utils-15.1.0.tgz"
     },
     "react-clone-referenced-element": {
       "version": "1.0.1",
-      "from": "react-clone-referenced-element@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/react-clone-referenced-element/-/react-clone-referenced-element-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/react-clone-referenced-element/-/react-clone-referenced-element-1.0.1.tgz"
     },
     "react-deep-force-update": {
       "version": "1.0.1",
-      "from": "react-deep-force-update@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/react-deep-force-update/-/react-deep-force-update-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/react-deep-force-update/-/react-deep-force-update-1.0.1.tgz"
     },
     "react-dom": {
       "version": "15.1.0",
-      "from": "react-dom@>=15.1.0 <16.0.0",
+      "from": "https://registry.npmjs.org/react-dom/-/react-dom-15.1.0.tgz",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.1.0.tgz"
     },
     "react-native": {
-      "version": "0.27.1",
-      "from": "react-native@0.27.1",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.27.1.tgz",
+      "version": "0.29.0",
+      "from": "react-native@>=0.29.0 <0.30.0",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.29.0.tgz",
       "dependencies": {
+        "babel-preset-es2015-node": {
+          "version": "4.0.2",
+          "from": "babel-preset-es2015-node@>=4.0.2 <5.0.0",
+          "resolved": "https://registry.npmjs.org/babel-preset-es2015-node/-/babel-preset-es2015-node-4.0.2.tgz",
+          "dependencies": {
+            "babel-plugin-transform-es2015-sticky-regex": {
+              "version": "6.8.0",
+              "from": "babel-plugin-transform-es2015-sticky-regex@>=6.0.0 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.8.0.tgz",
+              "dependencies": {
+                "babel-helper-regex": {
+                  "version": "6.9.0",
+                  "from": "babel-helper-regex@>=6.8.0 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.9.0.tgz",
+                  "dependencies": {
+                    "lodash": {
+                      "version": "4.13.1",
+                      "from": "lodash@>=4.2.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "babel-plugin-transform-es2015-unicode-regex": {
+              "version": "6.11.0",
+              "from": "babel-plugin-transform-es2015-unicode-regex@>=6.0.0 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.11.0.tgz",
+              "dependencies": {
+                "babel-helper-regex": {
+                  "version": "6.9.0",
+                  "from": "babel-helper-regex@>=6.8.0 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.9.0.tgz",
+                  "dependencies": {
+                    "lodash": {
+                      "version": "4.13.1",
+                      "from": "lodash@>=4.2.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
+                    }
+                  }
+                },
+                "regexpu-core": {
+                  "version": "2.0.0",
+                  "from": "regexpu-core@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-preset-fbjs": {
+          "version": "2.0.0",
+          "from": "babel-preset-fbjs@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-2.0.0.tgz",
+          "dependencies": {
+            "babel-plugin-transform-es2015-block-scoped-functions": {
+              "version": "6.8.0",
+              "from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.8.0 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.8.0.tgz"
+            },
+            "babel-plugin-transform-es2015-object-super": {
+              "version": "6.8.0",
+              "from": "babel-plugin-transform-es2015-object-super@>=6.8.0 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.8.0.tgz"
+            },
+            "babel-plugin-transform-es3-member-expression-literals": {
+              "version": "6.8.0",
+              "from": "babel-plugin-transform-es3-member-expression-literals@>=6.8.0 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es3-member-expression-literals/-/babel-plugin-transform-es3-member-expression-literals-6.8.0.tgz"
+            },
+            "babel-plugin-transform-es3-property-literals": {
+              "version": "6.8.0",
+              "from": "babel-plugin-transform-es3-property-literals@>=6.8.0 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es3-property-literals/-/babel-plugin-transform-es3-property-literals-6.8.0.tgz"
+            }
+          }
+        },
         "core-js": {
           "version": "2.4.0",
           "from": "core-js@>=2.2.2 <3.0.0",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.0.tgz"
         },
+        "fbjs-scripts": {
+          "version": "0.7.1",
+          "from": "fbjs-scripts@>=0.7.0 <0.8.0",
+          "resolved": "https://registry.npmjs.org/fbjs-scripts/-/fbjs-scripts-0.7.1.tgz",
+          "dependencies": {
+            "babel-preset-fbjs": {
+              "version": "1.0.0",
+              "from": "babel-preset-fbjs@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-1.0.0.tgz",
+              "dependencies": {
+                "babel-plugin-transform-es2015-block-scoped-functions": {
+                  "version": "6.8.0",
+                  "from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.6.5 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.8.0.tgz"
+                },
+                "babel-plugin-transform-es2015-object-super": {
+                  "version": "6.8.0",
+                  "from": "babel-plugin-transform-es2015-object-super@>=6.6.5 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.8.0.tgz"
+                },
+                "babel-plugin-transform-es3-member-expression-literals": {
+                  "version": "6.8.0",
+                  "from": "babel-plugin-transform-es3-member-expression-literals@>=6.5.0 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-transform-es3-member-expression-literals/-/babel-plugin-transform-es3-member-expression-literals-6.8.0.tgz"
+                },
+                "babel-plugin-transform-es3-property-literals": {
+                  "version": "6.8.0",
+                  "from": "babel-plugin-transform-es3-property-literals@>=6.8.0 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-transform-es3-property-literals/-/babel-plugin-transform-es3-property-literals-6.8.0.tgz"
+                }
+              }
+            },
+            "core-js": {
+              "version": "1.2.6",
+              "from": "core-js@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+            },
+            "cross-spawn": {
+              "version": "3.0.1",
+              "from": "cross-spawn@>=3.0.1 <4.0.0",
+              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "4.0.1",
+                  "from": "lru-cache@>=4.0.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "fs-extra": {
+          "version": "0.26.7",
+          "from": "fs-extra@>=0.26.2 <0.27.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
+          "dependencies": {
+            "jsonfile": {
+              "version": "2.3.1",
+              "from": "jsonfile@>=2.1.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.3.1.tgz"
+            },
+            "klaw": {
+              "version": "1.3.0",
+              "from": "klaw@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.0.tgz"
+            }
+          }
+        },
         "immutable": {
           "version": "3.7.6",
           "from": "immutable@>=3.7.6 <3.8.0",
           "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz"
+        },
+        "npmlog": {
+          "version": "2.0.4",
+          "from": "npmlog@>=2.0.4 <3.0.0",
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz"
+        },
+        "plist": {
+          "version": "1.2.0",
+          "from": "plist@>=1.2.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/plist/-/plist-1.2.0.tgz",
+          "dependencies": {
+            "xmlbuilder": {
+              "version": "4.0.0",
+              "from": "xmlbuilder@4.0.0",
+              "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.0.0.tgz"
+            },
+            "xmldom": {
+              "version": "0.1.22",
+              "from": "xmldom@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.22.tgz"
+            }
+          }
+        },
+        "xcode": {
+          "version": "0.8.8",
+          "from": "xcode@>=0.8.2 <0.9.0",
+          "resolved": "https://registry.npmjs.org/xcode/-/xcode-0.8.8.tgz",
+          "dependencies": {
+            "pegjs": {
+              "version": "0.9.0",
+              "from": "pegjs@0.9.0",
+              "resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.9.0.tgz"
+            },
+            "simple-plist": {
+              "version": "0.1.4",
+              "from": "simple-plist@0.1.4",
+              "resolved": "https://registry.npmjs.org/simple-plist/-/simple-plist-0.1.4.tgz",
+              "dependencies": {
+                "bplist-parser": {
+                  "version": "0.0.6",
+                  "from": "bplist-parser@0.0.6",
+                  "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.0.6.tgz"
+                },
+                "bplist-creator": {
+                  "version": "0.0.4",
+                  "from": "bplist-creator@0.0.4",
+                  "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.4.tgz",
+                  "dependencies": {
+                    "stream-buffers": {
+                      "version": "0.2.6",
+                      "from": "stream-buffers@>=0.2.3 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-0.2.6.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "xmldoc": {
+          "version": "0.4.0",
+          "from": "xmldoc@>=0.4.0 <0.5.0",
+          "resolved": "https://registry.npmjs.org/xmldoc/-/xmldoc-0.4.0.tgz"
         }
       }
     },
     "react-proxy": {
       "version": "1.1.8",
-      "from": "react-proxy@>=1.1.7 <2.0.0",
+      "from": "https://registry.npmjs.org/react-proxy/-/react-proxy-1.1.8.tgz",
       "resolved": "https://registry.npmjs.org/react-proxy/-/react-proxy-1.1.8.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.13.1",
-          "from": "lodash@>=4.6.1 <5.0.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
         }
       }
@@ -4397,1232 +4350,1131 @@
     },
     "react-static-container": {
       "version": "1.0.1",
-      "from": "react-static-container@>=1.0.0-alpha.1 <2.0.0",
+      "from": "https://registry.npmjs.org/react-static-container/-/react-static-container-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/react-static-container/-/react-static-container-1.0.1.tgz"
     },
     "react-timer-mixin": {
       "version": "0.13.3",
-      "from": "react-timer-mixin@>=0.13.2 <0.14.0",
+      "from": "https://registry.npmjs.org/react-timer-mixin/-/react-timer-mixin-0.13.3.tgz",
       "resolved": "https://registry.npmjs.org/react-timer-mixin/-/react-timer-mixin-0.13.3.tgz"
     },
     "react-transform-hmr": {
       "version": "1.0.4",
-      "from": "react-transform-hmr@>=1.0.4 <2.0.0",
+      "from": "https://registry.npmjs.org/react-transform-hmr/-/react-transform-hmr-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/react-transform-hmr/-/react-transform-hmr-1.0.4.tgz"
     },
     "read-all-stream": {
       "version": "3.1.0",
-      "from": "read-all-stream@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
       "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
       "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-        },
         "readable-stream": {
           "version": "2.1.4",
-          "from": "readable-stream@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz"
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         }
       }
     },
     "read-chunk": {
       "version": "1.0.1",
-      "from": "read-chunk@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/read-chunk/-/read-chunk-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-1.0.1.tgz"
     },
     "read-json-sync": {
       "version": "1.1.1",
-      "from": "read-json-sync@>=1.1.0 <2.0.0",
+      "from": "https://registry.npmjs.org/read-json-sync/-/read-json-sync-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/read-json-sync/-/read-json-sync-1.1.1.tgz"
     },
     "read-pkg": {
       "version": "1.1.0",
-      "from": "read-pkg@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
     },
     "read-pkg-up": {
       "version": "1.0.1",
-      "from": "read-pkg-up@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz"
     },
     "readable-stream": {
       "version": "1.1.14",
-      "from": "readable-stream@>=1.1.9 <1.2.0",
+      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
-    },
-    "readdirp": {
-      "version": "2.0.0",
-      "from": "readdirp@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@~1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-        },
-        "readable-stream": {
-          "version": "2.1.4",
-          "from": "readable-stream@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz"
-        }
-      }
     },
     "readline2": {
       "version": "1.0.1",
-      "from": "readline2@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz"
     },
     "rebound": {
       "version": "0.0.13",
-      "from": "rebound@>=0.0.13 <0.0.14",
+      "from": "https://registry.npmjs.org/rebound/-/rebound-0.0.13.tgz",
       "resolved": "https://registry.npmjs.org/rebound/-/rebound-0.0.13.tgz"
     },
     "recast": {
       "version": "0.10.33",
-      "from": "recast@0.10.33",
+      "from": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
       "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
       "dependencies": {
         "source-map": {
           "version": "0.5.6",
-          "from": "source-map@>=0.5.0 <0.6.0",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
         }
       }
     },
     "redent": {
       "version": "1.0.0",
-      "from": "redent@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz"
     },
     "regenerate": {
       "version": "1.3.1",
-      "from": "regenerate@>=1.2.1 <2.0.0",
+      "from": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.1.tgz",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.1.tgz"
-    },
-    "regenerator": {
-      "version": "0.8.40",
-      "from": "regenerator@0.8.40",
-      "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz"
     },
     "regenerator-runtime": {
       "version": "0.9.5",
-      "from": "regenerator-runtime@>=0.9.5 <0.10.0",
+      "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz"
     },
     "regex-cache": {
       "version": "0.4.3",
-      "from": "regex-cache@>=0.4.2 <0.5.0",
+      "from": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz"
-    },
-    "regexpu": {
-      "version": "1.3.0",
-      "from": "regexpu@>=1.3.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
-      "dependencies": {
-        "esprima": {
-          "version": "2.7.2",
-          "from": "esprima@>=2.6.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
-        }
-      }
     },
     "regjsgen": {
       "version": "0.2.0",
-      "from": "regjsgen@>=0.2.0 <0.3.0",
+      "from": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
     },
     "regjsparser": {
       "version": "0.1.5",
-      "from": "regjsparser@>=0.1.4 <0.2.0",
+      "from": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz"
     },
     "remove-markdown": {
       "version": "0.1.0",
-      "from": "remove-markdown@0.1.0",
+      "from": "https://registry.npmjs.org/remove-markdown/-/remove-markdown-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/remove-markdown/-/remove-markdown-0.1.0.tgz"
     },
     "repeat-element": {
       "version": "1.1.2",
-      "from": "repeat-element@>=1.1.2 <2.0.0",
+      "from": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
     },
     "repeat-string": {
       "version": "1.5.4",
-      "from": "repeat-string@>=1.5.2 <2.0.0",
+      "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
     },
     "repeating": {
       "version": "1.1.3",
-      "from": "repeating@>=1.1.0 <2.0.0",
+      "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz"
     },
     "replace-ext": {
       "version": "0.0.1",
-      "from": "replace-ext@0.0.1",
+      "from": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
     },
     "request": {
       "version": "2.72.0",
-      "from": "request@>=2.55.0 <3.0.0",
+      "from": "https://registry.npmjs.org/request/-/request-2.72.0.tgz",
       "resolved": "https://registry.npmjs.org/request/-/request-2.72.0.tgz",
       "dependencies": {
         "qs": {
           "version": "6.1.0",
-          "from": "qs@>=6.1.0 <6.2.0",
+          "from": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz"
         }
       }
     },
     "require-uncached": {
       "version": "1.0.2",
-      "from": "require-uncached@>=1.0.2 <2.0.0",
+      "from": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.2.tgz"
     },
     "resolve": {
       "version": "1.1.7",
-      "from": "resolve@>=1.1.3 <2.0.0",
+      "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
     },
     "resolve-from": {
       "version": "1.0.1",
-      "from": "resolve-from@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz"
     },
     "response-time": {
       "version": "2.3.1",
-      "from": "response-time@>=2.3.1 <2.4.0",
+      "from": "https://registry.npmjs.org/response-time/-/response-time-2.3.1.tgz",
       "resolved": "https://registry.npmjs.org/response-time/-/response-time-2.3.1.tgz"
     },
     "restore-cursor": {
       "version": "1.0.1",
-      "from": "restore-cursor@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz"
     },
     "right-align": {
       "version": "0.1.3",
-      "from": "right-align@>=0.1.1 <0.2.0",
+      "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz"
     },
     "rimraf": {
       "version": "2.5.2",
-      "from": "rimraf@>=2.2.8 <3.0.0",
+      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
       "dependencies": {
         "glob": {
           "version": "7.0.3",
-          "from": "glob@>=7.0.0 <8.0.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz"
         }
       }
     },
     "rndm": {
       "version": "1.2.0",
-      "from": "rndm@1.2.0",
+      "from": "https://registry.npmjs.org/rndm/-/rndm-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.2.0.tgz"
     },
     "run-async": {
       "version": "0.1.0",
-      "from": "run-async@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz"
     },
     "rx": {
       "version": "4.1.0",
-      "from": "rx@>=4.1.0 <5.0.0",
+      "from": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
       "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz"
     },
     "rx-lite": {
       "version": "3.1.2",
-      "from": "rx-lite@>=3.1.2 <4.0.0",
+      "from": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz"
     },
     "samsam": {
       "version": "1.1.2",
-      "from": "samsam@1.1.2",
+      "from": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz"
     },
     "sane": {
       "version": "1.3.4",
-      "from": "sane@>=1.2.0 <2.0.0",
+      "from": "https://registry.npmjs.org/sane/-/sane-1.3.4.tgz",
       "resolved": "https://registry.npmjs.org/sane/-/sane-1.3.4.tgz",
       "dependencies": {
         "minimatch": {
           "version": "0.2.14",
-          "from": "minimatch@>=0.2.14 <0.3.0",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz"
         }
       }
     },
     "sax": {
       "version": "1.1.6",
-      "from": "sax@>=1.1.1 <1.2.0",
+      "from": "https://registry.npmjs.org/sax/-/sax-1.1.6.tgz",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.6.tgz"
     },
     "seek-bzip": {
       "version": "1.0.5",
-      "from": "seek-bzip@>=1.0.3 <2.0.0",
+      "from": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
       "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
       "dependencies": {
         "commander": {
           "version": "2.8.1",
-          "from": "commander@>=2.8.1 <2.9.0",
+          "from": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz"
         }
       }
     },
     "semver": {
       "version": "5.1.0",
-      "from": "semver@>=5.0.3 <6.0.0",
+      "from": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
     },
     "semver-regex": {
       "version": "1.0.0",
-      "from": "semver-regex@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/semver-regex/-/semver-regex-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-1.0.0.tgz"
     },
     "semver-truncate": {
       "version": "1.1.0",
-      "from": "semver-truncate@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/semver-truncate/-/semver-truncate-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/semver-truncate/-/semver-truncate-1.1.0.tgz"
     },
     "send": {
       "version": "0.13.2",
-      "from": "send@0.13.2",
+      "from": "https://registry.npmjs.org/send/-/send-0.13.2.tgz",
       "resolved": "https://registry.npmjs.org/send/-/send-0.13.2.tgz",
       "dependencies": {
         "depd": {
           "version": "1.1.0",
-          "from": "depd@>=1.1.0 <1.2.0",
+          "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
         },
         "statuses": {
           "version": "1.2.1",
-          "from": "statuses@>=1.2.1 <1.3.0",
+          "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
         }
       }
     },
     "serve-favicon": {
       "version": "2.3.0",
-      "from": "serve-favicon@>=2.3.0 <2.4.0",
+      "from": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.3.0.tgz",
       "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.3.0.tgz"
     },
     "serve-index": {
       "version": "1.7.3",
-      "from": "serve-index@>=1.7.2 <1.8.0",
+      "from": "https://registry.npmjs.org/serve-index/-/serve-index-1.7.3.tgz",
       "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.7.3.tgz"
     },
     "serve-static": {
       "version": "1.10.3",
-      "from": "serve-static@>=1.10.0 <1.11.0",
+      "from": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.3.tgz",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.3.tgz"
     },
     "set-immediate-shim": {
       "version": "1.0.1",
-      "from": "set-immediate-shim@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
     },
     "shebang-regex": {
       "version": "1.0.0",
-      "from": "shebang-regex@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
     },
     "shelljs": {
       "version": "0.5.3",
-      "from": "shelljs@>=0.5.0 <0.6.0",
+      "from": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz"
     },
     "sigmund": {
       "version": "1.0.1",
-      "from": "sigmund@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
     },
     "signal-exit": {
       "version": "2.1.2",
-      "from": "signal-exit@>=2.1.2 <3.0.0",
+      "from": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
-    },
-    "simple-fmt": {
-      "version": "0.1.0",
-      "from": "simple-fmt@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz"
-    },
-    "simple-is": {
-      "version": "0.2.0",
-      "from": "simple-is@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz"
     },
     "sinon": {
       "version": "1.17.4",
-      "from": "sinon@>=1.9.1 <2.0.0",
+      "from": "https://registry.npmjs.org/sinon/-/sinon-1.17.4.tgz",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.4.tgz"
     },
     "slash": {
       "version": "1.0.0",
-      "from": "slash@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
     },
     "slice-ansi": {
       "version": "0.0.4",
-      "from": "slice-ansi@0.0.4",
+      "from": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz"
     },
     "sntp": {
       "version": "1.0.9",
-      "from": "sntp@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
     },
     "source-map": {
       "version": "0.4.4",
-      "from": "source-map@>=0.4.4 <0.5.0",
+      "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
     },
     "source-map-support": {
       "version": "0.2.10",
-      "from": "source-map-support@>=0.2.10 <0.3.0",
+      "from": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
       "dependencies": {
         "source-map": {
           "version": "0.1.32",
-          "from": "source-map@0.1.32",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz"
         }
       }
     },
     "sparkles": {
       "version": "1.0.0",
-      "from": "sparkles@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
     },
     "spawn-sync": {
       "version": "1.0.15",
-      "from": "spawn-sync@>=1.0.15 <2.0.0",
+      "from": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
       "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz"
     },
     "spdx-correct": {
       "version": "1.0.2",
-      "from": "spdx-correct@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz"
     },
     "spdx-exceptions": {
       "version": "1.0.4",
-      "from": "spdx-exceptions@>=1.0.4 <2.0.0",
+      "from": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
     },
     "spdx-expression-parse": {
       "version": "1.0.2",
-      "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz"
     },
     "spdx-license-ids": {
       "version": "1.2.1",
-      "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+      "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "from": "sprintf-js@>=1.0.3 <2.0.0",
+      "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
     },
     "squeak": {
       "version": "1.3.0",
-      "from": "squeak@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/squeak/-/squeak-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/squeak/-/squeak-1.3.0.tgz"
     },
     "sshpk": {
       "version": "1.8.3",
-      "from": "sshpk@>=1.7.0 <2.0.0",
+      "from": "https://registry.npmjs.org/sshpk/-/sshpk-1.8.3.tgz",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.8.3.tgz",
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
-          "from": "assert-plus@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
         }
       }
     },
-    "stable": {
-      "version": "0.1.5",
-      "from": "stable@>=0.1.3 <0.2.0",
-      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz"
-    },
     "stacktrace-parser": {
       "version": "0.1.3",
-      "from": "stacktrace-parser@>=0.1.3 <0.2.0",
+      "from": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.3.tgz"
     },
     "stat-mode": {
       "version": "0.2.1",
-      "from": "stat-mode@>=0.2.0 <0.3.0",
+      "from": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.1.tgz"
     },
     "statuses": {
       "version": "1.3.0",
-      "from": "statuses@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
     },
     "stream-combiner": {
       "version": "0.2.2",
-      "from": "stream-combiner@>=0.2.1 <0.3.0",
+      "from": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
       "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz"
     },
     "stream-combiner2": {
       "version": "1.0.2",
-      "from": "stream-combiner2@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
       "dependencies": {
-        "readable-stream": {
-          "version": "1.0.34",
-          "from": "readable-stream@>=1.0.17 <1.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
-        },
         "through2": {
           "version": "0.5.1",
-          "from": "through2@>=0.5.1 <0.6.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz"
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
         },
         "xtend": {
           "version": "3.0.0",
-          "from": "xtend@>=3.0.0 <3.1.0",
+          "from": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
         }
       }
     },
     "stream-counter": {
       "version": "0.2.0",
-      "from": "stream-counter@>=0.2.0 <0.3.0",
+      "from": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz"
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "from": "string_decoder@>=0.10.0 <0.11.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
     },
     "string-width": {
       "version": "1.0.1",
-      "from": "string-width@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz"
     },
-    "stringmap": {
-      "version": "0.2.2",
-      "from": "stringmap@>=0.2.2 <0.3.0",
-      "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz"
-    },
-    "stringset": {
-      "version": "0.2.1",
-      "from": "stringset@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz"
+    "string_decoder": {
+      "version": "0.10.31",
+      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
     },
     "stringstream": {
       "version": "0.0.5",
-      "from": "stringstream@>=0.0.4 <0.1.0",
+      "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "from": "strip-ansi@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
     },
     "strip-bom": {
       "version": "2.0.0",
-      "from": "strip-bom@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
     },
     "strip-bom-stream": {
       "version": "2.0.0",
-      "from": "strip-bom-stream@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz"
     },
     "strip-dirs": {
       "version": "1.1.1",
-      "from": "strip-dirs@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz"
     },
     "strip-indent": {
       "version": "1.0.1",
-      "from": "strip-indent@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
     },
     "strip-json-comments": {
       "version": "1.0.4",
-      "from": "strip-json-comments@>=1.0.4 <1.1.0",
+      "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
     },
     "strip-outer": {
       "version": "1.0.0",
-      "from": "strip-outer@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.0.tgz"
     },
     "subarg": {
       "version": "1.0.0",
-      "from": "subarg@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz"
     },
     "sum-up": {
       "version": "1.0.3",
-      "from": "sum-up@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.3.tgz"
     },
     "supports-color": {
       "version": "2.0.0",
-      "from": "supports-color@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
     },
     "symbol-tree": {
       "version": "3.1.4",
-      "from": "symbol-tree@>=3.1.0 <4.0.0",
+      "from": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.1.4.tgz",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.1.4.tgz"
     },
     "table": {
       "version": "3.7.8",
-      "from": "table@>=3.7.8 <4.0.0",
+      "from": "https://registry.npmjs.org/table/-/table-3.7.8.tgz",
       "resolved": "https://registry.npmjs.org/table/-/table-3.7.8.tgz",
       "dependencies": {
         "bluebird": {
           "version": "3.4.0",
-          "from": "bluebird@>=3.1.1 <4.0.0",
+          "from": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.0.tgz",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.0.tgz"
         },
         "lodash": {
           "version": "4.13.1",
-          "from": "lodash@>=4.0.0 <5.0.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
-        }
-      }
-    },
-    "tar": {
-      "version": "2.2.1",
-      "from": "tar@~2.2.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
-    },
-    "tar-pack": {
-      "version": "3.1.3",
-      "from": "tar-pack@~3.1.0",
-      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.3.tgz",
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-        },
-        "readable-stream": {
-          "version": "2.0.6",
-          "from": "readable-stream@>=2.0.4 <2.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
         }
       }
     },
     "tar-stream": {
       "version": "1.5.2",
-      "from": "tar-stream@>=1.1.1 <2.0.0",
+      "from": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz",
       "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-        },
         "readable-stream": {
           "version": "2.1.4",
-          "from": "readable-stream@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz"
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         }
       }
     },
     "temp": {
       "version": "0.8.3",
-      "from": "temp@0.8.3",
+      "from": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
       "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
       "dependencies": {
         "rimraf": {
           "version": "2.2.8",
-          "from": "rimraf@>=2.2.6 <2.3.0",
+          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         }
       }
     },
     "text-table": {
       "version": "0.2.0",
-      "from": "text-table@>=0.2.0 <0.3.0",
+      "from": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
     },
     "textextensions": {
       "version": "1.0.2",
-      "from": "textextensions@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/textextensions/-/textextensions-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-1.0.2.tgz"
     },
     "through": {
       "version": "2.3.8",
-      "from": "through@>=2.3.6 <3.0.0",
+      "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
     },
     "through2": {
       "version": "2.0.1",
-      "from": "through2@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
       "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-        },
         "readable-stream": {
           "version": "2.0.6",
-          "from": "readable-stream@>=2.0.0 <2.1.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         }
       }
     },
     "through2-filter": {
       "version": "2.0.0",
-      "from": "through2-filter@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz"
     },
     "time-stamp": {
       "version": "1.0.1",
-      "from": "time-stamp@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.1.tgz"
     },
     "timed-out": {
       "version": "2.0.0",
-      "from": "timed-out@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
     },
     "tmpl": {
       "version": "1.0.4",
-      "from": "tmpl@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz"
     },
     "to-absolute-glob": {
       "version": "0.1.1",
-      "from": "to-absolute-glob@>=0.1.1 <0.2.0",
+      "from": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz"
     },
     "to-fast-properties": {
       "version": "1.0.2",
-      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
     },
     "to-iso-string": {
       "version": "0.0.2",
-      "from": "to-iso-string@0.0.2",
+      "from": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
       "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz"
     },
     "topo": {
       "version": "1.1.0",
-      "from": "topo@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz"
     },
     "tough-cookie": {
       "version": "2.2.2",
-      "from": "tough-cookie@>=2.2.0 <3.0.0",
+      "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
     },
     "tr46": {
       "version": "0.0.3",
-      "from": "tr46@>=0.0.1 <0.1.0",
+      "from": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz"
     },
     "traverse": {
       "version": "0.6.6",
-      "from": "traverse@>=0.6.6 <0.7.0",
+      "from": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz"
     },
     "trim-newlines": {
       "version": "1.0.0",
-      "from": "trim-newlines@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
     },
     "trim-repeated": {
       "version": "1.0.0",
-      "from": "trim-repeated@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz"
-    },
-    "trim-right": {
-      "version": "1.0.1",
-      "from": "trim-right@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
-    },
-    "try-resolve": {
-      "version": "1.0.1",
-      "from": "try-resolve@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz"
     },
     "tryit": {
       "version": "1.0.2",
-      "from": "tryit@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/tryit/-/tryit-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.2.tgz"
-    },
-    "tryor": {
-      "version": "0.1.2",
-      "from": "tryor@>=0.1.2 <0.2.0",
-      "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz"
     },
     "tsscmp": {
       "version": "1.0.5",
-      "from": "tsscmp@1.0.5",
+      "from": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.5.tgz",
       "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.5.tgz"
     },
     "tunnel-agent": {
       "version": "0.4.3",
-      "from": "tunnel-agent@>=0.4.0 <0.5.0",
+      "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
     },
     "tv4": {
       "version": "1.2.7",
-      "from": "tv4@>=1.2.7 <2.0.0",
+      "from": "https://registry.npmjs.org/tv4/-/tv4-1.2.7.tgz",
       "resolved": "https://registry.npmjs.org/tv4/-/tv4-1.2.7.tgz"
     },
     "tweetnacl": {
       "version": "0.13.3",
-      "from": "tweetnacl@>=0.13.0 <0.14.0",
+      "from": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
     },
     "type-check": {
       "version": "0.3.2",
-      "from": "type-check@>=0.3.2 <0.4.0",
+      "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
     },
     "type-detect": {
       "version": "1.0.0",
-      "from": "type-detect@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz"
     },
     "type-is": {
       "version": "1.6.13",
-      "from": "type-is@>=1.6.6 <1.7.0",
+      "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz"
     },
     "typedarray": {
       "version": "0.0.6",
-      "from": "typedarray@>=0.0.5 <0.1.0",
+      "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
     },
     "ua-parser-js": {
       "version": "0.7.10",
-      "from": "ua-parser-js@>=0.7.9 <0.8.0",
+      "from": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.10.tgz",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.10.tgz"
     },
     "uglify-js": {
       "version": "2.6.2",
-      "from": "uglify-js@>=2.6.2 <3.0.0",
+      "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.2.tgz",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.2.tgz",
       "dependencies": {
-        "camelcase": {
-          "version": "1.2.1",
-          "from": "camelcase@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
-        },
         "source-map": {
           "version": "0.5.6",
-          "from": "source-map@>=0.5.1 <0.6.0",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-        },
-        "window-size": {
-          "version": "0.1.0",
-          "from": "window-size@0.1.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
         },
         "yargs": {
           "version": "3.10.0",
-          "from": "yargs@>=3.10.0 <3.11.0",
+          "from": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
+        },
+        "camelcase": {
+          "version": "1.2.1",
+          "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+        },
+        "window-size": {
+          "version": "0.1.0",
+          "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
         }
       }
     },
     "uglify-to-browserify": {
       "version": "1.0.2",
-      "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
-    },
-    "uid-number": {
-      "version": "0.0.6",
-      "from": "uid-number@~0.0.6",
-      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
     },
     "uid-safe": {
       "version": "2.1.1",
-      "from": "uid-safe@2.1.1",
+      "from": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.1.tgz",
       "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.1.tgz"
     },
     "ultron": {
       "version": "1.0.2",
-      "from": "ultron@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
     },
     "underscore.string": {
       "version": "3.3.4",
-      "from": "underscore.string@>=3.0.3 <4.0.0",
+      "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz"
     },
     "unique-stream": {
       "version": "2.2.1",
-      "from": "unique-stream@>=2.0.2 <3.0.0",
+      "from": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
       "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz"
     },
     "unpipe": {
       "version": "1.0.0",
-      "from": "unpipe@1.0.0",
+      "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
     },
     "untildify": {
       "version": "2.1.0",
-      "from": "untildify@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz"
     },
     "unzip-response": {
       "version": "1.0.0",
-      "from": "unzip-response@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.0.tgz"
     },
     "url-parse-lax": {
       "version": "1.0.0",
-      "from": "url-parse-lax@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz"
     },
     "url-regex": {
       "version": "2.1.3",
-      "from": "url-regex@>=2.0.2 <3.0.0",
+      "from": "https://registry.npmjs.org/url-regex/-/url-regex-2.1.3.tgz",
       "resolved": "https://registry.npmjs.org/url-regex/-/url-regex-2.1.3.tgz"
     },
     "user-home": {
       "version": "1.1.1",
-      "from": "user-home@>=1.1.1 <2.0.0",
+      "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
     },
     "utf-8-validate": {
       "version": "1.2.1",
-      "from": "utf-8-validate@>=1.2.0 <1.3.0",
+      "from": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-1.2.1.tgz",
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-1.2.1.tgz"
     },
     "util": {
       "version": "0.10.3",
-      "from": "util@>=0.10.3 <1.0.0",
+      "from": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "from": "util-deprecate@>=1.0.1 <1.1.0",
+      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
     },
     "utils-merge": {
       "version": "1.0.0",
-      "from": "utils-merge@1.0.0",
+      "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
     },
     "uuid": {
       "version": "2.0.2",
-      "from": "uuid@>=2.0.1 <3.0.0",
+      "from": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz"
     },
     "vali-date": {
       "version": "1.0.0",
-      "from": "vali-date@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz"
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
-      "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+      "from": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
     },
     "vary": {
       "version": "1.0.1",
-      "from": "vary@>=1.0.1 <1.1.0",
+      "from": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"
     },
     "verror": {
       "version": "1.3.6",
-      "from": "verror@1.3.6",
+      "from": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
     },
     "vhost": {
       "version": "3.0.2",
-      "from": "vhost@>=3.0.1 <3.1.0",
+      "from": "https://registry.npmjs.org/vhost/-/vhost-3.0.2.tgz",
       "resolved": "https://registry.npmjs.org/vhost/-/vhost-3.0.2.tgz"
     },
     "vinyl": {
       "version": "0.5.3",
-      "from": "vinyl@>=0.5.0 <0.6.0",
+      "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
       "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz"
     },
     "vinyl-assign": {
       "version": "1.2.1",
-      "from": "vinyl-assign@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/vinyl-assign/-/vinyl-assign-1.2.1.tgz",
       "resolved": "https://registry.npmjs.org/vinyl-assign/-/vinyl-assign-1.2.1.tgz",
       "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-        },
         "readable-stream": {
           "version": "2.1.4",
-          "from": "readable-stream@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz"
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         }
       }
     },
     "vinyl-file": {
       "version": "2.0.0",
-      "from": "vinyl-file@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-2.0.0.tgz",
       "dependencies": {
         "vinyl": {
           "version": "1.1.1",
-          "from": "vinyl@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/vinyl/-/vinyl-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.1.1.tgz"
         }
       }
     },
     "vinyl-fs": {
       "version": "2.4.3",
-      "from": "vinyl-fs@>=2.2.0 <3.0.0",
+      "from": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.3.tgz",
       "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.3.tgz",
       "dependencies": {
-        "first-chunk-stream": {
-          "version": "1.0.0",
-          "from": "first-chunk-stream@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-        },
         "readable-stream": {
           "version": "2.1.4",
-          "from": "readable-stream@>=2.0.4 <3.0.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz"
         },
         "strip-bom-stream": {
           "version": "1.0.0",
-          "from": "strip-bom-stream@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz"
         },
         "vinyl": {
           "version": "1.1.1",
-          "from": "vinyl@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/vinyl/-/vinyl-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.1.1.tgz"
+        },
+        "first-chunk-stream": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         }
       }
     },
     "walker": {
       "version": "1.0.7",
-      "from": "walker@>=1.0.5 <1.1.0",
+      "from": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz"
     },
     "ware": {
       "version": "1.3.0",
-      "from": "ware@>=1.2.0 <2.0.0",
+      "from": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz"
     },
     "watch": {
       "version": "0.10.0",
-      "from": "watch@>=0.10.0 <0.11.0",
+      "from": "https://registry.npmjs.org/watch/-/watch-0.10.0.tgz",
       "resolved": "https://registry.npmjs.org/watch/-/watch-0.10.0.tgz"
     },
     "webidl-conversions": {
       "version": "2.0.1",
-      "from": "webidl-conversions@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-2.0.1.tgz"
     },
     "whatwg-fetch": {
       "version": "1.0.0",
-      "from": "whatwg-fetch@>=0.10.0",
+      "from": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-1.0.0.tgz"
     },
     "whatwg-url-compat": {
       "version": "0.6.5",
-      "from": "whatwg-url-compat@>=0.6.5 <0.7.0",
+      "from": "https://registry.npmjs.org/whatwg-url-compat/-/whatwg-url-compat-0.6.5.tgz",
       "resolved": "https://registry.npmjs.org/whatwg-url-compat/-/whatwg-url-compat-0.6.5.tgz"
     },
     "which": {
       "version": "1.2.10",
-      "from": "which@>=1.2.9 <2.0.0",
+      "from": "https://registry.npmjs.org/which/-/which-1.2.10.tgz",
       "resolved": "https://registry.npmjs.org/which/-/which-1.2.10.tgz"
     },
     "window-size": {
       "version": "0.1.4",
-      "from": "window-size@>=0.1.2 <0.2.0",
+      "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
     },
     "wordwrap": {
       "version": "1.0.0",
-      "from": "wordwrap@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
     },
     "worker-farm": {
       "version": "1.3.1",
-      "from": "worker-farm@>=1.3.1 <2.0.0",
+      "from": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.3.1.tgz",
       "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.3.1.tgz"
     },
     "wrap-ansi": {
       "version": "2.0.0",
-      "from": "wrap-ansi@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz"
     },
     "wrap-fn": {
       "version": "0.1.5",
-      "from": "wrap-fn@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/wrap-fn/-/wrap-fn-0.1.5.tgz",
       "resolved": "https://registry.npmjs.org/wrap-fn/-/wrap-fn-0.1.5.tgz"
     },
     "wrappy": {
       "version": "1.0.2",
-      "from": "wrappy@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
     },
     "write": {
       "version": "0.2.1",
-      "from": "write@>=0.2.1 <0.3.0",
+      "from": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz"
     },
     "ws": {
       "version": "0.8.1",
-      "from": "ws@>=0.8.0 <0.9.0",
+      "from": "https://registry.npmjs.org/ws/-/ws-0.8.1.tgz",
       "resolved": "https://registry.npmjs.org/ws/-/ws-0.8.1.tgz"
     },
     "xdg-basedir": {
       "version": "2.0.0",
-      "from": "xdg-basedir@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz"
     },
     "xml-name-validator": {
       "version": "2.0.1",
-      "from": "xml-name-validator@>=2.0.1 <3.0.0",
+      "from": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz"
     },
     "xregexp": {
       "version": "3.1.1",
-      "from": "xregexp@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/xregexp/-/xregexp-3.1.1.tgz",
       "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-3.1.1.tgz"
     },
     "xtend": {
       "version": "4.0.1",
-      "from": "xtend@>=4.0.0 <4.1.0",
+      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
     },
     "y18n": {
       "version": "3.2.1",
-      "from": "y18n@>=3.2.0 <4.0.0",
+      "from": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
     },
     "yallist": {
       "version": "2.0.0",
-      "from": "yallist@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz"
     },
     "yargs": {
       "version": "3.32.0",
-      "from": "yargs@>=3.24.0 <4.0.0",
+      "from": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
       "dependencies": {
         "cliui": {
           "version": "3.2.0",
-          "from": "cliui@>=3.0.3 <4.0.0",
+          "from": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz"
         }
       }
     },
     "yauzl": {
       "version": "2.5.0",
-      "from": "yauzl@>=2.2.1 <3.0.0",
+      "from": "https://registry.npmjs.org/yauzl/-/yauzl-2.5.0.tgz",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.5.0.tgz"
     },
     "yeoman-assert": {
       "version": "2.2.1",
-      "from": "yeoman-assert@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/yeoman-assert/-/yeoman-assert-2.2.1.tgz",
       "resolved": "https://registry.npmjs.org/yeoman-assert/-/yeoman-assert-2.2.1.tgz",
       "dependencies": {
         "path-exists": {
           "version": "2.1.0",
-          "from": "path-exists@>=2.1.0 <3.0.0",
+          "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
         }
       }
     },
     "yeoman-environment": {
       "version": "1.6.1",
-      "from": "yeoman-environment@>=1.2.7 <2.0.0",
+      "from": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-1.6.1.tgz",
       "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-1.6.1.tgz",
       "dependencies": {
         "inquirer": {
           "version": "1.0.3",
-          "from": "inquirer@>=1.0.2 <2.0.0",
+          "from": "https://registry.npmjs.org/inquirer/-/inquirer-1.0.3.tgz",
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.0.3.tgz"
         },
         "lodash": {
           "version": "4.13.1",
-          "from": "lodash@>=4.11.1 <5.0.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
         },
         "mute-stream": {
           "version": "0.0.6",
-          "from": "mute-stream@0.0.6",
+          "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
           "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz"
         },
         "run-async": {
           "version": "2.2.0",
-          "from": "run-async@>=2.2.0 <3.0.0",
+          "from": "https://registry.npmjs.org/run-async/-/run-async-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.2.0.tgz"
         }
       }
     },
     "yeoman-generator": {
       "version": "0.20.3",
-      "from": "yeoman-generator@>=0.20.3 <0.21.0",
+      "from": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-0.20.3.tgz",
       "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-0.20.3.tgz",
       "dependencies": {
-        "ansi-regex": {
-          "version": "1.1.1",
-          "from": "ansi-regex@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
-        },
         "async": {
           "version": "1.5.2",
-          "from": "async@>=1.4.2 <2.0.0",
+          "from": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
-        },
-        "cli-width": {
-          "version": "1.1.1",
-          "from": "cli-width@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz"
         },
         "inquirer": {
           "version": "0.8.5",
-          "from": "inquirer@>=0.8.0 <0.9.0",
+          "from": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.5.tgz",
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.5.tgz"
         },
-        "mute-stream": {
-          "version": "0.0.4",
-          "from": "mute-stream@0.0.4",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
+        "user-home": {
+          "version": "2.0.0",
+          "from": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz"
+        },
+        "ansi-regex": {
+          "version": "1.1.1",
+          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+        },
+        "cli-width": {
+          "version": "1.1.1",
+          "from": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz"
         },
         "readline2": {
           "version": "0.1.1",
-          "from": "readline2@>=0.1.1 <0.2.0",
+          "from": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
           "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz"
+        },
+        "mute-stream": {
+          "version": "0.0.4",
+          "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
         },
         "rx": {
           "version": "2.5.3",
-          "from": "rx@>=2.4.3 <3.0.0",
+          "from": "https://registry.npmjs.org/rx/-/rx-2.5.3.tgz",
           "resolved": "https://registry.npmjs.org/rx/-/rx-2.5.3.tgz"
         },
         "strip-ansi": {
           "version": "2.0.1",
-          "from": "strip-ansi@>=2.0.1 <3.0.0",
+          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz"
-        },
-        "user-home": {
-          "version": "2.0.0",
-          "from": "user-home@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz"
         }
       }
     },
     "yeoman-welcome": {
       "version": "1.0.1",
-      "from": "yeoman-welcome@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/yeoman-welcome/-/yeoman-welcome-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/yeoman-welcome/-/yeoman-welcome-1.0.1.tgz"
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "start-packager": "cd node_modules/react-native && npm start -- --reset-cache",
     "clean-example": "cd Example && xcodebuild -workspace Emission.xcworkspace -scheme Emission -destination 'platform=iOS Simulator,name=iPhone 6' clean",
     "start": "npm run clean-example && npm run start-packager",
-    "bundle": "react-native bundle --platform=ios --dev=false --entry-file=index.ios.js --bundle-output Pod/Assets/Emission.js --sourcemap-output Pod/Assets/Emission.js.map",
-    "release": "node scripts/release.js"
+    "bundle": "react-native bundle --platform=ios --dev=false --entry-file=index.ios.js --bundle-output Pod/Assets/Emission.js --sourcemap-output Pod/Assets/Emission.js.map"
   },
   "repository": {
     "type": "git",
@@ -40,8 +39,8 @@
   "dependencies": {
     "babel-relay-plugin": "https://github.com/alloy/relay/releases/download/v0.9.1-alpha.2/babel-relay-plugin-0.9.1.tgz",
     "lodash": "3.10.1",
-    "react": "^15.1.0",
-    "react-native": "0.27.1",
+    "react": "^15.2.0",
+    "react-native": "0.29.0",
     "react-relay": "https://github.com/alloy/relay/releases/download/v0.9.1-alpha.2/react-relay-0.9.1.tgz",
     "remove-markdown": "0.1.0"
   },


### PR DESCRIPTION
- [x] Pretty straightforward RN upgrade to v0.29.0
- [x] Fixed known issue in the new RN version related to `flex-wrap` for related artists
- [x] Rigorously searched for other weirdness in new RN version

![simulator screen shot jul 6 2016 6 12 00 pm](https://cloud.githubusercontent.com/assets/2712962/16625698/11aa9848-43a6-11e6-9608-cf5f17b9943d.png)



With the addition of `alignItems: flex-start`, everything is beautiful again:


![simulator screen shot jul 6 2016 6 09 07 pm](https://cloud.githubusercontent.com/assets/2712962/16625716/25ae3994-43a6-11e6-9a4a-5ce911b9f3cb.png)



Just like they said: https://github.com/facebook/react-native/releases/tag/v0.28.0