### PR TITLE
[Shows] Fixed bug where current and upcoming shows were not properly wrapping

### DIFF
--- a/lib/components/artist/shows/index.js
+++ b/lib/components/artist/shows/index.js
@@ -44,11 +44,11 @@ class Shows extends React.Component {
 
   currentAndUpcomingList() {
     if (this.props.artist.current_shows.length || this.props.artist.upcoming_shows.length) {
+      const shows = [].concat.apply([], [this.props.artist.current_shows, this.props.artist.upcoming_shows]);
       return (
         <View style={{ marginBottom: 20 }}>
           <SerifText style={styles.title}>Current & Upcoming Shows</SerifText>
-          <LargeShowsList shows={this.props.artist.current_shows} />
-          <LargeShowsList shows={this.props.artist.upcoming_shows} />
+          <LargeShowsList shows={shows} />
         </View>
       );
     }


### PR DESCRIPTION
Fixes this problem:

![simulator screen shot jul 11 2016 3 42 52 pm](https://cloud.githubusercontent.com/assets/2712962/16732590/3e675afc-477e-11e6-944f-5a0fdd778fb3.png)

So our Current & Upcoming list looks like this instead:

![simulator screen shot jul 11 2016 3 44 19 pm](https://cloud.githubusercontent.com/assets/2712962/16732616/5cefd846-477e-11e6-938e-541112c7bd18.png)
