### PR TITLE
Made a generic artworks grid for home rail

### DIFF
--- a/lib/components/artist/artworks/index.js
+++ b/lib/components/artist/artworks/index.js
@@ -6,7 +6,7 @@ import { Text, View, StyleSheet } from 'react-native';
 
 import Separator from '../../separator'
 import SerifText from '../../text/serif';
-import ArtworksGrid from './grid';
+import ArtworksGrid from '../../artwork_grids/infinite_scroll_grid';
 const { artworksQuery } = ArtworksGrid;
 
 import colors from '../../../../data/colors';

--- a/lib/components/artwork_grids/artwork.js
+++ b/lib/components/artwork_grids/artwork.js
@@ -1,0 +1,83 @@
+'use strict';
+
+import Relay from 'react-relay';
+import React from 'react';
+import { Text, View, StyleSheet, TouchableWithoutFeedback } from 'react-native';
+
+import ImageView from '../opaque_image_view';
+import SerifText from '../text/serif';
+import colors from '../../../data/colors';
+import SwitchBoard from '../../modules/switch_board';
+
+export default class Artwork extends React.Component {
+  handleTap() {
+    SwitchBoard.presentNavigationViewController(this, this.props.artwork.href);
+  }
+
+  render() {
+    const artwork = this.props.artwork;
+    return (
+      <TouchableWithoutFeedback onPress={this.handleTap.bind(this)}>
+        <View>
+          <ImageView style={styles.image} aspectRatio={artwork.image.aspect_ratio} imageURL={artwork.image.url} />
+          <SerifText style={[styles.text, styles.artist]}>{artwork.artist.name}</SerifText>
+          { this.artworkTitle() }
+          { this.props.artwork.partner ? <SerifText style={styles.text}>{ this.props.artwork.partner.name }</SerifText> : null }
+          { this.saleMessage() }
+        </View>
+      </TouchableWithoutFeedback>
+    );
+  }
+
+  artworkTitle() {
+    const artwork = this.props.artwork;
+    if (artwork.title) {
+      return (
+        <SerifText style={styles.text}>
+          <SerifText style={[styles.text, styles.title]}>{ artwork.title }</SerifText>
+          { artwork.date ? (", " + artwork.date) : "" }
+        </SerifText>
+      );
+    } else {
+      return null;
+    }
+  }
+
+  saleMessage() {
+    const message = this.props.artwork.sale_message;
+    return message ? <SerifText style={styles.text}>{ message }</SerifText> : null;
+   }
+};
+
+Artwork.propTypes = {
+  artwork: React.PropTypes.shape({
+    title: React.PropTypes.string,
+    sale_message: React.PropTypes.string,
+    image: React.PropTypes.shape({
+      url: React.PropTypes.string,
+      aspect_ratio: React.PropTypes.number,
+    }),
+    artist: React.PropTypes.shape({
+      name: React.PropTypes.string,
+    }),
+    partner: React.PropTypes.shape({
+      name: React.PropTypes.string,
+    }),
+  }),
+};
+
+const styles = StyleSheet.create({
+  image: {
+    marginBottom: 10,
+  },
+  text: {
+    fontSize: 12,
+    color: colors['gray-semibold'],
+  },
+  artist: {
+    fontWeight: 'bold',
+  },
+  title: {
+    fontStyle: 'italic',
+  }
+});

--- a/lib/components/artwork_grids/generic_grid.js
+++ b/lib/components/artwork_grids/generic_grid.js
@@ -1,0 +1,149 @@
+'use strict';
+
+import Relay from 'react-relay';
+import React from 'react';
+import { Dimensions, View, ScrollView, StyleSheet } from 'react-native';
+
+import Artwork from './artwork';
+import Spinner from '../spinner';
+import { metaphysicsURL } from '../../relay/config';
+
+class GenericArtworksGrid extends React.Component {
+  static defaultProps = {
+    sectionDirection: 'column',
+    sectionCount: Dimensions.get('window').width > 700 ? 3 : 2,
+    sectionMargin: 20,
+    itemMargin: 20,
+  }
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      sectionDimension: 0,
+      artworks: this.props.artworks,
+    }
+
+    this.onLayout = this.onLayout.bind(this);
+  }
+
+  onLayout(event: LayoutEvent) {
+    const layout = event.nativeEvent.layout;
+    if (layout.width > 0) {
+      const sectionMargins = this.props.sectionMargin * (this.props.sectionCount - 1);
+      this.setState({ sectionDimension: (layout.width - sectionMargins) / this.props.sectionCount });
+    }
+  }
+
+  sectionedArtworks() {
+    const sectionedArtworks = [];
+    const sectionRatioSums = [];
+    for (let i = 0; i < this.props.sectionCount; i++) {
+      sectionedArtworks.push([]);
+      sectionRatioSums.push(0);
+    };
+
+    const artworks = this.state.artworks;
+    for (let i = 0; i < artworks.length; i++) {
+      const artwork = this.state.artworks[i];
+
+      if (artwork.image) {
+        let lowestRatioSum = Number.MAX_VALUE;
+        let sectionIndex = null;
+        for (let j = 0; j < sectionRatioSums.length; j++) {
+          const ratioSum = sectionRatioSums[j];
+          if (ratioSum < lowestRatioSum) {
+            sectionIndex = j;
+            lowestRatioSum = ratioSum;
+          }
+        }
+
+        const section = sectionedArtworks[sectionIndex];
+        section.push(artwork);
+
+        // total section aspect ratio
+        const aspectRatio = artwork.image.aspect_ratio || 1;
+        sectionRatioSums[sectionIndex] += (1 / aspectRatio);
+      }
+    }
+    return sectionedArtworks;
+  }
+
+  renderSections() {
+    const spacerStyle = {
+      height: this.props.itemMargin,
+    };
+    const sectionedArtworks = this.sectionedArtworks();
+    const sections = [];
+    for (let i = 0; i < this.props.sectionCount; i++) {
+      const artworkComponents = [];
+      const artworks = sectionedArtworks[i];
+      for (let j = 0; j < artworks.length; j++) {
+        artworkComponents.push(<Artwork artwork={artworks[j]} key={'artwork-'+j} />);
+        if (j < artworks.length-1) {
+          artworkComponents.push(<View style={spacerStyle} key={'spacer-'+j} accessibilityLabel='Spacer View' />);
+        }
+      }
+
+      const sectionSpecificStlye = {
+          width: this.state.sectionDimension,
+          marginRight: (i == this.props.sectionCount-1 ? 0 : this.props.sectionMargin),
+      };
+      sections.push(
+        <View style={[styles.section, sectionSpecificStlye]} key={i} accessibilityLabel={'Section ' + i}>
+          {artworkComponents}
+        </View>
+      );
+    }
+    return sections;
+  }
+
+  render() {
+    const artworks = this.state.sectionDimension ? this.renderSections() : null;
+    return (
+      <View onLayout={this.onLayout}>
+        <View style={styles.container} accessibilityLabel='Artworks Content View'>
+          {artworks}
+        </View>
+        {this.state.fetchingNextPage ? <Spinner style={styles.spinner} /> : null}
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+  },
+  section: {
+    flex: 1,
+    flexDirection: 'column',
+  },
+  spinner: {
+    marginTop: 20,
+  },
+});
+
+const GenericArtworksGridContainer = Relay.createContainer(GenericArtworksGrid, {
+  fragments: {
+    artworks: () => Relay.QL`
+      fragment on Artwork @relay(plural: true) {
+        title
+        date
+        sale_message
+        image {
+          url(version: "large")
+          aspect_ratio
+        }
+        artist {
+          name
+        }
+        partner {
+          name
+        }
+        href
+      }
+    `,
+  }
+});
+
+export default GenericArtworksGridContainer;

--- a/lib/components/artwork_grids/infinite_scroll_grid.js
+++ b/lib/components/artwork_grids/infinite_scroll_grid.js
@@ -1,0 +1,272 @@
+'use strict';
+
+// 1. Get first layout pass of grid view so we have a total width and calculate the column width (componentDidMount?).
+// 2. Possibly do artwork column layout now, as we can do so based just on the aspect ratio, assuming the text height
+//    won't be too different between artworks.
+// 3. Get artwork heights by either:
+//    - calculating the item size upfront with aspect ratio and a static height for the text labels.
+//    - leting the artwork component do a layout pass and calculate its own height based on the column width.
+// 4. Update height of grid to encompass all items.
+
+import Relay from 'react-relay';
+import React from 'react';
+import { Dimensions, View, ScrollView, StyleSheet } from 'react-native';
+
+import Artwork from './artwork';
+import Spinner from '../spinner';
+import { metaphysicsURL } from '../../relay/config';
+
+
+const PageSize = 10;
+const PageEndThreshold = 1000;
+
+/**
+ * TODOs:
+ * - currently all the code assumes column layout
+ *   - do no invert aspect ratios in row layout
+ * - deal with edge-cases when calculating in which section an artwork should go
+ *   - see ARMasonryCollectionViewLayout for details on how to deal with last works sticking out
+ *   - the calculation currently only takes into account the size of the image, not if e.g. the sale message is present
+ */
+class InfiniteScrollArtworksGrid extends React.Component {
+  static defaultProps = {
+    sectionDirection: 'column',
+    sectionCount: Dimensions.get('window').width > 700 ? 3 : 2,
+    sectionMargin: 20,
+    itemMargin: 20,
+  }
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      sectionDimension: 0,
+      artworks: this.props.artworks,
+      page: 1,
+      completed: false,
+      fetchingNextPage: false,
+    };
+
+    this.onLayout = this.onLayout.bind(this);
+    this.onScroll = this.onScroll.bind(this);
+
+    this._sentEndForContentLength = null;
+  }
+
+  fetchNextPage() {
+    if (this.state.fetchingNextPage || this.state.completed) {
+      return;
+    }
+
+    const nextPage = this.state.page + 1;
+    const query = this.props.artworksQuery(this.props.relay.route.params.artistID, nextPage);
+
+    fetch(metaphysicsURL, { method: 'post',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ query }) })
+      .then((response) => {
+        if (response.status >= 200 && response.status < 300) {
+          return response
+        } else {
+          const error = new Error(response.statusText)
+          error.response = response
+          throw error
+        }
+      })
+      .then((response) => response.json())
+      .then(({ data }) => {
+        const artworks = data.artist.artworks;
+        const completed = artworks < PageSize;
+        if (completed && this.props.onComplete) {
+          this.props.onComplete();
+        }
+        this.setState({
+          page: nextPage,
+          artworks: this.state.artworks.concat(artworks),
+          completed: completed,
+          fetchingNextPage: false,
+        });
+      })
+      .catch((error) => {
+        this.setState({ fetchingNextPage: false });
+        console.log(error);
+      });
+
+    this.setState({ fetchingNextPage: true });
+  }
+
+  onLayout(event: LayoutEvent) {
+    const layout = event.nativeEvent.layout;
+    if (layout.width > 0) {
+      // This is the sum of all margins in between sections, so do not count to the right of last column.
+      const sectionMargins = this.props.sectionMargin * (this.props.sectionCount - 1);
+      this.setState({ sectionDimension: (layout.width - sectionMargins) / this.props.sectionCount });
+    }
+  }
+
+  sectionedArtworks() {
+    const sectionedArtworks = [];
+    const sectionRatioSums = [];
+    for (let i = 0; i < this.props.sectionCount; i++) {
+      sectionedArtworks.push([]);
+      sectionRatioSums.push(0);
+    };
+
+    const artworks = this.state.artworks;
+    for (let i = 0; i < artworks.length; i++) {
+      const artwork = this.state.artworks[i];
+
+      // There are artworks without images and other ‘issues’. Like Force we’re just going to reject those for now.
+      // See: https://github.com/artsy/eigen/issues/1667
+      //
+      if (artwork.image) {
+        // Find section with lowest *inverted* aspect ratio sum, which is the shortest column.
+        let lowestRatioSum = Number.MAX_VALUE; // Start higher, so we always find a
+        let sectionIndex = null;
+        for (let j = 0; j < sectionRatioSums.length; j++) {
+          const ratioSum = sectionRatioSums[j];
+          if (ratioSum < lowestRatioSum) {
+            sectionIndex = j;
+            lowestRatioSum = ratioSum;
+          }
+        }
+
+        const section = sectionedArtworks[sectionIndex];
+        section.push(artwork);
+
+        // Keep track of total section aspect ratio
+        const aspectRatio = artwork.image.aspect_ratio || 1; // Ensure we never divide by null/0
+        // Invert the aspect ratio so that a lower value means a shorter section.
+        sectionRatioSums[sectionIndex] += (1 / aspectRatio);
+      }
+    }
+
+    return sectionedArtworks;
+  }
+
+  renderSections() {
+    const spacerStyle = {
+      height: this.props.itemMargin,
+    };
+
+    const sectionedArtworks = this.sectionedArtworks();
+    const sections = [];
+    for (let i = 0; i < this.props.sectionCount; i++) {
+      const artworkComponents = [];
+      const artworks = sectionedArtworks[i];
+      for (let j = 0; j < artworks.length; j++) {
+        artworkComponents.push(<Artwork artwork={artworks[j]} key={'artwork-'+j} />);
+        // Setting a marginBottom on the artwork component didn’t work, so using a spacer view instead.
+        if (j < artworks.length-1) {
+          artworkComponents.push(<View style={spacerStyle} key={'spacer-'+j} accessibilityLabel='Spacer View' />);
+        }
+      }
+
+      const sectionSpecificStyle = {
+        width: this.state.sectionDimension,
+        marginRight: (i == this.props.sectionCount-1 ? 0 : this.props.sectionMargin),
+      };
+      sections.push(
+        <View style={[styles.section, sectionSpecificStyle]} key={i} accessibilityLabel={'Section ' + i}>
+          {artworkComponents}
+        </View>
+      );
+    }
+    return sections;
+  }
+
+  // Lifted pretty much straight from RN’s ListView.js
+  onScroll(event) {
+    const scrollProperties = event.nativeEvent;
+    const contentLength = scrollProperties.contentSize.height;
+    if (contentLength !== this._sentEndForContentLength) {
+      const offset = scrollProperties.contentOffset.y;
+      const visibleLength = scrollProperties.layoutMeasurement.height;
+      const distanceFromEnd = contentLength - visibleLength - offset;
+      if (distanceFromEnd < PageEndThreshold) {
+        this._sentEndForContentLength = contentLength;
+        this.fetchNextPage();
+      }
+    }
+  }
+
+  render() {
+    const artworks = this.state.sectionDimension ? this.renderSections() : null;
+    return (
+      <ScrollView onScroll={this.onScroll}
+                  scrollEventThrottle={50}
+                  onLayout={this.onLayout}
+                  scrollsToTop={false}
+                  accessibilityLabel='Artworks ScrollView'>
+        <View style={styles.container} accessibilityLabel='Artworks Content View'>
+          {artworks}
+        </View>
+        {this.state.fetchingNextPage ? <Spinner style={styles.spinner} /> : null}
+      </ScrollView>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+  },
+  section: {
+    flex: 1,
+    flexDirection: 'column',
+  },
+  spinner: {
+    marginTop: 20,
+  },
+});
+
+const InfiniteScrollArtworksGridContainer = Relay.createContainer(InfiniteScrollArtworksGrid, {
+  fragments: {
+    artworks: () => Relay.QL`
+      fragment on Artwork @relay(plural: true) {
+        title
+        date
+        sale_message
+        image {
+          url(version: "large")
+          aspect_ratio
+        }
+        artist {
+          name
+        }
+        partner {
+            name
+        }
+        href
+      }
+    `,
+  }
+});
+
+export default InfiniteScrollArtworksGridContainer;
+
+// TODO: While we do pagination manually, we can’t actually use a Relay container around Artwork.
+InfiniteScrollArtworksGridContainer.artworksQuery = (artistID, filter, page) => {
+  return `
+    query {
+      artist(id: "${artistID}") {
+        artworks(sort: partner_updated_at_desc, filter: ${filter} size: ${PageSize}, page: ${page}) {
+          title
+          date
+          sale_message
+          image {
+            url(version: "large")
+            aspect_ratio
+          }
+          artist {
+            name
+          }
+          partner {
+            name
+          }
+          href
+        }
+      }
+    }
+  `;
+};
+

--- a/lib/components/home/artwork_rail.js
+++ b/lib/components/home/artwork_rail.js
@@ -3,9 +3,11 @@
 
 import Relay from 'react-relay';
 import React from 'react';
-import { View, Text } from 'react-native';
+import { View, Text, StyleSheet } from 'react-native';
 
 import Spinner from '../spinner';
+import Grid from '../artwork_grids/generic_grid';
+import SerifText from '../text/serif';
 
 class ArtworkRail extends React.Component {
   componentDidMount() {
@@ -14,11 +16,9 @@ class ArtworkRail extends React.Component {
 
   renderModuleResults() {
     if (this.props.rail.results) {
-      return this.props.rail.results.map(artwork => {
-        // Compose key, because an artwork may appear twice on the home view in different modules.
-        const key = this.props.rail.__id + artwork.__id;
-        return <Text key={key}>{artwork.title}</Text>;
-      });
+      return (
+        <Grid artworks={this.props.rail.results}/>
+      );
     } else {
       return <Spinner style={{ flex: 1 }} />;
     }
@@ -28,14 +28,22 @@ class ArtworkRail extends React.Component {
   render() {
     return (
       <View>
-        <Text>{this.props.rail.title}</Text>
-        <View style={{ marginLeft: 20 }}>
+        <SerifText style={styles.title}>{this.props.rail.title}</SerifText>
+        <View style={{ margin: 20 }}>
           {this.renderModuleResults()}
         </View>
       </View>
     );
   }
 }
+
+const styles = StyleSheet.create({
+  title: {
+    margin: 10,
+    fontSize: 20,
+    alignSelf: 'center',
+  },
+});
 
 export default Relay.createContainer(ArtworkRail, {
   initialVariables: {
@@ -45,11 +53,9 @@ export default Relay.createContainer(ArtworkRail, {
   fragments: {
     rail: () => Relay.QL`
       fragment on HomePageArtworkModule {
-        __id
         title
         results @include(if: $fetchContent) {
-          __id
-          title
+          ${Grid.getFragment('artworks')}
         }
       }
     `,


### PR DESCRIPTION
This grid is exactly like the existing infinite scroll grid without the scroll-to-reload behavior. I've also moved the `artist/artworks` components to a new `artwork_grids` directory so we can use them in both home and artist contexts.

![simulator screen shot jul 19 2016 1 35 58 pm](https://cloud.githubusercontent.com/assets/2712962/16948742/b664bb2e-4db6-11e6-83f7-a0b12742e0e5.png)
