### PR TITLE
[WIP][Home][ArtworksRail] Non-performant WIP way to change grid sectionCount upon rotation

### DIFF
--- a/lib/components/artwork_grids/generic_grid.js
+++ b/lib/components/artwork_grids/generic_grid.js
@@ -16,9 +16,14 @@ class GenericArtworksGrid extends React.Component {
 
   static defaultProps = {
     sectionDirection: 'column',
-    sectionCount: Dimensions.get('window').width > 700 ? 3 : 2,
     sectionMargin: 20,
     itemMargin: 20
+  }
+
+  sectionCount () {
+    const width = Dimensions.get('window').width;
+    const isPad = width > 700;
+    return isPad ? (width > 1000 ? 4 : 3)  : 2;
   }
 
   constructor(props) {
@@ -34,15 +39,15 @@ class GenericArtworksGrid extends React.Component {
   onLayout = (event: SyntheticEvent) => {
     const layout = event.nativeEvent.layout;
     if (layout.width > 0) {
-      const sectionMargins = this.props.sectionMargin * (this.props.sectionCount - 1);
-      this.setState({ sectionDimension: (layout.width - sectionMargins) / this.props.sectionCount });
+      const sectionMargins = this.props.sectionMargin * (this.sectionCount() - 1);
+      this.setState({ sectionDimension: (layout.width - sectionMargins) / this.sectionCount() });
     }
   }
 
   sectionedArtworks() {
     const sectionedArtworks = [];
     const sectionRatioSums = [];
-    for (let i = 0; i < this.props.sectionCount; i++) {
+    for (let i = 0; i < this.sectionCount(); i++) {
       sectionedArtworks.push([]);
       sectionRatioSums.push(0);
     }
@@ -79,7 +84,7 @@ class GenericArtworksGrid extends React.Component {
     };
     const sectionedArtworks = this.sectionedArtworks();
     const sections = [];
-    for (let i = 0; i < this.props.sectionCount; i++) {
+    for (let i = 0; i < this.sectionCount(); i++) {
       const artworkComponents = [];
       const artworks = sectionedArtworks[i];
       for (let j = 0; j < artworks.length; j++) {
@@ -91,7 +96,7 @@ class GenericArtworksGrid extends React.Component {
 
       const sectionSpecificStlye = {
           width: this.state.sectionDimension,
-          marginRight: (i === this.props.sectionCount - 1 ? 0 : this.props.sectionMargin),
+          marginRight: (i === this.sectionCount() - 1 ? 0 : this.props.sectionMargin),
       };
       sections.push(
         <View style={[styles.section, sectionSpecificStlye]} key={i} accessibilityLabel={'Section ' + i}>


### PR DESCRIPTION
I'm trying to figure out the best way to make the artworks grid update its number of columns when it rotates on iPad:

<img width="1224" alt="screen shot 2016-07-29 at 9 13 02 pm" src="https://cloud.githubusercontent.com/assets/2712962/17260531/4566cb42-55d1-11e6-9619-2cb77fa7bfcd.png">

This solution slows things down considerably and I don't like it, but I wanted to show where my train of thought is going. I'd like to minimize the number of times `Dimensions` is called, but also make sure that it is called at least once when a rotation happens.