### PR TITLE
[Home][ArtworkRail] Header Visuals

### DIFF
--- a/lib/components/home/artwork_rails/artwork_rail.js
+++ b/lib/components/home/artwork_rails/artwork_rail.js
@@ -69,7 +69,7 @@ class ArtworkRail extends React.Component {
 
   mainContainerHeight() {
     if (this.expandable()) {
-      const initialRailHeight = isPad ? 450 : 580
+      const initialRailHeight = isPad ? 460 : 530
       return this.state.expanded ? this.state.gridHeight + 101 : initialRailHeight
     } else {
       return this.state.gridHeight + 31

--- a/lib/components/home/artwork_rails/artwork_rail.js
+++ b/lib/components/home/artwork_rails/artwork_rail.js
@@ -5,11 +5,11 @@ import Relay from 'react-relay'
 import React from 'react'
 import { View, StyleSheet, TouchableHighlight, LayoutAnimation, Text, Image, Dimensions } from 'react-native'
 
-import Spinner from '../spinner'
-import Grid from '../artwork_grids/generic_grid'
-import SerifText from '../text/serif'
-import Separator from '../separator'
-import colors from '../../../data/colors'
+import Spinner from '../../spinner'
+import Grid from '../../artwork_grids/generic_grid'
+import Header from './artwork_rail_header'
+import Separator from '../../separator'
+import colors from '../../../../data/colors'
 
 const isPad = Dimensions.get('window').width > 700
 
@@ -37,7 +37,7 @@ class ArtworkRail extends React.Component {
     if (!this.state.expanded) {
       return (
         <TouchableHighlight style={styles.expansionButton} onPress={this.onPress.bind(this) } underlayColor={'white'}>
-            <Image style={{height: 8, width: 15, alignSelf: 'center'}} source={require('../../../images/chevron.png')} />
+            <Image style={{height: 8, width: 15, alignSelf: 'center'}} source={require('../../../../images/chevron.png')} />
         </TouchableHighlight>
       )
     }
@@ -69,7 +69,7 @@ class ArtworkRail extends React.Component {
 
   mainContainerHeight() {
     if (this.expandable()) {
-      const initialRailHeight = isPad ? 500 : 580
+      const initialRailHeight = isPad ? 450 : 580
       return this.state.expanded ? this.state.gridHeight + 101 : initialRailHeight
     } else {
       return this.state.gridHeight + 31
@@ -117,7 +117,7 @@ class ArtworkRail extends React.Component {
     const sideMargin = isPad ? 40 : 20
     return (
       <View>
-        <SerifText numberOfLines={2} style={styles.title}>{this.props.rail.title}</SerifText>
+        <Header rail={this.props.rail}/>
         <View style={{ marginLeft: sideMargin, marginRight: sideMargin }}>
           { this.renderModuleResults() }
         </View>
@@ -127,14 +127,6 @@ class ArtworkRail extends React.Component {
 }
 
 const styles = StyleSheet.create({
-  title: {
-    margin: isPad ? 40 : 20,
-    marginBottom: isPad ? 30 : 20,
-    marginTop: isPad ? 50 : 40,
-    fontSize: isPad ? 30 : 26,
-    alignSelf: 'center',
-    textAlign: 'center',
-  },
   container: {
     backgroundColor: 'white',
   },
@@ -177,7 +169,7 @@ export default Relay.createContainer(ArtworkRail, {
   fragments: {
     rail: () => Relay.QL`
       fragment on HomePageArtworkModule {
-        title
+        ${Header.getFragment('rail')}
         results @include(if: $fetchContent) {
           ${Grid.getFragment('artworks')}
         }

--- a/lib/components/home/artwork_rails/artwork_rail_header.js
+++ b/lib/components/home/artwork_rails/artwork_rail_header.js
@@ -47,6 +47,7 @@ class ArtworkRailHeader extends React.Component {
 
 const styles = StyleSheet.create({
   container: {
+    marginTop: 30,
     marginBottom: 30,
   },
   title: {
@@ -57,7 +58,7 @@ const styles = StyleSheet.create({
   },
   viewAllButton: {
     fontFamily: 'Avant Garde Gothic ITCW01Dm',
-    fontSize: 12,
+    fontSize: isPad ? 14 : 12,
     color: colors['gray-medium'],
     textAlign: 'center',
     letterSpacing: 0.5,
@@ -71,6 +72,7 @@ const styles = StyleSheet.create({
   followAnnotation: {
     fontStyle: 'italic',
     alignSelf: 'center',
+    fontSize: 16,
   }
 })
 

--- a/lib/components/home/artwork_rails/artwork_rail_header.js
+++ b/lib/components/home/artwork_rails/artwork_rail_header.js
@@ -1,0 +1,42 @@
+/* @flow */
+'use strict'
+
+import Relay from 'react-relay'
+import React from 'react'
+import { StyleSheet, Dimensions } from 'react-native'
+
+import SerifText from '../../text/serif'
+
+const isPad = Dimensions.get('window').width > 700
+
+class ArtworkRailHeader extends React.Component {
+  render() {
+    return (
+      <SerifText numberOfLines={2} style={styles.title}>{ this.props.rail.title + '\n' + (this.props.rail.context && this.props.rail.context.__typename) }</SerifText>
+    )
+  }
+}
+
+const styles = StyleSheet.create({
+  title: {
+    margin: isPad ? 40 : 20,
+    marginBottom: isPad ? 30 : 20,
+    marginTop: isPad ? 50 : 40,
+    fontSize: isPad ? 30 : 26,
+    alignSelf: 'center',
+    textAlign: 'center',
+  },
+})
+
+export default Relay.createContainer(ArtworkRailHeader, {
+  fragments: {
+    rail: () => Relay.QL`
+      fragment on HomePageArtworkModule {
+        title
+        context {
+          __typename
+        }
+      }
+    `,
+  }
+})

--- a/lib/components/home/artwork_rails/artwork_rail_header.js
+++ b/lib/components/home/artwork_rails/artwork_rail_header.js
@@ -3,28 +3,60 @@
 
 import Relay from 'react-relay'
 import React from 'react'
-import { StyleSheet, Dimensions } from 'react-native'
+import { StyleSheet, Dimensions, View, Text } from 'react-native'
 
 import SerifText from '../../text/serif'
+import colors from '../../../../data/colors'
+import Button from '../../buttons/inverted_button'
 
 const isPad = Dimensions.get('window').width > 700
 
 class ArtworkRailHeader extends React.Component {
   render() {
     return (
-      <SerifText numberOfLines={2} style={styles.title}>{ this.props.rail.title + '\n' + (this.props.rail.context && this.props.rail.context.__typename) }</SerifText>
+      <View>
+        <SerifText numberOfLines={2} style={styles.title}>{ this.props.rail.title }</SerifText>
+        { this.props.rail.context && this.actionButton() }
+      </View>
     )
+  }
+
+  actionButton() {
+    switch (this.props.rail.context.__typename) {
+      case 'HomePageModuleContextFollowArtists':
+        return <Text style={styles.viewAllButton}> { 'View All'.toUpperCase() } </Text>
+      case 'HomePageModuleContextRelatedArtist':
+        return (
+          <View style={styles.followButton}>
+            <Button text={'Follow'}/>
+          </View>
+        )
+      default:
+        return null
+    }
   }
 }
 
 const styles = StyleSheet.create({
   title: {
-    margin: isPad ? 40 : 20,
-    marginBottom: isPad ? 30 : 20,
     marginTop: isPad ? 50 : 40,
     fontSize: isPad ? 30 : 26,
     alignSelf: 'center',
     textAlign: 'center',
+  },
+  viewAllButton: {
+    fontFamily: 'Avant Garde Gothic ITCW01Dm',
+    fontSize: 15,
+    color: colors['gray-medium'],
+    textAlign: 'center',
+    letterSpacing: 0.5,
+    marginBottom: 20,
+  },
+  followButton: {
+    marginTop: 10,
+    marginBottom: 20,
+    margin: 160,
+    height: 35,
   },
 })
 

--- a/lib/components/home/artwork_rails/artwork_rail_header.js
+++ b/lib/components/home/artwork_rails/artwork_rail_header.js
@@ -14,11 +14,19 @@ const isPad = Dimensions.get('window').width > 700
 class ArtworkRailHeader extends React.Component {
   render() {
     return (
-      <View>
+      <View style={styles.container}>
+        { this.props.rail.context && this.followAnnotation() }
         <SerifText numberOfLines={2} style={styles.title}>{ this.props.rail.title }</SerifText>
         { this.props.rail.context && this.actionButton() }
       </View>
     )
+  }
+
+  followAnnotation() {
+    // string comparing feels super weird but making a javascript 'enum' might be worse?
+    if (this.props.rail.context.__typename === 'HomePageModuleContextRelatedArtist') {
+      return <SerifText style={styles.followAnnotation}>{ 'Based on ' + this.props.rail.context.based_on.name }</SerifText>
+    }
   }
 
   actionButton() {
@@ -38,28 +46,45 @@ class ArtworkRailHeader extends React.Component {
 }
 
 const styles = StyleSheet.create({
+  container: {
+    marginBottom: 30,
+  },
   title: {
-    marginTop: isPad ? 50 : 40,
+    marginTop: 10,
     fontSize: isPad ? 30 : 26,
     alignSelf: 'center',
     textAlign: 'center',
   },
   viewAllButton: {
     fontFamily: 'Avant Garde Gothic ITCW01Dm',
-    fontSize: 15,
+    fontSize: 12,
     color: colors['gray-medium'],
     textAlign: 'center',
     letterSpacing: 0.5,
-    marginBottom: 20,
   },
   followButton: {
     marginTop: 10,
-    marginBottom: 20,
-    margin: 160,
-    height: 35,
+    marginBottom: 0,
+    margin: isPad ? 160 : 135,
+    height: 30,
   },
+  followAnnotation: {
+    fontStyle: 'italic',
+    alignSelf: 'center',
+  }
 })
 
+const relatedArtistFragment = Relay.QL`
+  fragment related_artists_context on HomePageModuleContextRelatedArtist {
+    artist {
+      href
+      id
+    }
+    based_on {
+      name
+    }
+  }
+`
 export default Relay.createContainer(ArtworkRailHeader, {
   fragments: {
     rail: () => Relay.QL`
@@ -67,6 +92,7 @@ export default Relay.createContainer(ArtworkRailHeader, {
         title
         context {
           __typename
+          ${ relatedArtistFragment }
         }
       }
     `,

--- a/lib/containers/home.js
+++ b/lib/containers/home.js
@@ -5,7 +5,7 @@ import Relay from 'react-relay'
 import React from 'react'
 import { ScrollView } from 'react-native'
 
-import ArtworkRail from '../components/home/artwork_rail'
+import ArtworkRail from '../components/home/artwork_rails/artwork_rail'
 import ArtistRail from '../components/home/artist_rails/artist_rail'
 
 class Home extends React.Component {


### PR DESCRIPTION
- [x] New component for header
- [x] Related Artist state (based on + follow button)

![simulator screen shot aug 16 2016 10 46 20 pm](https://cloud.githubusercontent.com/assets/2712962/17715321/da8673b8-6403-11e6-91db-5704f8f9fe10.png)

- [x] Additional content state

![simulator screen shot aug 16 2016 10 49 54 pm](https://cloud.githubusercontent.com/assets/2712962/17715329/df7f6924-6403-11e6-939e-1ba72618971d.png)

- [x] No additional content state
- [x] Polish
- [x] iPad styling


![rail](https://cloud.githubusercontent.com/assets/2712962/17715505/ab7a6b28-6404-11e6-9fe2-f66a3c2566ac.gif)

