### PR TITLE
[package] Add concurrently back and clean-up shrinkwrap.

### DIFF
--- a/Dangerfile.js
+++ b/Dangerfile.js
@@ -1,23 +1,27 @@
 // CHANGELOG check
-if (_.includes(git.modified_files, "CHANGELOG.md") === false) {
+const hasAppChanges = _.filter(git.modified_files, function(path){
+  return _.includes(path, 'lib/');
+}).length > 0
+
+if (hasAppChanges && _.includes(git.modified_files, "CHANGELOG.md") === false) {
   fail("No CHANGELOG added.")
 }
 
-const test_files = _.filter(git.modified_files, function(path){
+const testFiles = _.filter(git.modified_files, function(path){
   return _.includes(path, '__tests__/');
 })
 
-const logical_test_paths = _.map(test_files, function(path){
+const logicalTestPaths = _.map(testFiles, function(path){
   // turns "lib/__tests__/i-am-good-tests.js" into "lib/i-am-good.js"
   return path.replace(/__tests__\//, '').replace(/-tests\./, '.')
 })
 
-const source_paths = _.filter(git.modified_files, function(path){
+const sourcePaths = _.filter(git.modified_files, function(path){
   return _.includes(path, 'lib/') &&  !_.includes(path, '__tests__/');
 })
 
 // Check that any new file has a corresponding tests file
-const untested_files = _.difference(source_paths, logical_test_paths)
-if (untested_files.length > 0) {
-  warn("The following files do not have tests: " + github.html_link(untested_files))
+const untestedFiles = _.difference(sourcePaths, logicalTestPaths)
+if (untestedFiles.length > 0) {
+  warn("The following files do not have tests: " + github.html_link(untestedFiles))
 }

--- a/dependencyci.yml
+++ b/dependencyci.yml
@@ -7,3 +7,6 @@ platforms:
     jade:
       tests:
         deprecated: skip
+    firebase:
+      tests:
+        unlicensed: skip

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,6 +2,60 @@
   "name": "emission",
   "version": "1.0.3",
   "dependencies": {
+    "@kadira/react-native-storybook": {
+      "version": "1.12.3",
+      "from": "@kadira/react-native-storybook@>=1.11.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/@kadira/react-native-storybook/-/react-native-storybook-1.12.3.tgz",
+      "dependencies": {
+        "glob": {
+          "version": "7.0.5",
+          "from": "glob@>=7.0.0 <8.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz"
+        },
+        "minimatch": {
+          "version": "3.0.3",
+          "from": "minimatch@>=3.0.2 <4.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
+        },
+        "shelljs": {
+          "version": "0.7.3",
+          "from": "shelljs@>=0.7.0 <0.8.0",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.3.tgz"
+        }
+      }
+    },
+    "@kadira/react-split-pane": {
+      "version": "1.4.7",
+      "from": "@kadira/react-split-pane@>=1.4.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/@kadira/react-split-pane/-/react-split-pane-1.4.7.tgz"
+    },
+    "@kadira/storybook-channel": {
+      "version": "1.1.0",
+      "from": "@kadira/storybook-channel@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/@kadira/storybook-channel/-/storybook-channel-1.1.0.tgz"
+    },
+    "@kadira/storybook-channel-firebase": {
+      "version": "1.0.3",
+      "from": "@kadira/storybook-channel-firebase@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/@kadira/storybook-channel-firebase/-/storybook-channel-firebase-1.0.3.tgz"
+    },
+    "@kadira/storybook-channel-websocket": {
+      "version": "1.0.1",
+      "from": "@kadira/storybook-channel-websocket@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/@kadira/storybook-channel-websocket/-/storybook-channel-websocket-1.0.1.tgz"
+    },
+    "@kadira/storybook-ui": {
+      "version": "2.6.1",
+      "from": "@kadira/storybook-ui@>=2.1.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/@kadira/storybook-ui/-/storybook-ui-2.6.1.tgz",
+      "dependencies": {
+        "qs": {
+          "version": "6.2.1",
+          "from": "qs@>=6.2.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz"
+        }
+      }
+    },
     "abab": {
       "version": "1.0.3",
       "from": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz",
@@ -51,6 +105,18 @@
         }
       }
     },
+    "agent-base": {
+      "version": "2.0.1",
+      "from": "agent-base@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.0.1.tgz",
+      "dependencies": {
+        "semver": {
+          "version": "5.0.3",
+          "from": "semver@>=5.0.1 <5.1.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
+        }
+      }
+    },
     "align-text": {
       "version": "0.1.4",
       "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
@@ -65,6 +131,11 @@
       "version": "0.3.1",
       "from": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
       "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz"
+    },
+    "ansi-align": {
+      "version": "1.1.0",
+      "from": "ansi-align@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-1.1.0.tgz"
     },
     "ansi-escapes": {
       "version": "1.4.0",
@@ -81,10 +152,25 @@
       "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
     },
+    "ansicolors": {
+      "version": "0.2.1",
+      "from": "ansicolors@>=0.2.1 <0.3.0",
+      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz"
+    },
+    "any-promise": {
+      "version": "1.3.0",
+      "from": "any-promise@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz"
+    },
     "archive-type": {
       "version": "3.2.0",
       "from": "https://registry.npmjs.org/archive-type/-/archive-type-3.2.0.tgz",
       "resolved": "https://registry.npmjs.org/archive-type/-/archive-type-3.2.0.tgz"
+    },
+    "archy": {
+      "version": "1.0.0",
+      "from": "archy@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz"
     },
     "are-we-there-yet": {
       "version": "1.1.2",
@@ -111,10 +197,20 @@
       "from": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
     },
+    "array-equal": {
+      "version": "1.0.0",
+      "from": "array-equal@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz"
+    },
     "array-find-index": {
       "version": "1.0.1",
       "from": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz"
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "from": "array-flatten@1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
     },
     "array-union": {
       "version": "1.0.1",
@@ -155,11 +251,6 @@
       "version": "0.2.0",
       "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
-    },
-    "assertion-error": {
-      "version": "1.0.2",
-      "from": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz"
     },
     "ast-query": {
       "version": "1.2.0",
@@ -313,6 +404,11 @@
       "from": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.8.0.tgz"
     },
+    "babel-jest": {
+      "version": "14.1.0",
+      "from": "babel-jest@>=14.1.0 <15.0.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-14.1.0.tgz"
+    },
     "babel-messages": {
       "version": "6.8.0",
       "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
@@ -327,6 +423,16 @@
       "version": "6.8.0",
       "from": "https://registry.npmjs.org/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.8.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.8.0.tgz"
+    },
+    "babel-plugin-istanbul": {
+      "version": "1.1.0",
+      "from": "babel-plugin-istanbul@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-1.1.0.tgz"
+    },
+    "babel-plugin-jest-hoist": {
+      "version": "14.1.1",
+      "from": "babel-plugin-jest-hoist@>=14.1.0 <15.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-14.1.1.tgz"
     },
     "babel-plugin-react-transform": {
       "version": "2.0.2",
@@ -595,6 +701,11 @@
       "from": "babel-preset-fbjs@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-2.0.0.tgz"
     },
+    "babel-preset-jest": {
+      "version": "14.1.0",
+      "from": "babel-preset-jest@>=14.1.0 <15.0.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-14.1.0.tgz"
+    },
     "babel-preset-react-native": {
       "version": "1.9.0",
       "from": "https://registry.npmjs.org/babel-preset-react-native/-/babel-preset-react-native-1.9.0.tgz",
@@ -715,6 +826,33 @@
       "from": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz"
     },
+    "bin-check": {
+      "version": "2.0.0",
+      "from": "bin-check@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/bin-check/-/bin-check-2.0.0.tgz"
+    },
+    "bin-version": {
+      "version": "1.0.4",
+      "from": "bin-version@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/bin-version/-/bin-version-1.0.4.tgz"
+    },
+    "bin-version-check": {
+      "version": "2.1.0",
+      "from": "bin-version-check@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/bin-version-check/-/bin-version-check-2.1.0.tgz",
+      "dependencies": {
+        "semver": {
+          "version": "4.3.6",
+          "from": "semver@>=4.0.3 <5.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+        }
+      }
+    },
+    "bin-wrapper": {
+      "version": "3.0.2",
+      "from": "bin-wrapper@>=3.0.2 <4.0.0",
+      "resolved": "https://registry.npmjs.org/bin-wrapper/-/bin-wrapper-3.0.2.tgz"
+    },
     "binaryextensions": {
       "version": "1.0.1",
       "from": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-1.0.1.tgz",
@@ -737,6 +875,11 @@
         }
       }
     },
+    "bluebird": {
+      "version": "3.4.1",
+      "from": "bluebird@>=3.1.1 <4.0.0",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.1.tgz"
+    },
     "body-parser": {
       "version": "1.13.3",
       "from": "https://registry.npmjs.org/body-parser/-/body-parser-1.13.3.tgz",
@@ -758,6 +901,18 @@
       "version": "2.10.1",
       "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+    },
+    "boxen": {
+      "version": "0.6.0",
+      "from": "boxen@>=0.6.0 <0.7.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-0.6.0.tgz",
+      "dependencies": {
+        "repeating": {
+          "version": "2.0.1",
+          "from": "repeating@^2.0.0",
+          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
+        }
+      }
     },
     "bplist-creator": {
       "version": "0.0.4",
@@ -851,6 +1006,11 @@
       "from": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz"
     },
+    "cardinal": {
+      "version": "0.5.0",
+      "from": "cardinal@>=0.5.0 <0.6.0",
+      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.5.0.tgz"
+    },
     "caseless": {
       "version": "0.11.0",
       "from": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
@@ -872,21 +1032,6 @@
       "version": "0.1.3",
       "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz"
-    },
-    "chai": {
-      "version": "3.5.0",
-      "from": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz"
-    },
-    "chai-as-promised": {
-      "version": "5.3.0",
-      "from": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-5.3.0.tgz",
-      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-5.3.0.tgz"
-    },
-    "chai-enzyme": {
-      "version": "0.4.2",
-      "from": "https://registry.npmjs.org/chai-enzyme/-/chai-enzyme-0.4.2.tgz",
-      "resolved": "https://registry.npmjs.org/chai-enzyme/-/chai-enzyme-0.4.2.tgz"
     },
     "chalk": {
       "version": "1.1.3",
@@ -910,6 +1055,16 @@
         }
       }
     },
+    "classnames": {
+      "version": "2.2.5",
+      "from": "classnames@>=2.2.3 <3.0.0",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz"
+    },
+    "cli-boxes": {
+      "version": "1.0.0",
+      "from": "cli-boxes@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz"
+    },
     "cli-cursor": {
       "version": "1.0.2",
       "from": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
@@ -919,6 +1074,18 @@
       "version": "0.3.1",
       "from": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
       "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz"
+    },
+    "cli-usage": {
+      "version": "0.1.2",
+      "from": "cli-usage@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/cli-usage/-/cli-usage-0.1.2.tgz",
+      "dependencies": {
+        "minimist": {
+          "version": "0.2.0",
+          "from": "minimist@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
+        }
+      }
     },
     "cli-width": {
       "version": "2.1.0",
@@ -962,6 +1129,11 @@
       "from": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
     },
+    "columnify": {
+      "version": "1.5.4",
+      "from": "columnify@>=1.5.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz"
+    },
     "combined-stream": {
       "version": "1.0.5",
       "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
@@ -1002,6 +1174,73 @@
       "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz"
     },
+    "concurrently": {
+      "version": "2.2.0",
+      "from": "concurrently@latest",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-2.2.0.tgz",
+      "dependencies": {
+        "ansi-regex": {
+          "version": "0.2.1",
+          "from": "ansi-regex@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+        },
+        "ansi-styles": {
+          "version": "1.1.0",
+          "from": "ansi-styles@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+        },
+        "bluebird": {
+          "version": "2.9.6",
+          "from": "bluebird@2.9.6",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.6.tgz"
+        },
+        "chalk": {
+          "version": "0.5.1",
+          "from": "chalk@0.5.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz"
+        },
+        "commander": {
+          "version": "2.6.0",
+          "from": "commander@2.6.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
+        },
+        "cross-spawn": {
+          "version": "0.2.9",
+          "from": "cross-spawn@>=0.2.9 <0.3.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-0.2.9.tgz"
+        },
+        "has-ansi": {
+          "version": "0.1.0",
+          "from": "has-ansi@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz"
+        },
+        "lodash": {
+          "version": "4.15.0",
+          "from": "lodash@>=4.5.1 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz"
+        },
+        "rx": {
+          "version": "2.3.24",
+          "from": "rx@2.3.24",
+          "resolved": "https://registry.npmjs.org/rx/-/rx-2.3.24.tgz"
+        },
+        "strip-ansi": {
+          "version": "0.3.0",
+          "from": "strip-ansi@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz"
+        },
+        "supports-color": {
+          "version": "0.2.0",
+          "from": "supports-color@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+        }
+      }
+    },
+    "configstore": {
+      "version": "2.0.0",
+      "from": "configstore@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-2.0.0.tgz"
+    },
     "connect": {
       "version": "2.30.2",
       "from": "https://registry.npmjs.org/connect/-/connect-2.30.2.tgz",
@@ -1011,6 +1250,16 @@
       "version": "1.6.2",
       "from": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.6.2.tgz",
       "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.6.2.tgz"
+    },
+    "console-stream": {
+      "version": "0.1.1",
+      "from": "console-stream@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/console-stream/-/console-stream-0.1.1.tgz"
+    },
+    "content-disposition": {
+      "version": "0.5.1",
+      "from": "content-disposition@0.5.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz"
     },
     "content-type": {
       "version": "1.0.2",
@@ -1293,17 +1542,10 @@
         }
       }
     },
-    "deep-eql": {
-      "version": "0.1.3",
-      "from": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-      "dependencies": {
-        "type-detect": {
-          "version": "0.1.1",
-          "from": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
-        }
-      }
+    "deep-equal": {
+      "version": "1.0.1",
+      "from": "deep-equal@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz"
     },
     "deep-extend": {
       "version": "0.4.1",
@@ -1315,10 +1557,10 @@
       "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
     },
-    "define-properties": {
-      "version": "1.1.2",
-      "from": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz"
+    "defaults": {
+      "version": "1.0.3",
+      "from": "defaults@>=1.0.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz"
     },
     "defined": {
       "version": "1.0.0",
@@ -1429,6 +1671,11 @@
       "from": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz"
     },
+    "dot-prop": {
+      "version": "2.4.0",
+      "from": "dot-prop@>=2.3.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-2.4.0.tgz"
+    },
     "download": {
       "version": "4.4.3",
       "from": "https://registry.npmjs.org/download/-/download-4.4.3.tgz",
@@ -1508,6 +1755,16 @@
       "from": "https://registry.npmjs.org/ejs/-/ejs-2.4.2.tgz",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.4.2.tgz"
     },
+    "element-class": {
+      "version": "0.2.2",
+      "from": "element-class@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/element-class/-/element-class-0.2.2.tgz"
+    },
+    "encodeurl": {
+      "version": "1.0.1",
+      "from": "encodeurl@>=1.0.1 <1.1.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz"
+    },
     "encoding": {
       "version": "0.1.12",
       "from": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
@@ -1522,38 +1779,6 @@
       "version": "1.1.1",
       "from": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
-    },
-    "enzyme": {
-      "version": "2.3.0",
-      "from": "https://registry.npmjs.org/enzyme/-/enzyme-2.3.0.tgz",
-      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-2.3.0.tgz",
-      "dependencies": {
-        "cheerio": {
-          "version": "0.20.0",
-          "from": "https://registry.npmjs.org/cheerio/-/cheerio-0.20.0.tgz",
-          "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.20.0.tgz"
-        },
-        "css-select": {
-          "version": "1.2.0",
-          "from": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz"
-        },
-        "css-what": {
-          "version": "2.1.0",
-          "from": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz"
-        },
-        "domutils": {
-          "version": "1.5.1",
-          "from": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz"
-        },
-        "lodash": {
-          "version": "4.13.1",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
-        }
-      }
     },
     "errno": {
       "version": "0.1.4",
@@ -1581,16 +1806,6 @@
           "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
         }
       }
-    },
-    "es-abstract": {
-      "version": "1.5.1",
-      "from": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.5.1.tgz",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.5.1.tgz"
-    },
-    "es-to-primitive": {
-      "version": "1.1.1",
-      "from": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz"
     },
     "es5-ext": {
       "version": "0.10.11",
@@ -1781,10 +1996,25 @@
       "from": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-1.1.1.tgz"
     },
+    "events": {
+      "version": "1.1.1",
+      "from": "events@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz"
+    },
     "exec-sh": {
       "version": "0.2.0",
       "from": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.0.tgz"
+    },
+    "executable": {
+      "version": "1.1.0",
+      "from": "executable@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/executable/-/executable-1.1.0.tgz"
+    },
+    "exenv": {
+      "version": "1.2.0",
+      "from": "exenv@1.2.0",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.0.tgz"
     },
     "exit-hook": {
       "version": "1.1.1",
@@ -1800,6 +2030,68 @@
       "version": "1.8.2",
       "from": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz"
+    },
+    "express": {
+      "version": "4.14.0",
+      "from": "express@>=4.14.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
+      "dependencies": {
+        "accepts": {
+          "version": "1.3.3",
+          "from": "accepts@>=1.3.3 <1.4.0",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz"
+        },
+        "cookie": {
+          "version": "0.3.1",
+          "from": "cookie@0.3.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
+        },
+        "depd": {
+          "version": "1.1.0",
+          "from": "depd@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
+        },
+        "finalhandler": {
+          "version": "0.5.0",
+          "from": "finalhandler@0.5.0",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz"
+        },
+        "http-errors": {
+          "version": "1.5.0",
+          "from": "http-errors@>=1.5.0 <1.6.0",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz"
+        },
+        "negotiator": {
+          "version": "0.6.1",
+          "from": "negotiator@0.6.1",
+          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
+        },
+        "qs": {
+          "version": "6.2.0",
+          "from": "qs@6.2.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz"
+        },
+        "range-parser": {
+          "version": "1.2.0",
+          "from": "range-parser@>=1.2.0 <1.3.0",
+          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
+        },
+        "send": {
+          "version": "0.14.1",
+          "from": "send@0.14.1",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz"
+        },
+        "serve-static": {
+          "version": "1.11.1",
+          "from": "serve-static@>=1.11.1 <1.12.0",
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz"
+        },
+        "vary": {
+          "version": "1.1.0",
+          "from": "vary@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
+        }
+      }
     },
     "express-session": {
       "version": "1.11.3",
@@ -1915,6 +2207,11 @@
       "from": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
     },
+    "filled-array": {
+      "version": "1.1.0",
+      "from": "filled-array@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/filled-array/-/filled-array-1.1.0.tgz"
+    },
     "finalhandler": {
       "version": "0.4.0",
       "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.0.tgz",
@@ -1939,6 +2236,11 @@
         }
       }
     },
+    "find-versions": {
+      "version": "1.2.1",
+      "from": "find-versions@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-1.2.1.tgz"
+    },
     "findup-sync": {
       "version": "0.2.1",
       "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
@@ -1948,6 +2250,206 @@
           "version": "4.3.5",
           "from": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz"
+        }
+      }
+    },
+    "firebase": {
+      "version": "3.3.0",
+      "from": "firebase@>=3.2.1 <4.0.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-3.3.0.tgz",
+      "dependencies": {
+        "dom-storage": {
+          "version": "2.0.2",
+          "from": "dom-storage@2.0.2",
+          "resolved": "https://registry.npmjs.org/dom-storage/-/dom-storage-2.0.2.tgz"
+        },
+        "faye-websocket": {
+          "version": "0.9.3",
+          "from": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.9.3.tgz",
+          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.9.3.tgz",
+          "dependencies": {
+            "websocket-driver": {
+              "version": "0.6.4",
+              "from": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.4.tgz",
+              "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.4.tgz",
+              "dependencies": {
+                "websocket-extensions": {
+                  "version": "0.1.1",
+                  "from": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "jsonwebtoken": {
+          "version": "5.7.0",
+          "from": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-5.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-5.7.0.tgz",
+          "dependencies": {
+            "jws": {
+              "version": "3.1.3",
+              "from": "https://registry.npmjs.org/jws/-/jws-3.1.3.tgz",
+              "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.3.tgz",
+              "dependencies": {
+                "base64url": {
+                  "version": "1.0.6",
+                  "from": "https://registry.npmjs.org/base64url/-/base64url-1.0.6.tgz",
+                  "resolved": "https://registry.npmjs.org/base64url/-/base64url-1.0.6.tgz",
+                  "dependencies": {
+                    "concat-stream": {
+                      "version": "1.4.10",
+                      "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+                      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+                      "dependencies": {
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "readable-stream": {
+                          "version": "1.1.14",
+                          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.2",
+                              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            }
+                          }
+                        },
+                        "typedarray": {
+                          "version": "0.0.6",
+                          "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                        }
+                      }
+                    },
+                    "meow": {
+                      "version": "2.0.0",
+                      "from": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
+                      "dependencies": {
+                        "camelcase-keys": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                          "dependencies": {
+                            "camelcase": {
+                              "version": "1.2.1",
+                              "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                            },
+                            "map-obj": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "indent-string": {
+                          "version": "1.2.2",
+                          "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+                          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+                          "dependencies": {
+                            "get-stdin": {
+                              "version": "4.0.1",
+                              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                            },
+                            "repeating": {
+                              "version": "1.1.3",
+                              "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                              "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                              "dependencies": {
+                                "is-finite": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                  "dependencies": {
+                                    "number-is-nan": {
+                                      "version": "1.0.0",
+                                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "minimist": {
+                          "version": "1.2.0",
+                          "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                        },
+                        "object-assign": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "jwa": {
+                  "version": "1.1.3",
+                  "from": "https://registry.npmjs.org/jwa/-/jwa-1.1.3.tgz",
+                  "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.3.tgz",
+                  "dependencies": {
+                    "buffer-equal-constant-time": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz"
+                    },
+                    "ecdsa-sig-formatter": {
+                      "version": "1.0.5",
+                      "from": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.5.tgz",
+                      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.5.tgz",
+                      "dependencies": {
+                        "base64-url": {
+                          "version": "1.2.2",
+                          "from": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.2.tgz",
+                          "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "ms": {
+              "version": "0.7.1",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+            },
+            "xtend": {
+              "version": "4.0.1",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+            }
+          }
+        },
+        "rsvp": {
+          "version": "3.2.1",
+          "from": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz"
+        },
+        "xmlhttprequest": {
+          "version": "1.8.0",
+          "from": "xmlhttprequest@1.8.0",
+          "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz"
         }
       }
     },
@@ -1973,6 +2475,11 @@
       "from": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.0.10.tgz",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.0.10.tgz"
     },
+    "flow-bin": {
+      "version": "0.29.0",
+      "from": "flow-bin@0.29.0",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.29.0.tgz"
+    },
     "for-in": {
       "version": "0.1.5",
       "from": "https://registry.npmjs.org/for-in/-/for-in-0.1.5.tgz",
@@ -1982,11 +2489,6 @@
       "version": "0.1.4",
       "from": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz"
-    },
-    "foreach": {
-      "version": "2.0.5",
-      "from": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -2010,6 +2512,11 @@
       "from": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz"
     },
+    "forwarded": {
+      "version": "0.1.0",
+      "from": "forwarded@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
+    },
     "fresh": {
       "version": "0.3.0",
       "from": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
@@ -2030,6 +2537,16 @@
       "from": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
     },
+    "fuse.js": {
+      "version": "2.4.1",
+      "from": "fuse.js@>=2.2.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-2.4.1.tgz"
+    },
+    "fuzzysearch": {
+      "version": "1.0.3",
+      "from": "fuzzysearch@>=1.0.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/fuzzysearch/-/fuzzysearch-1.0.3.tgz"
+    },
     "gauge": {
       "version": "1.2.7",
       "from": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
@@ -2044,6 +2561,11 @@
       "version": "1.2.0",
       "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
+    },
+    "get-caller-file": {
+      "version": "1.0.2",
+      "from": "get-caller-file@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz"
     },
     "get-proxy": {
       "version": "1.1.0",
@@ -2183,6 +2705,11 @@
       "from": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz"
     },
+    "growly": {
+      "version": "1.3.0",
+      "from": "growly@>=1.2.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz"
+    },
     "gruntfile-editor": {
       "version": "1.2.0",
       "from": "https://registry.npmjs.org/gruntfile-editor/-/gruntfile-editor-1.2.0.tgz",
@@ -2246,6 +2773,18 @@
       "from": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz"
     },
+    "handlebars": {
+      "version": "4.0.5",
+      "from": "handlebars@>=4.0.1 <5.0.0",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "from": "async@^1.4.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+        }
+      }
+    },
     "har-validator": {
       "version": "2.0.6",
       "from": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
@@ -2260,6 +2799,11 @@
       "version": "2.0.0",
       "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
+    },
+    "has-flag": {
+      "version": "1.0.0",
+      "from": "has-flag@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
     },
     "has-gulplog": {
       "version": "0.1.0",
@@ -2281,6 +2825,11 @@
       "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
     },
+    "hoist-non-react-statics": {
+      "version": "1.2.0",
+      "from": "hoist-non-react-statics@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz"
+    },
     "home-or-tmp": {
       "version": "1.0.0",
       "from": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
@@ -2290,23 +2839,6 @@
       "version": "2.1.5",
       "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz"
-    },
-    "html": {
-      "version": "0.0.10",
-      "from": "https://registry.npmjs.org/html/-/html-0.0.10.tgz",
-      "resolved": "https://registry.npmjs.org/html/-/html-0.0.10.tgz",
-      "dependencies": {
-        "glob": {
-          "version": "3.2.11",
-          "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz"
-        },
-        "minimatch": {
-          "version": "0.3.0",
-          "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz"
-        }
-      }
     },
     "html-wiring": {
       "version": "1.2.0",
@@ -2335,10 +2867,20 @@
       "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz"
     },
+    "http-proxy-agent": {
+      "version": "1.0.0",
+      "from": "http-proxy-agent@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-1.0.0.tgz"
+    },
     "http-signature": {
       "version": "1.1.1",
       "from": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
+    },
+    "https-proxy-agent": {
+      "version": "1.0.0",
+      "from": "https-proxy-agent@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz"
     },
     "iconv-lite": {
       "version": "0.4.13",
@@ -2404,6 +2946,11 @@
         }
       }
     },
+    "interpret": {
+      "version": "1.0.1",
+      "from": "interpret@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.1.tgz"
+    },
     "invariant": {
       "version": "2.2.1",
       "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
@@ -2413,6 +2960,11 @@
       "version": "1.0.0",
       "from": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+    },
+    "ipaddr.js": {
+      "version": "1.1.1",
+      "from": "ipaddr.js@1.1.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.1.tgz"
     },
     "is-absolute": {
       "version": "0.1.7",
@@ -2439,15 +2991,10 @@
       "from": "https://registry.npmjs.org/is-bzip2/-/is-bzip2-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-bzip2/-/is-bzip2-1.0.0.tgz"
     },
-    "is-callable": {
-      "version": "1.1.3",
-      "from": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz"
-    },
-    "is-date-object": {
-      "version": "1.0.1",
-      "from": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz"
+    "is-dom": {
+      "version": "1.0.5",
+      "from": "is-dom@>=1.0.5 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-dom/-/is-dom-1.0.5.tgz"
     },
     "is-dotfile": {
       "version": "1.0.2",
@@ -2498,6 +3045,11 @@
       "version": "2.1.1",
       "from": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.1.1.tgz",
       "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.1.1.tgz"
+    },
+    "is-npm": {
+      "version": "1.0.0",
+      "from": "is-npm@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz"
     },
     "is-number": {
       "version": "2.1.0",
@@ -2554,11 +3106,6 @@
       "from": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz"
     },
-    "is-regex": {
-      "version": "1.0.3",
-      "from": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.3.tgz",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.3.tgz"
-    },
     "is-relative": {
       "version": "0.1.3",
       "from": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
@@ -2579,16 +3126,6 @@
       "from": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
     },
-    "is-subset": {
-      "version": "0.1.1",
-      "from": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz"
-    },
-    "is-symbol": {
-      "version": "1.0.1",
-      "from": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz"
-    },
     "is-tar": {
       "version": "1.0.0",
       "from": "https://registry.npmjs.org/is-tar/-/is-tar-1.0.0.tgz",
@@ -2598,6 +3135,11 @@
       "version": "1.0.0",
       "from": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+    },
+    "is-unc-path": {
+      "version": "0.1.1",
+      "from": "is-unc-path@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.1.tgz"
     },
     "is-url": {
       "version": "1.2.2",
@@ -2613,6 +3155,11 @@
       "version": "0.3.0",
       "from": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz"
+    },
+    "is-windows": {
+      "version": "0.1.1",
+      "from": "is-windows@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.1.1.tgz"
     },
     "is-zip": {
       "version": "1.0.0",
@@ -2656,6 +3203,67 @@
       "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
     },
+    "istanbul": {
+      "version": "0.4.5",
+      "from": "istanbul@>=0.4.4 <0.5.0",
+      "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "from": "async@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+        },
+        "esprima": {
+          "version": "2.7.3",
+          "from": "esprima@>=2.7.0 <2.8.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
+        },
+        "supports-color": {
+          "version": "3.1.2",
+          "from": "supports-color@>=3.1.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
+        }
+      }
+    },
+    "istanbul-lib-coverage": {
+      "version": "1.0.0",
+      "from": "istanbul-lib-coverage@>=1.0.0-alpha.4 <2.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.0.0.tgz"
+    },
+    "istanbul-lib-instrument": {
+      "version": "1.1.0",
+      "from": "istanbul-lib-instrument@>=1.1.0-alpha.4 <2.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.1.0.tgz",
+      "dependencies": {
+        "babel-generator": {
+          "version": "6.11.4",
+          "from": "babel-generator@^6.11.3",
+          "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.11.4.tgz"
+        },
+        "babel-types": {
+          "version": "6.13.0",
+          "from": "babel-types@^6.10.2",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.13.0.tgz",
+          "dependencies": {
+            "babel-traverse": {
+              "version": "6.13.0",
+              "from": "babel-traverse@^6.13.0",
+              "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.13.0.tgz"
+            }
+          }
+        },
+        "lodash": {
+          "version": "4.15.0",
+          "from": "lodash@^4.2.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz"
+        },
+        "source-map": {
+          "version": "0.5.6",
+          "from": "source-map@^0.5.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+        }
+      }
+    },
     "istextorbinary": {
       "version": "1.0.2",
       "from": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-1.0.2.tgz",
@@ -2677,6 +3285,212 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
         }
       }
+    },
+    "jasmine-check": {
+      "version": "0.1.5",
+      "from": "jasmine-check@>=0.1.4 <0.2.0",
+      "resolved": "https://registry.npmjs.org/jasmine-check/-/jasmine-check-0.1.5.tgz"
+    },
+    "jest": {
+      "version": "14.1.0",
+      "from": "jest@>=14.1.0 <15.0.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-14.1.0.tgz"
+    },
+    "jest-changed-files": {
+      "version": "14.0.0",
+      "from": "jest-changed-files@>=14.0.0 <15.0.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-14.0.0.tgz"
+    },
+    "jest-cli": {
+      "version": "14.1.0",
+      "from": "jest-cli@>=14.1.0 <15.0.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-14.1.0.tgz",
+      "dependencies": {
+        "cliui": {
+          "version": "3.2.0",
+          "from": "cliui@^3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz"
+        },
+        "window-size": {
+          "version": "0.2.0",
+          "from": "window-size@^0.2.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz"
+        },
+        "yargs": {
+          "version": "4.8.1",
+          "from": "yargs@>=4.7.1 <5.0.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz"
+        }
+      }
+    },
+    "jest-config": {
+      "version": "14.1.0",
+      "from": "jest-config@>=14.1.0 <15.0.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-14.1.0.tgz"
+    },
+    "jest-diff": {
+      "version": "14.0.0",
+      "from": "jest-diff@>=14.0.0 <15.0.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-14.0.0.tgz"
+    },
+    "jest-environment-jsdom": {
+      "version": "14.0.0",
+      "from": "jest-environment-jsdom@>=14.0.0 <15.0.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-14.0.0.tgz",
+      "dependencies": {
+        "acorn": {
+          "version": "2.7.0",
+          "from": "acorn@>=2.4.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
+        },
+        "jsdom": {
+          "version": "9.4.2",
+          "from": "jsdom@>=9.4.0 <10.0.0",
+          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.4.2.tgz"
+        },
+        "tough-cookie": {
+          "version": "2.3.1",
+          "from": "tough-cookie@>=2.3.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz"
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "from": "webidl-conversions@>=3.0.1 <4.0.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz"
+        }
+      }
+    },
+    "jest-environment-node": {
+      "version": "14.0.0",
+      "from": "jest-environment-node@>=14.0.0 <15.0.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-14.0.0.tgz"
+    },
+    "jest-file-exists": {
+      "version": "14.0.0",
+      "from": "jest-file-exists@>=14.0.0 <15.0.0",
+      "resolved": "https://registry.npmjs.org/jest-file-exists/-/jest-file-exists-14.0.0.tgz"
+    },
+    "jest-haste-map": {
+      "version": "14.1.0",
+      "from": "jest-haste-map@>=14.1.0 <15.0.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-14.1.0.tgz"
+    },
+    "jest-jasmine2": {
+      "version": "14.0.0",
+      "from": "jest-jasmine2@>=14.0.0 <15.0.0",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-14.0.0.tgz"
+    },
+    "jest-matcher-utils": {
+      "version": "14.0.0",
+      "from": "jest-matcher-utils@>=14.0.0 <15.0.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-14.0.0.tgz"
+    },
+    "jest-matchers": {
+      "version": "14.0.0",
+      "from": "jest-matchers@>=14.0.0 <15.0.0",
+      "resolved": "https://registry.npmjs.org/jest-matchers/-/jest-matchers-14.0.0.tgz"
+    },
+    "jest-mock": {
+      "version": "14.0.0",
+      "from": "jest-mock@>=14.0.0 <15.0.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-14.0.0.tgz"
+    },
+    "jest-react-native": {
+      "version": "14.1.3",
+      "from": "jest-react-native@>=14.1.2 <15.0.0",
+      "resolved": "https://registry.npmjs.org/jest-react-native/-/jest-react-native-14.1.3.tgz"
+    },
+    "jest-resolve": {
+      "version": "14.1.0",
+      "from": "jest-resolve@>=14.1.0 <15.0.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-14.1.0.tgz"
+    },
+    "jest-resolve-dependencies": {
+      "version": "14.1.0",
+      "from": "jest-resolve-dependencies@>=14.1.0 <15.0.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-14.1.0.tgz"
+    },
+    "jest-runtime": {
+      "version": "14.1.0",
+      "from": "jest-runtime@>=14.1.0 <15.0.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-14.1.0.tgz",
+      "dependencies": {
+        "babel-core": {
+          "version": "6.13.2",
+          "from": "babel-core@>=6.11.4 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.13.2.tgz"
+        },
+        "babel-generator": {
+          "version": "6.11.4",
+          "from": "babel-generator@>=6.11.4 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.11.4.tgz"
+        },
+        "babel-jest": {
+          "version": "13.2.2",
+          "from": "babel-jest@13.2.2",
+          "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-13.2.2.tgz"
+        },
+        "babel-plugin-jest-hoist": {
+          "version": "13.2.2",
+          "from": "babel-plugin-jest-hoist@>=13.2.2 <14.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-13.2.2.tgz"
+        },
+        "babel-preset-jest": {
+          "version": "13.2.2",
+          "from": "babel-preset-jest@>=13.2.2 <14.0.0",
+          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-13.2.2.tgz"
+        },
+        "babel-traverse": {
+          "version": "6.13.0",
+          "from": "babel-traverse@>=6.13.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.13.0.tgz"
+        },
+        "babel-types": {
+          "version": "6.13.0",
+          "from": "babel-types@>=6.13.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.13.0.tgz"
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "from": "cliui@>=3.2.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz"
+        },
+        "lodash": {
+          "version": "4.15.0",
+          "from": "lodash@^4.2.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz"
+        },
+        "minimatch": {
+          "version": "3.0.3",
+          "from": "minimatch@^3.0.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
+        },
+        "source-map": {
+          "version": "0.5.6",
+          "from": "source-map@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+        },
+        "window-size": {
+          "version": "0.2.0",
+          "from": "window-size@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz"
+        },
+        "yargs": {
+          "version": "4.8.1",
+          "from": "yargs@^4.7.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz"
+        }
+      }
+    },
+    "jest-snapshot": {
+      "version": "14.0.0",
+      "from": "jest-snapshot@>=14.0.0 <15.0.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-14.0.0.tgz"
+    },
+    "jest-util": {
+      "version": "14.0.0",
+      "from": "jest-util@>=14.0.0 <15.0.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-14.0.0.tgz"
     },
     "jodid25519": {
       "version": "1.0.2",
@@ -2709,18 +3523,6 @@
       "version": "0.1.0",
       "from": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
-    },
-    "jsdom": {
-      "version": "7.2.2",
-      "from": "https://registry.npmjs.org/jsdom/-/jsdom-7.2.2.tgz",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-7.2.2.tgz",
-      "dependencies": {
-        "acorn": {
-          "version": "2.7.0",
-          "from": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
-        }
-      }
     },
     "jsesc": {
       "version": "0.5.0",
@@ -2789,6 +3591,11 @@
         }
       }
     },
+    "keycode": {
+      "version": "2.1.4",
+      "from": "keycode@>=2.1.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.1.4.tgz"
+    },
     "kind-of": {
       "version": "3.0.3",
       "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.3.tgz",
@@ -2799,10 +3606,20 @@
       "from": "klaw@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.0.tgz"
     },
+    "latest-version": {
+      "version": "2.0.0",
+      "from": "latest-version@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-2.0.0.tgz"
+    },
     "lazy-cache": {
       "version": "1.0.4",
       "from": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
+    },
+    "lazy-req": {
+      "version": "1.1.0",
+      "from": "lazy-req@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/lazy-req/-/lazy-req-1.1.0.tgz"
     },
     "lazystream": {
       "version": "1.0.0",
@@ -2831,20 +3648,60 @@
       "from": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz"
     },
+    "listify": {
+      "version": "1.0.0",
+      "from": "listify@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/listify/-/listify-1.0.0.tgz"
+    },
     "load-json-file": {
       "version": "1.1.0",
       "from": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz"
+    },
+    "lockfile": {
+      "version": "1.0.1",
+      "from": "lockfile@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.1.tgz"
     },
     "lodash": {
       "version": "3.10.1",
       "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
     },
+    "lodash-es": {
+      "version": "4.15.0",
+      "from": "lodash-es@>=4.2.1 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.15.0.tgz"
+    },
+    "lodash._arraycopy": {
+      "version": "3.0.0",
+      "from": "lodash._arraycopy@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
+    },
+    "lodash._arrayeach": {
+      "version": "3.0.0",
+      "from": "lodash._arrayeach@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz"
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "from": "lodash._baseassign@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz"
+    },
+    "lodash._baseclone": {
+      "version": "3.3.0",
+      "from": "lodash._baseclone@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz"
+    },
     "lodash._basecopy": {
       "version": "3.0.1",
       "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+    },
+    "lodash._basefor": {
+      "version": "3.0.3",
+      "from": "lodash._basefor@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz"
     },
     "lodash._baseiteratee": {
       "version": "4.7.0",
@@ -2865,6 +3722,16 @@
       "version": "3.0.0",
       "from": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+    },
+    "lodash._bindcallback": {
+      "version": "3.0.1",
+      "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+    },
+    "lodash._createassigner": {
+      "version": "3.1.1",
+      "from": "lodash._createassigner@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz"
     },
     "lodash._getnative": {
       "version": "3.9.1",
@@ -2919,6 +3786,11 @@
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.0.7.tgz"
         }
       }
+    },
+    "lodash.clonedeep": {
+      "version": "3.0.2",
+      "from": "lodash.clonedeep@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz"
     },
     "lodash.escape": {
       "version": "3.2.0",
@@ -2993,6 +3865,11 @@
         }
       }
     },
+    "lodash.pick": {
+      "version": "4.4.0",
+      "from": "lodash.pick@>=4.2.1 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz"
+    },
     "lodash.pickby": {
       "version": "4.4.0",
       "from": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.4.0.tgz",
@@ -3028,6 +3905,11 @@
       "from": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz"
     },
+    "logalot": {
+      "version": "2.1.0",
+      "from": "logalot@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/logalot/-/logalot-2.1.0.tgz"
+    },
     "lolex": {
       "version": "1.3.2",
       "from": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
@@ -3053,20 +3935,62 @@
       "from": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
     },
+    "lpad": {
+      "version": "2.0.1",
+      "from": "lpad@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/lpad/-/lpad-2.0.1.tgz"
+    },
+    "lpad-align": {
+      "version": "1.1.0",
+      "from": "lpad-align@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/lpad-align/-/lpad-align-1.1.0.tgz"
+    },
     "lru-cache": {
       "version": "2.7.3",
       "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+    },
+    "make-error": {
+      "version": "1.2.0",
+      "from": "make-error@>=1.2.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.2.0.tgz"
+    },
+    "make-error-cause": {
+      "version": "1.2.1",
+      "from": "make-error-cause@>=1.2.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/make-error-cause/-/make-error-cause-1.2.1.tgz"
     },
     "makeerror": {
       "version": "1.0.11",
       "from": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz"
     },
+    "mantra-core": {
+      "version": "1.7.0",
+      "from": "mantra-core@>=1.6.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/mantra-core/-/mantra-core-1.7.0.tgz"
+    },
     "map-obj": {
       "version": "1.0.1",
       "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+    },
+    "marked": {
+      "version": "0.3.6",
+      "from": "marked@>=0.3.2 <0.4.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz"
+    },
+    "marked-terminal": {
+      "version": "1.6.1",
+      "from": "marked-terminal@>=1.6.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-1.6.1.tgz",
+      "dependencies": {
+        "lodash.assign": {
+          "version": "3.2.0",
+          "from": "lodash.assign@^3.0.0",
+          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz"
+        }
+      }
     },
     "media-typer": {
       "version": "0.3.0",
@@ -3116,6 +4040,11 @@
       "version": "1.2.0",
       "from": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "from": "merge-descriptors@1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
     },
     "merge-stream": {
       "version": "1.0.0",
@@ -3197,6 +4126,11 @@
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
         }
       }
+    },
+    "mobx": {
+      "version": "2.4.4",
+      "from": "mobx@>=2.3.4 <3.0.0",
+      "resolved": "https://registry.npmjs.org/mobx/-/mobx-2.4.4.tgz"
     },
     "mocha": {
       "version": "2.5.3",
@@ -3294,6 +4228,11 @@
       "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
     },
+    "node-emoji": {
+      "version": "0.1.0",
+      "from": "node-emoji@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-0.1.0.tgz"
+    },
     "node-fetch": {
       "version": "1.5.3",
       "from": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.5.3.tgz",
@@ -3308,6 +4247,11 @@
       "version": "0.4.0",
       "from": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz"
+    },
+    "node-notifier": {
+      "version": "4.6.1",
+      "from": "node-notifier@>=4.6.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-4.6.1.tgz"
     },
     "node-status-codes": {
       "version": "1.0.0",
@@ -3364,30 +4308,15 @@
       "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
     },
-    "object-is": {
-      "version": "1.0.1",
-      "from": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz"
-    },
-    "object-keys": {
-      "version": "1.0.9",
-      "from": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.9.tgz",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.9.tgz"
-    },
-    "object.assign": {
-      "version": "4.0.3",
-      "from": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.3.tgz",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.3.tgz"
-    },
     "object.omit": {
       "version": "2.0.0",
       "from": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz"
     },
-    "object.values": {
-      "version": "1.0.3",
-      "from": "https://registry.npmjs.org/object.values/-/object.values-1.0.3.tgz",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.0.3.tgz"
+    "object.pick": {
+      "version": "1.1.2",
+      "from": "object.pick@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.1.2.tgz"
     },
     "on-finished": {
       "version": "2.3.0",
@@ -3458,6 +4387,11 @@
         }
       }
     },
+    "os-filter-obj": {
+      "version": "1.0.3",
+      "from": "os-filter-obj@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/os-filter-obj/-/os-filter-obj-1.0.3.tgz"
+    },
     "os-homedir": {
       "version": "1.0.1",
       "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
@@ -3477,6 +4411,16 @@
       "version": "1.0.1",
       "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+    },
+    "osenv": {
+      "version": "0.1.3",
+      "from": "osenv@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz"
+    },
+    "package-json": {
+      "version": "2.3.3",
+      "from": "package-json@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-2.3.3.tgz"
     },
     "parents": {
       "version": "1.0.1",
@@ -3523,6 +4467,11 @@
       "from": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
       "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz"
     },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "from": "path-to-regexp@0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
+    },
     "path-type": {
       "version": "1.1.0",
       "from": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
@@ -3568,6 +4517,58 @@
       "from": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz"
     },
+    "popsicle": {
+      "version": "8.0.4",
+      "from": "popsicle@>=8.0.2 <9.0.0",
+      "resolved": "https://registry.npmjs.org/popsicle/-/popsicle-8.0.4.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "from": "async@>=0.9.0 <0.10.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+        },
+        "combined-stream": {
+          "version": "0.0.7",
+          "from": "combined-stream@>=0.0.4 <0.1.0",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz"
+        },
+        "delayed-stream": {
+          "version": "0.0.5",
+          "from": "delayed-stream@0.0.5",
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+        },
+        "form-data": {
+          "version": "0.2.0",
+          "from": "form-data@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz"
+        },
+        "mime-db": {
+          "version": "1.12.0",
+          "from": "mime-db@>=1.12.0 <1.13.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
+        },
+        "mime-types": {
+          "version": "2.0.14",
+          "from": "mime-types@>=2.0.3 <2.1.0",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz"
+        }
+      }
+    },
+    "popsicle-proxy-agent": {
+      "version": "3.0.0",
+      "from": "popsicle-proxy-agent@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/popsicle-proxy-agent/-/popsicle-proxy-agent-3.0.0.tgz"
+    },
+    "popsicle-retry": {
+      "version": "3.2.1",
+      "from": "popsicle-retry@>=3.2.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/popsicle-retry/-/popsicle-retry-3.2.1.tgz"
+    },
+    "popsicle-status": {
+      "version": "2.0.0",
+      "from": "popsicle-status@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/popsicle-status/-/popsicle-status-2.0.0.tgz"
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -3587,6 +4588,11 @@
       "version": "2.0.1",
       "from": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-2.0.1.tgz"
+    },
+    "pretty-format": {
+      "version": "3.6.0",
+      "from": "pretty-format@>=3.5.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.6.0.tgz"
     },
     "private": {
       "version": "0.1.6",
@@ -3613,6 +4619,16 @@
       "from": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz"
     },
+    "promise-finally": {
+      "version": "2.2.1",
+      "from": "promise-finally@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/promise-finally/-/promise-finally-2.2.1.tgz"
+    },
+    "proxy-addr": {
+      "version": "1.1.2",
+      "from": "proxy-addr@>=1.1.2 <1.2.0",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz"
+    },
     "prr": {
       "version": "0.0.0",
       "from": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
@@ -3628,10 +4644,25 @@
       "from": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
       "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
     },
+    "qr.js": {
+      "version": "0.0.0",
+      "from": "qr.js@0.0.0",
+      "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz"
+    },
+    "qrcode.react": {
+      "version": "0.6.1",
+      "from": "qrcode.react@>=0.6.1 <0.7.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-0.6.1.tgz"
+    },
     "qs": {
       "version": "4.0.0",
       "from": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
       "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
+    },
+    "querystringify": {
+      "version": "0.0.4",
+      "from": "querystringify@>=0.0.0 <0.1.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz"
     },
     "random-bytes": {
       "version": "1.0.0",
@@ -3670,11 +4701,6 @@
       "from": "react@>=15.2.0 <15.3.0",
       "resolved": "https://registry.npmjs.org/react/-/react-15.2.0.tgz"
     },
-    "react-addons-test-utils": {
-      "version": "15.1.0",
-      "from": "https://registry.npmjs.org/react-addons-test-utils/-/react-addons-test-utils-15.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/react-addons-test-utils/-/react-addons-test-utils-15.1.0.tgz"
-    },
     "react-clone-referenced-element": {
       "version": "1.0.1",
       "from": "https://registry.npmjs.org/react-clone-referenced-element/-/react-clone-referenced-element-1.0.1.tgz",
@@ -3689,6 +4715,33 @@
       "version": "15.1.0",
       "from": "https://registry.npmjs.org/react-dom/-/react-dom-15.1.0.tgz",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.1.0.tgz"
+    },
+    "react-fuzzy": {
+      "version": "0.2.3",
+      "from": "react-fuzzy@>=0.2.3 <0.3.0",
+      "resolved": "https://registry.npmjs.org/react-fuzzy/-/react-fuzzy-0.2.3.tgz"
+    },
+    "react-inspector": {
+      "version": "1.1.0",
+      "from": "react-inspector@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-1.1.0.tgz"
+    },
+    "react-komposer": {
+      "version": "1.13.1",
+      "from": "react-komposer@>=1.9.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/react-komposer/-/react-komposer-1.13.1.tgz"
+    },
+    "react-modal": {
+      "version": "1.4.0",
+      "from": "react-modal@>=1.2.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-1.4.0.tgz",
+      "dependencies": {
+        "lodash.assign": {
+          "version": "3.2.0",
+          "from": "lodash.assign@>=3.2.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz"
+        }
+      }
     },
     "react-native": {
       "version": "0.30.0",
@@ -3785,6 +4838,11 @@
       "from": "https://github.com/alloy/relay/releases/download/v0.9.2/react-relay-0.9.2.tgz",
       "resolved": "https://github.com/alloy/relay/releases/download/v0.9.2/react-relay-0.9.2.tgz"
     },
+    "react-simple-di": {
+      "version": "1.2.0",
+      "from": "react-simple-di@>=1.2.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/react-simple-di/-/react-simple-di-1.2.0.tgz"
+    },
     "react-static-container": {
       "version": "1.0.1",
       "from": "https://registry.npmjs.org/react-static-container/-/react-static-container-1.0.1.tgz",
@@ -3794,6 +4852,11 @@
       "version": "1.0.0",
       "from": "react-storybooks-relay-container@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/react-storybooks-relay-container/-/react-storybooks-relay-container-1.0.0.tgz"
+    },
+    "react-test-renderer": {
+      "version": "15.3.1",
+      "from": "react-test-renderer@>=15.3.0 <16.0.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-15.3.1.tgz"
     },
     "react-timer-mixin": {
       "version": "0.13.3",
@@ -3874,10 +4937,39 @@
         }
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "from": "rechoir@>=0.6.2 <0.7.0",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz"
+    },
     "redent": {
       "version": "1.0.0",
       "from": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz"
+    },
+    "redeyed": {
+      "version": "0.5.0",
+      "from": "redeyed@>=0.5.0 <0.6.0",
+      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.5.0.tgz",
+      "dependencies": {
+        "esprima-fb": {
+          "version": "12001.1.0-dev-harmony-fb",
+          "from": "esprima-fb@>=12001.1.0-dev-harmony-fb <12001.2.0",
+          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-12001.1.0-dev-harmony-fb.tgz"
+        }
+      }
+    },
+    "redux": {
+      "version": "3.5.2",
+      "from": "redux@>=3.5.2 <4.0.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-3.5.2.tgz",
+      "dependencies": {
+        "lodash": {
+          "version": "4.15.0",
+          "from": "lodash@>=4.2.1 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz"
+        }
+      }
     },
     "regenerate": {
       "version": "1.3.1",
@@ -3898,6 +4990,11 @@
       "version": "2.0.0",
       "from": "regexpu-core@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz"
+    },
+    "registry-url": {
+      "version": "3.1.0",
+      "from": "registry-url@>=3.0.3 <4.0.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz"
     },
     "regjsgen": {
       "version": "0.2.0",
@@ -3946,10 +5043,25 @@
         }
       }
     },
+    "require-directory": {
+      "version": "2.1.1",
+      "from": "require-directory@>=2.1.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
+    },
+    "require-main-filename": {
+      "version": "1.0.1",
+      "from": "require-main-filename@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz"
+    },
     "require-uncached": {
       "version": "1.0.2",
       "from": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.2.tgz"
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "from": "requires-port@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
     },
     "resolve": {
       "version": "1.1.7",
@@ -4047,6 +5159,28 @@
       "from": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
     },
+    "semver-diff": {
+      "version": "2.1.0",
+      "from": "semver-diff@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz"
+    },
+    "semver-regex": {
+      "version": "1.0.0",
+      "from": "semver-regex@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-1.0.0.tgz"
+    },
+    "semver-truncate": {
+      "version": "1.1.2",
+      "from": "semver-truncate@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/semver-truncate/-/semver-truncate-1.1.2.tgz",
+      "dependencies": {
+        "semver": {
+          "version": "5.3.0",
+          "from": "semver@>=5.3.0 <6.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
+        }
+      }
+    },
     "send": {
       "version": "0.13.2",
       "from": "https://registry.npmjs.org/send/-/send-0.13.2.tgz",
@@ -4079,10 +5213,25 @@
       "from": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.3.tgz",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.3.tgz"
     },
+    "set-blocking": {
+      "version": "2.0.0",
+      "from": "set-blocking@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
+    },
     "set-immediate-shim": {
       "version": "1.0.1",
       "from": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
+    },
+    "setprototypeof": {
+      "version": "1.0.1",
+      "from": "setprototypeof@1.0.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz"
+    },
+    "shallowequal": {
+      "version": "0.2.2",
+      "from": "shallowequal@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-0.2.2.tgz"
     },
     "shebang-regex": {
       "version": "1.0.0",
@@ -4093,6 +5242,11 @@
       "version": "0.5.3",
       "from": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz"
+    },
+    "shellwords": {
+      "version": "0.1.0",
+      "from": "shellwords@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.0.tgz"
     },
     "sigmund": {
       "version": "1.0.1",
@@ -4124,10 +5278,20 @@
       "from": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz"
     },
+    "slide": {
+      "version": "1.1.6",
+      "from": "slide@>=1.1.5 <2.0.0",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
+    },
     "sntp": {
       "version": "1.0.9",
       "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+    },
+    "sort-keys": {
+      "version": "1.1.2",
+      "from": "sort-keys@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz"
     },
     "source-map": {
       "version": "0.4.4",
@@ -4180,6 +5344,11 @@
       "version": "1.0.3",
       "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+    },
+    "squeak": {
+      "version": "1.3.0",
+      "from": "squeak@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/squeak/-/squeak-1.3.0.tgz"
     },
     "sshpk": {
       "version": "1.8.3",
@@ -4250,6 +5419,11 @@
       "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
     },
+    "string-template": {
+      "version": "1.0.0",
+      "from": "string-template@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/string-template/-/string-template-1.0.0.tgz"
+    },
     "string-width": {
       "version": "1.0.1",
       "from": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
@@ -4310,6 +5484,11 @@
       "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
     },
+    "symbol-observable": {
+      "version": "0.2.4",
+      "from": "symbol-observable@>=0.2.3 <0.3.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-0.2.4.tgz"
+    },
     "symbol-tree": {
       "version": "3.1.4",
       "from": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.1.4.tgz",
@@ -4361,6 +5540,16 @@
         }
       }
     },
+    "test-exclude": {
+      "version": "1.1.0",
+      "from": "test-exclude@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-1.1.0.tgz"
+    },
+    "testcheck": {
+      "version": "0.1.4",
+      "from": "testcheck@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/testcheck/-/testcheck-0.1.4.tgz"
+    },
     "text-table": {
       "version": "0.2.0",
       "from": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -4370,6 +5559,16 @@
       "version": "1.0.2",
       "from": "https://registry.npmjs.org/textextensions/-/textextensions-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-1.0.2.tgz"
+    },
+    "thenify": {
+      "version": "3.2.0",
+      "from": "thenify@>=3.1.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.2.0.tgz"
+    },
+    "throat": {
+      "version": "3.0.0",
+      "from": "throat@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/throat/-/throat-3.0.0.tgz"
     },
     "through": {
       "version": "2.3.8",
@@ -4397,6 +5596,11 @@
       "version": "2.0.0",
       "from": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz"
+    },
+    "throwback": {
+      "version": "1.1.1",
+      "from": "throwback@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/throwback/-/throwback-1.1.1.tgz"
     },
     "time-stamp": {
       "version": "1.0.1",
@@ -4432,6 +5636,18 @@
       "version": "1.1.0",
       "from": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz"
+    },
+    "touch": {
+      "version": "1.0.0",
+      "from": "touch@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-1.0.0.tgz",
+      "dependencies": {
+        "nopt": {
+          "version": "1.0.10",
+          "from": "nopt@>=1.0.10 <1.1.0",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz"
+        }
+      }
     },
     "tough-cookie": {
       "version": "2.2.2",
@@ -4488,11 +5704,6 @@
       "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
     },
-    "type-detect": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz"
-    },
     "type-is": {
       "version": "1.6.13",
       "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
@@ -4502,6 +5713,43 @@
       "version": "0.0.6",
       "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+    },
+    "typescript": {
+      "version": "1.8.7",
+      "from": "typescript@1.8.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-1.8.7.tgz"
+    },
+    "typings": {
+      "version": "1.3.2",
+      "from": "typings@>=1.3.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/typings/-/typings-1.3.2.tgz"
+    },
+    "typings-core": {
+      "version": "1.4.1",
+      "from": "typings-core@>=1.4.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/typings-core/-/typings-core-1.4.1.tgz",
+      "dependencies": {
+        "detect-indent": {
+          "version": "4.0.0",
+          "from": "detect-indent@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz"
+        },
+        "is-absolute": {
+          "version": "0.2.5",
+          "from": "is-absolute@>=0.2.3 <0.3.0",
+          "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.5.tgz"
+        },
+        "is-relative": {
+          "version": "0.2.1",
+          "from": "is-relative@>=0.2.1 <0.3.0",
+          "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz"
+        },
+        "repeating": {
+          "version": "2.0.1",
+          "from": "repeating@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
+        }
+      }
     },
     "ua-parser-js": {
       "version": "0.7.10",
@@ -4545,6 +5793,11 @@
       "from": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
     },
+    "unc-path-regex": {
+      "version": "0.1.2",
+      "from": "unc-path-regex@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz"
+    },
     "underscore.string": {
       "version": "3.3.4",
       "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
@@ -4569,6 +5822,16 @@
       "version": "1.0.0",
       "from": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.0.tgz"
+    },
+    "update-notifier": {
+      "version": "1.0.2",
+      "from": "update-notifier@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-1.0.2.tgz"
+    },
+    "url-parse": {
+      "version": "1.1.3",
+      "from": "url-parse@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.3.tgz"
     },
     "url-parse-lax": {
       "version": "1.0.0",
@@ -4706,25 +5969,42 @@
       "from": "https://registry.npmjs.org/watch/-/watch-0.10.0.tgz",
       "resolved": "https://registry.npmjs.org/watch/-/watch-0.10.0.tgz"
     },
-    "webidl-conversions": {
-      "version": "2.0.1",
-      "from": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-2.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-2.0.1.tgz"
+    "wcwidth": {
+      "version": "1.0.1",
+      "from": "wcwidth@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz"
     },
     "whatwg-fetch": {
       "version": "1.0.0",
       "from": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-1.0.0.tgz"
     },
-    "whatwg-url-compat": {
-      "version": "0.6.5",
-      "from": "https://registry.npmjs.org/whatwg-url-compat/-/whatwg-url-compat-0.6.5.tgz",
-      "resolved": "https://registry.npmjs.org/whatwg-url-compat/-/whatwg-url-compat-0.6.5.tgz"
+    "whatwg-url": {
+      "version": "3.0.0",
+      "from": "whatwg-url@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-3.0.0.tgz",
+      "dependencies": {
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "from": "webidl-conversions@^3.0.0",
+          "resolved": "http://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz"
+        }
+      }
     },
     "which": {
       "version": "1.2.10",
       "from": "https://registry.npmjs.org/which/-/which-1.2.10.tgz",
       "resolved": "https://registry.npmjs.org/which/-/which-1.2.10.tgz"
+    },
+    "which-module": {
+      "version": "1.0.0",
+      "from": "which-module@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz"
+    },
+    "widest-line": {
+      "version": "1.0.0",
+      "from": "widest-line@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz"
     },
     "window-size": {
       "version": "0.1.0",
@@ -4760,6 +6040,11 @@
       "version": "0.2.1",
       "from": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz"
+    },
+    "write-file-atomic": {
+      "version": "1.2.0",
+      "from": "write-file-atomic@>=1.1.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.2.0.tgz"
     },
     "ws": {
       "version": "1.1.1",
@@ -4830,6 +6115,18 @@
           "version": "0.1.4",
           "from": "window-size@>=0.1.4 <0.2.0",
           "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "2.4.1",
+      "from": "yargs-parser@>=2.4.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
+      "dependencies": {
+        "camelcase": {
+          "version": "3.0.0",
+          "from": "camelcase@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
         }
       }
     },
@@ -4938,6 +6235,11 @@
       "version": "1.0.1",
       "from": "https://registry.npmjs.org/yeoman-welcome/-/yeoman-welcome-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/yeoman-welcome/-/yeoman-welcome-1.0.1.tgz"
+    },
+    "zip-object": {
+      "version": "0.1.0",
+      "from": "zip-object@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/zip-object/-/zip-object-0.1.0.tgz"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "babel-polyfill": "^6.13.0",
     "babel-preset-react-native": "^1.9.0",
     "babel-relay-plugin": "^0.9.0",
+    "concurrently": "^2.2.0",
     "eslint": "^2.5.3",
     "eslint-plugin-flow-vars": "^0.2.1",
     "eslint-plugin-flowtype": "^2.3.1",


### PR DESCRIPTION
Ok, so, our shrinkwrap was out-of-date (still contained removed test packages) and we were missing the `concurrently` package.

Two of our dependencies (`react-native`storybook` and `react-test-renderer`) have version requirements on common dependencies that are unsatisfiable, which means that [npm will not shrinkwrap](https://github.com/npm/npm/issues/10836). However, they work fine at runtime with our current versions.

After going down the rabbit hole for a while, I settled on fixing it by hand-editing the `package.json` files of these two dependencies to bump the version requirements that were troublesome such that they would satisfy. After that I was able to shrinkwrap again, of which this is the result.

I suspect that there will be similar issues in the future when trying to shrinkwrap, because your `package.json` files will be re-installed with their original version requirements. We should then:

* either see if we can actually fix the issue by updating some dependencies
* re-edit the files to satisfy the requirements