### PR TITLE
[Config] Add `useStagingEnvironment` option.

### DIFF
--- a/Example/Emission/AppDelegate.m
+++ b/Example/Emission/AppDelegate.m
@@ -19,13 +19,27 @@
 #import <Extraction/ARSpinner.h>
 #import <SAMKeychain/SAMKeychain.h>
 
+// The slug of the artist to show as the root artist from the component selection list.
+//
 #define ARTIST @"alex-katz"
 
-#if TARGET_OS_SIMULATOR
+// Disable this to force using the release JS bundle, note that you should really do so by running a Release build.
+//
+// To do this, hold down the alt key when clicking the run button and select the Release configuration. Remember to
+// change this back afterwards.
+//
+#if TARGET_OS_SIMULATOR && defined(DEBUG)
 #define ENABLE_DEV_MODE
 #endif
 
+// * Disable all of this to use the production env in a Debug build
+// * or just the ENABLE_DEV_MODE check to use staging in a Release build
+//
 #ifdef ENABLE_DEV_MODE
+#define USE_STAGING_ENV
+#endif
+
+#ifdef USE_STAGING_ENV
 #define KEYCHAIN_SERVICE @"Emission-Staging"
 #else
 #define KEYCHAIN_SERVICE @"Emission-Production"
@@ -109,7 +123,7 @@ randomBOOL(void)
   // These are of Eigen OSS: https://github.com/artsy/eigen/blob/0e193d1b/Makefile#L36-L37
   ArtsyAuthentication *auth = [[ArtsyAuthentication alloc] initWithClientID:@"e750db60ac506978fc70"
                                                                clientSecret:@"3a33d2085cbd1176153f99781bbce7c6"];
-#ifdef ENABLE_DEV_MODE
+#ifdef USE_STAGING_ENV
   auth.router.staging = YES;
 #endif
 
@@ -150,8 +164,16 @@ randomBOOL(void)
   AREmission *emission = nil;
 
 #ifdef ENABLE_DEV_MODE
+#ifdef USE_STAGING_ENV
+  BOOL staging = YES;
+#else
+  BOOL staging = NO;
+#endif
   NSURL *packagerURL = [NSURL URLWithString:@"http://localhost:8081/Example/Emission/index.ios.bundle?platform=ios&dev=true"];
-  emission = [[AREmission alloc] initWithUserID:userID authenticationToken:accessToken packagerURL:packagerURL];
+  emission = [[AREmission alloc] initWithUserID:userID
+                            authenticationToken:accessToken
+                                    packagerURL:packagerURL
+                          useStagingEnvironment:staging];
 #else
   emission = [[AREmission alloc] initWithUserID:userID authenticationToken:accessToken];
 #endif

--- a/Pod/Classes/Core/AREmission.h
+++ b/Pod/Classes/Core/AREmission.h
@@ -16,9 +16,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithUserID:(NSString *)userID
            authenticationToken:(NSString *)authenticationToken;
+
 - (instancetype)initWithUserID:(NSString *)userID
            authenticationToken:(NSString *)authenticationToken
-                   packagerURL:(nullable NSURL *)packagerURL NS_DESIGNATED_INITIALIZER;
+                   packagerURL:(nullable NSURL *)packagerURL
+         useStagingEnvironment:(BOOL)useStagingEnvironment NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/Pod/Classes/Core/AREmission.m
+++ b/Pod/Classes/Core/AREmission.m
@@ -10,6 +10,7 @@
 @interface AREmissionConfiguration : NSObject <RCTBridgeModule>
 @property (nonatomic, strong, readwrite) NSString *userID;
 @property (nonatomic, strong, readwrite) NSString *authenticationToken;
+@property (nonatomic, assign, readwrite) BOOL useStagingEnvironment;
 @end
 
 @implementation AREmissionConfiguration
@@ -21,6 +22,7 @@ RCT_EXPORT_MODULE(Emission);
   return @{
     @"userID": self.userID,
     @"authenticationToken": self.authenticationToken,
+    @"useStagingEnvironment": @(self.useStagingEnvironment),
   };
 }
 
@@ -49,12 +51,16 @@ static AREmission *_sharedInstance = nil;
 - (instancetype)initWithUserID:(NSString *)userID
            authenticationToken:(NSString *)authenticationToken;
 {
-  return [self initWithUserID:userID authenticationToken:authenticationToken packagerURL:nil];
+  return [self initWithUserID:userID
+          authenticationToken:authenticationToken
+                  packagerURL:nil
+        useStagingEnvironment:NO];
 }
 
 - (instancetype)initWithUserID:(NSString *)userID
            authenticationToken:(NSString *)authenticationToken
-                   packagerURL:(nullable NSURL *)packagerURL;
+                   packagerURL:(nullable NSURL *)packagerURL
+         useStagingEnvironment:(BOOL)useStagingEnvironment;
 {
   if ((self = [super init])) {
     _eventsModule = [AREventsModule new];
@@ -64,6 +70,7 @@ static AREmission *_sharedInstance = nil;
     _configurationModule = [AREmissionConfiguration new];
     _configurationModule.userID = userID;
     _configurationModule.authenticationToken = authenticationToken;
+    _configurationModule.useStagingEnvironment = useStagingEnvironment;
 
     NSArray *modules = @[_APIModule, _configurationModule, _eventsModule, _switchBoardModule];
 

--- a/lib/relay/config.js
+++ b/lib/relay/config.js
@@ -6,7 +6,7 @@ import { NativeModules } from 'react-native'
 const { Emission } = NativeModules
 
 let metaphysicsURL
-if (__DEV__) {
+if (Emission.useStagingEnvironment) {
   metaphysicsURL = 'https://metaphysics-staging.artsy.net'
 } else {
   metaphysicsURL = 'https://metaphysics-production.artsy.net'


### PR DESCRIPTION
This PR separates the ‘debug’ and ‘use staging/production’ configuration so that it’s possible to e.g. run a debug build using production.