### PR TITLE
[Home] First go at pull-to-refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Master
 
-  Added a default minimum height for all rails - maxim
+- Added pull-to-refresh functionality to home view - sarah
+- Added a default minimum height for all rails - maxim
 - Added a pretty load failure view and allow for retrying - alloy
 - Added a section header for all Home rails - sarah
 - Added an Artworks rail to Home view - sarah

--- a/lib/components/artwork_grids/generic_grid.js
+++ b/lib/components/artwork_grids/generic_grid.js
@@ -31,6 +31,10 @@ class GenericArtworksGrid extends React.Component {
     this.onLayout = this.onLayout.bind(this)
   }
 
+  componentWillReceiveProps(nextProps) {
+    this.setState({ artworks: nextProps.artworks })
+  }
+
   onLayout = (event: SyntheticEvent) => {
     const layout = event.nativeEvent.layout
     if (layout.width > 0) {
@@ -129,8 +133,6 @@ const styles = StyleSheet.create({
 })
 
 const GenericArtworksGridContainer = Relay.createContainer(GenericArtworksGrid, {
-  shouldComponentUpdate: () => true,
-
   fragments: {
     artworks: () => Relay.QL`
       fragment on Artwork @relay(plural: true) {

--- a/lib/components/artwork_grids/generic_grid.js
+++ b/lib/components/artwork_grids/generic_grid.js
@@ -9,7 +9,7 @@ import Artwork from './artwork'
 import Spinner from '../spinner'
 
 class GenericArtworksGrid extends React.Component {
-    state: {
+  state: {
     sectionDimension: number,
     artworks: [Object];
   };
@@ -129,6 +129,8 @@ const styles = StyleSheet.create({
 })
 
 const GenericArtworksGridContainer = Relay.createContainer(GenericArtworksGrid, {
+  shouldComponentUpdate: () => true,
+
   fragments: {
     artworks: () => Relay.QL`
       fragment on Artwork @relay(plural: true) {

--- a/lib/components/home/artwork_rails/artwork_rail.js
+++ b/lib/components/home/artwork_rails/artwork_rail.js
@@ -148,9 +148,6 @@ class ArtworkRail extends React.Component {
           { this.renderExpansionButton() }
         </View>
       )
-    } else if (this.props.rail.results) {
-      // temporary; for those pesky empty rails on staging
-      return null
     } else {
       return <Spinner style={{ flex: 1 }} />
     }
@@ -205,6 +202,8 @@ const styles = StyleSheet.create({
 })
 
 export default Relay.createContainer(ArtworkRail, {
+  shouldComponentUpdate: () => true,
+
   initialVariables: {
     fetchContent: false,
   },

--- a/lib/components/home/artwork_rails/artwork_rail.js
+++ b/lib/components/home/artwork_rails/artwork_rail.js
@@ -202,8 +202,6 @@ const styles = StyleSheet.create({
 })
 
 export default Relay.createContainer(ArtworkRail, {
-  shouldComponentUpdate: () => true,
-
   initialVariables: {
     fetchContent: false,
   },

--- a/lib/components/home/artwork_rails/artwork_rail_header.js
+++ b/lib/components/home/artwork_rails/artwork_rail_header.js
@@ -46,6 +46,7 @@ class ArtworkRailHeader extends React.Component {
   }
 
   render() {
+    console.log(this.props.rail.title)
     return (
       <TouchableWithoutFeedback onPress={this.handleViewAll}>
         <View style={styles.container}>

--- a/lib/components/home/artwork_rails/artwork_rail_header.js
+++ b/lib/components/home/artwork_rails/artwork_rail_header.js
@@ -46,7 +46,6 @@ class ArtworkRailHeader extends React.Component {
   }
 
   render() {
-    console.log(this.props.rail.title)
     return (
       <TouchableWithoutFeedback onPress={this.handleViewAll}>
         <View style={styles.container}>

--- a/lib/containers/home.js
+++ b/lib/containers/home.js
@@ -3,7 +3,7 @@
 
 import Relay from 'react-relay'
 import React from 'react'
-import { ScrollView, Text, TouchableHighlight, RefreshControl } from 'react-native'
+import { ScrollView, RefreshControl } from 'react-native'
 
 import ArtworkRail from '../components/home/artwork_rails/artwork_rail'
 import ArtistRail from '../components/home/artist_rails/artist_rail'
@@ -13,20 +13,30 @@ class Home extends React.Component {
     super()
     this.state = {
       isRefreshing: false,
+      modules: [],
     }
   }
+
+  registerModule(module) {
+    if (module) {
+      this.state.modules.push(module)
+    }
+  }
+
   render() {
+    this.state.modules = []
+
     const modules = []
     const artwork_modules = this.props.home.artwork_modules
     const artist_modules = this.props.home.artist_modules.concat() // create a copy
     for (let i = 0; i < artwork_modules.length; i++) {
       const artwork_module = artwork_modules[i]
-      modules.push(<ArtworkRail key={artwork_module.__id} rail={artwork_module} />)
+      modules.push(<ArtworkRail ref={this.registerModule.bind(this)} key={artwork_module.__id} rail={artwork_module} />)
       // For now, show an artist rail after each 2 artwork rails, until the artist rails array is depleted.
       if ((i + 1) % 2 === 0) {
         const artist_module = artist_modules.shift()
         if (artist_module) {
-          modules.push(<ArtistRail key={artist_module.__id} rail={artist_module} />)
+          modules.push(<ArtistRail ref={this.registerModule.bind(this)} key={artist_module.__id} rail={artist_module} />)
         }
       }
     }
@@ -44,14 +54,12 @@ class Home extends React.Component {
   }
   refresh() {
     this.setState({isRefreshing: true})
-    this.props.relay.forceFetch()
+    this.state.modules.forEach((module) => module.forceFetch())
     this.setState({isRefreshing: false})
   }
 }
 
 export default Relay.createContainer(Home, {
-  shouldComponentUpdate: () => true,
-
   fragments: {
     home: () => Relay.QL`
       fragment on HomePage {

--- a/lib/containers/home.js
+++ b/lib/containers/home.js
@@ -3,12 +3,18 @@
 
 import Relay from 'react-relay'
 import React from 'react'
-import { ScrollView } from 'react-native'
+import { ScrollView, Text, TouchableHighlight, RefreshControl } from 'react-native'
 
 import ArtworkRail from '../components/home/artwork_rails/artwork_rail'
 import ArtistRail from '../components/home/artist_rails/artist_rail'
 
 class Home extends React.Component {
+  constructor() {
+    super()
+    this.state = {
+      isRefreshing: false,
+    }
+  }
   render() {
     const modules = []
     const artwork_modules = this.props.home.artwork_modules
@@ -24,11 +30,28 @@ class Home extends React.Component {
         }
       }
     }
-    return (<ScrollView>{modules}</ScrollView>)
+    return (
+      <ScrollView
+        refreshControl={
+          <RefreshControl
+            refreshing={this.state.isRefreshing}
+            onRefresh={this.refresh.bind(this)}
+            />
+        }>
+        {modules}
+      </ScrollView>
+    )
+  }
+  refresh() {
+    this.setState({isRefreshing: true})
+    this.props.relay.forceFetch()
+    this.setState({isRefreshing: false})
   }
 }
 
 export default Relay.createContainer(Home, {
+  shouldComponentUpdate: () => true,
+
   fragments: {
     home: () => Relay.QL`
       fragment on HomePage {


### PR DESCRIPTION
The `<RefreshControl>` component provided by RN looks and feels great out-of-the-box, but I'm having some Relay trouble.

The `forceFetch` approach in this pr will update all `artwork_modules` that have new `id`'s after the initial Home rendering. This is great for gene rails, which are changed often, and the Related Artist rail, which returns a new set of works and a new artist each time. I'm having trouble with the Recently Saved rail because its `id` does not change even though the works in its child `Grid` container can. I've been reading a lot about Relay but I'm not entirely sure why calling `forceFetch` on the parent Home container doesn't check for changes in the children. I did take a look at the `RootContainer` and its `forceFetch` variable, but I'm not sure what exactly I can do there to solve this.

Anyway, this implementation of pull-to-refresh will at least update some rails and looks pretty. `RefreshControl` doesn't offer much in the way of customization but I can definitely start on our custom spinner once I wrap my head around this Relay stuff.

![pulltorefresh](https://cloud.githubusercontent.com/assets/2712962/18417425/f0fb5852-7830-11e6-882d-d56855fa8763.gif)
