### PR TITLE
[Artworks] Use unique artwork component keys. #tiny

### DIFF
--- a/lib/components/artwork_grids/generic_grid.js
+++ b/lib/components/artwork_grids/generic_grid.js
@@ -80,7 +80,8 @@ class GenericArtworksGrid extends React.Component {
       const artworkComponents = []
       const artworks = sectionedArtworks[i]
       for (let j = 0; j < artworks.length; j++) {
-        artworkComponents.push(<Artwork artwork={artworks[j]} key={'artwork-' + j} />)
+        const artwork = artworks[j]
+        artworkComponents.push(<Artwork artwork={artwork} key={artwork.__id} />)
         if (j < artworks.length - 1) {
           artworkComponents.push(<View style={spacerStyle} key={'spacer-' + j} accessibilityLabel="Spacer View" />)
         }
@@ -125,6 +126,7 @@ const GenericArtworksGridContainer = Relay.createContainer(GenericArtworksGrid, 
   fragments: {
     artworks: () => Relay.QL`
       fragment on Artwork @relay(plural: true) {
+        __id
         title
         date
         sale_message


### PR DESCRIPTION
Otherwise a component for a different artwork (with a different image
aspect ratio) might get re-used for the wrong artwork, leading to
incorrectly scaled images.

Fixes #289.