### PR TITLE
[Home] Selective Pull-To-Refresh #tiny

### DIFF
--- a/lib/containers/home.js
+++ b/lib/containers/home.js
@@ -8,6 +8,10 @@ import { ScrollView, RefreshControl } from 'react-native'
 import ArtworkRail from '../components/home/artwork_rails/artwork_rail'
 import ArtistRail from '../components/home/artist_rails/artist_rail'
 
+const frequentlyUpdatedModules = [
+  'saved_works',
+]
+
 class Home extends React.Component {
   constructor() {
     super()
@@ -54,7 +58,14 @@ class Home extends React.Component {
   }
   refresh() {
     this.setState({isRefreshing: true})
-    this.state.modules.forEach((module) => module.forceFetch())
+
+    // forceFetch for entirely new modules
+    this.props.relay.forceFetch()
+
+    // only individuallyforceFetch modules that have possibly changed in the past day
+    const forceFetchModules = this.state.modules.filter((module) => frequentlyUpdatedModules.indexOf(module.props.rail.key) > -1)
+    forceFetchModules.forEach((module) => module.forceFetch())
+
     this.setState({isRefreshing: false})
   }
 }
@@ -65,6 +76,7 @@ export default Relay.createContainer(Home, {
       fragment on HomePage {
         artwork_modules(max_rails: 99) {
           __id
+          key
           ${ArtworkRail.getFragment('rail')}
         }
         artist_modules {


### PR DESCRIPTION
This pr makes our pull-to-refresh implementation a bit smarter. By calling `forceFetch` on the Home container, it ensures all entirely new modules are fetched every time. It will then check for modules that are frequently updated and `forceFetch` them individually instead of refreshing every single rail every time.