### PR TITLE
Vscode fine tuning

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,14 @@
     "editor.rulers": [120],
     "editor.tabSize": 2,
 
+    "search.exclude": {
+        "**/node_modules": true,
+        "externals/**": true,
+        "**/typings/**": true,
+        "Example/DerivedData": true,
+        "Example/Pods/Headers/**": true
+    },
+
     // Because we use Flow - see https://github.com/flowtype/flow-for-vscode#setup
     "javascript.validate.enable": false,
     "clang.compilationDatabase": "${workspaceRoot}/Example/compile_commands.json",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
         "*.podspec": "ruby",
         "Podfile": "ruby",
         "*.h": "objective-c",
-        "*.js": "flow"
+        "*.js": "javascriptreact"
     },
     "files.trimTrailingWhitespace": true,
 


### PR DESCRIPTION
I’m not sure why JS files were set to be recognised as the `flow` type. It doesn’t appear to exist and JS files would get recognised as plain text files.