### PR TITLE
Remove typings from dev deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Master
 
+- Remove typings from the npm `package.json` as the recommendation is a global install - orta
 - Make follow artist button in artist rail work and replace with a new suggestion based on that artist - alloy
 - Home now asks for maximum of 99 artwork rails - sarah
 - Added pull-to-refresh functionality to home view - sarah

--- a/package.json
+++ b/package.json
@@ -67,8 +67,7 @@
     "jest-cli": "^14.1.0",
     "jest-react-native": "^14.1.2",
     "react-storybooks-relay-container": "^1.0.0",
-    "react-test-renderer": "^15.3.0",
-    "typings": "^1.3.2"
+    "react-test-renderer": "^15.3.0"
   },
   "peerDependencies": {
     "babel-relay-plugin": "^0.9.0"


### PR DESCRIPTION
I was already recommending that you globally install  `typings` in the docs

![screen shot 2016-09-16 at 10 10 38 am](https://cloud.githubusercontent.com/assets/49038/18588800/fa6fc076-7bf5-11e6-8dcc-e3e8258af962.png)

So having it in our npm deps was superfluous. You can fix this I think with `npm prune` after installing this version.

#trivial