### PR TITLE
Fix missing asset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.1.0-beta.3
+
+- Fix missing image asset issue - alloy
+
 ### 1.1.0-beta.2
 
 - Adds an initial Gene view - orta

--- a/Emission.podspec
+++ b/Emission.podspec
@@ -27,5 +27,6 @@ Pod::Spec.new do |s|
   react_native_version = npm_package['dependencies']['react-native'].sub('^', '~>')
   s.dependency 'React/Core', react_native_version
   s.dependency 'React/RCTText', react_native_version
+  s.dependency 'React/RCTImage', react_native_version
   s.dependency 'React/RCTNetwork', react_native_version
 end

--- a/Emission.podspec
+++ b/Emission.podspec
@@ -15,8 +15,7 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '8.0'
   s.requires_arc   = true
   s.source_files   = 'Pod/Classes/**/*.{h,m}'
-  s.resource       = 'Pod/Assets/Emission.js'
-  s.preserve_paths = 'Pod/Assets/assets/images/*.png'
+  s.resources      = 'Pod/Assets/{Emission.js,assets}'
 
   # Artsy pods
   s.dependency 'Artsy+UIFonts', '>= 1.1.0'

--- a/Example/Emission.xcodeproj/project.pbxproj
+++ b/Example/Emission.xcodeproj/project.pbxproj
@@ -15,7 +15,6 @@
 		510DCB361CCA69EC0075E8CB /* EmissionUITests.m in Sources */ = {isa = PBXBuildFile; fileRef = 510DCB351CCA69EC0075E8CB /* EmissionUITests.m */; };
 		510E94FD1CCA828900BDF098 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 510E94FB1CCA828900BDF098 /* LaunchScreen.xib */; };
 		510E95141CCEB84F00BDF098 /* TestHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 510E95131CCEB84F00BDF098 /* TestHelper.m */; };
-		51278F621D93FAD700742B34 /* assets in Resources */ = {isa = PBXBuildFile; fileRef = 51278F611D93FAD700742B34 /* assets */; };
 		51F3E9A41CF3B8A4004A2013 /* RotationNavigationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 51F3E9A31CF3B8A4004A2013 /* RotationNavigationController.m */; };
 		60B743B71D3EB12600E6B2A3 /* ARStorybookComponentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 60B743B61D3EB12600E6B2A3 /* ARStorybookComponentViewController.m */; };
 		A99EF3F9379BB0B67C290F17 /* libPods-EmissionTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7845722F426267DCFE6FD462 /* libPods-EmissionTests.a */; };
@@ -57,7 +56,6 @@
 		510E94FC1CCA828900BDF098 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
 		510E95131CCEB84F00BDF098 /* TestHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TestHelper.m; sourceTree = "<group>"; };
 		510E95151CCEC22C00BDF098 /* TestHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestHelper.h; sourceTree = "<group>"; };
-		51278F611D93FAD700742B34 /* assets */ = {isa = PBXFileReference; lastKnownFileType = folder; name = assets; path = ../../Pod/Assets/assets; sourceTree = "<group>"; };
 		51F3E9A21CF3B8A4004A2013 /* RotationNavigationController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RotationNavigationController.h; sourceTree = "<group>"; };
 		51F3E9A31CF3B8A4004A2013 /* RotationNavigationController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RotationNavigationController.m; sourceTree = "<group>"; };
 		60B743B51D3EB12600E6B2A3 /* ARStorybookComponentViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARStorybookComponentViewController.h; sourceTree = "<group>"; };
@@ -104,7 +102,6 @@
 		510DCB0F1CCA69EC0075E8CB /* Emission */ = {
 			isa = PBXGroup;
 			children = (
-				51278F611D93FAD700742B34 /* assets */,
 				510E94FB1CCA828900BDF098 /* LaunchScreen.xib */,
 				510DCB131CCA69EC0075E8CB /* AppDelegate.h */,
 				510DCB141CCA69EC0075E8CB /* AppDelegate.m */,
@@ -337,7 +334,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				51278F621D93FAD700742B34 /* assets in Resources */,
 				510E94FD1CCA828900BDF098 /* LaunchScreen.xib in Resources */,
 				510DCB1D1CCA69EC0075E8CB /* Assets.xcassets in Resources */,
 			);

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -6,7 +6,7 @@ react_path = '../node_modules/react-native'
 target 'Emission' do
   pod 'Emission', :path => '../'
   pod 'Extraction'
-  pod 'React', :path => react_path, :subspecs => %w(RCTWebSocket RCTImage)
+  pod 'React', :path => react_path, :subspecs => %w(RCTWebSocket)
   if ENV['ARTSY_STAFF_MEMBER'] != nil || ENV['CI'] != nil
     pod 'Artsy+UIFonts', :git => "https://github.com/artsy/Artsy-UIFonts.git"
   else

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -14,6 +14,7 @@ PODS:
     - Artsy+UIFonts (>= 1.1.0)
     - Extraction (>= 1.2.0)
     - React/Core (~> 0.30.0)
+    - React/RCTImage (~> 0.30.0)
     - React/RCTNetwork (~> 0.30.0)
     - React/RCTText (~> 0.30.0)
     - SDWebImage (>= 3.7.2)
@@ -70,7 +71,6 @@ DEPENDENCIES:
   - Artsy+UIFonts (from `https://github.com/artsy/Artsy-UIFonts.git`)
   - Emission (from `../`)
   - Extraction
-  - React/RCTImage (from `../node_modules/react-native`)
   - React/RCTTest (from `../node_modules/react-native`)
   - React/RCTWebSocket (from `../node_modules/react-native`)
   - SAMKeychain
@@ -106,7 +106,7 @@ SPEC CHECKSUMS:
   Artsy+UIColors: 10a2d71e9ffe1015be43d4e084d13ff4337aab97
   Artsy+UIFonts: 108bfe625c45008ebb15c4c62003882dd345c4b8
   Artsy-UIButtons: 26e6d1e0d2174773e9cf7693985d27faddd61743
-  Emission: c428804c1d63bdabf84124cf2284bd2be8ee846c
+  Emission: 1c8656a1636b1d28eb45bbb4cad80aa2ca40be97
   Extraction: fa0b2384907cb1842b07236fc5c2014e26bc0e51
   FLKAutoLayout: 106b14dbae09d32c6730190f4e78a959759ba4a4
   ISO8601DateFormatter: 4551b6ce4f83185425f583b0b3feb3c7b59b942c
@@ -118,6 +118,6 @@ SPEC CHECKSUMS:
   Specta: ac94d110b865115fe60ff2c6d7281053c6f8e8a2
   UIView+BooleanAnimations: a760be9a066036e55f298b7b7350a6cb14cfcd97
 
-PODFILE CHECKSUM: ab2b14498bb09c9ba993d5484696be2421070207
+PODFILE CHECKSUM: af04d610a78f4ef6211c4ff54ac79ae9aa8d0c78
 
 COCOAPODS: 1.0.1


### PR DESCRIPTION
Fixes https://github.com/artsy/eigen/issues/1833

* The required `RCTImage` subspec was only added to the Emission Example app, not the Emission podspec which meant that Eigen did not include that module.
* It turns out that RN does look in the Emission framework bundle when integrated into Eigen, so these assets can be included in the pod as normal.