### PR TITLE
Fixed inverted button width in artworks header and disappearance in artist cards #tiny

### DIFF
--- a/lib/components/artist/header.js
+++ b/lib/components/artist/header.js
@@ -3,7 +3,7 @@
 
 import React from 'react'
 import Relay from 'react-relay'
-import { NativeModules, StyleSheet, View } from 'react-native'
+import { NativeModules, StyleSheet, View, Dimensions } from 'react-native'
 const { ARTemporaryAPIModule } = NativeModules
 
 import Events from '../../native_modules/events'
@@ -12,6 +12,8 @@ import colors from '../../../data/colors'
 import InvertedButton from '../buttons/inverted_button'
 import Headline from '../text/headline'
 import SerifText from '../text/serif'
+
+const isPad = Dimensions.get('window').width > 700
 
 class Header extends React.Component {
   state: {
@@ -147,6 +149,10 @@ const styles = StyleSheet.create({
   },
   followButton: {
     height: 40,
+    width: isPad ? 330 : null,
+    alignSelf: isPad ? 'center' : null,
+    marginLeft: 0,
+    marginRight: 0,
   }
 })
 

--- a/lib/components/buttons/inverted_button.js
+++ b/lib/components/buttons/inverted_button.js
@@ -8,8 +8,6 @@ import Headline from '../text/headline'
 import colors from '../../../data/colors'
 import Spinner from '../spinner'
 
-const sideMargin = Dimensions.get('window').width > 700 ? 175 : 0
-
 const AnimationDuration = 250
 const AnimatedTouchable = Animated.createAnimatedComponent(TouchableHighlight)
 const AnimatedHeadline = Animated.createAnimatedComponent(Headline)
@@ -79,8 +77,6 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-    marginLeft: sideMargin,
-    marginRight: sideMargin,
   },
   text: {
     color: 'white'

--- a/lib/components/home/artwork_rails/artwork_rail_header.js
+++ b/lib/components/home/artwork_rails/artwork_rail_header.js
@@ -142,8 +142,9 @@ const styles = StyleSheet.create({
   followButton: {
     marginTop: 10,
     marginBottom: 0,
-    margin: isPad ? 160 : 135,
+    alignSelf: 'center',
     height: 30,
+    width: 90,
   },
   followAnnotation: {
     fontStyle: 'italic',

--- a/lib/components/tab_view.js
+++ b/lib/components/tab_view.js
@@ -6,8 +6,6 @@ import { StyleSheet, View, Dimensions } from 'react-native'
 
 import SwitchView from './switch_view'
 
-const sideMargin = Dimensions.get('window').width > 700 ? 175 : 0
-
 export default class TabView extends React.Component {
   render() {
     const { children, ...props } = this.props
@@ -30,7 +28,7 @@ const styles = StyleSheet.create({
   switch: {
     marginTop: 30,
     marginBottom: 30,
-    marginLeft: sideMargin,
-    marginRight: sideMargin,
+    marginLeft: 0,
+    marginRight: 0,
   }
 })

--- a/lib/containers/artist.js
+++ b/lib/containers/artist.js
@@ -3,7 +3,7 @@
 
 import Relay from 'react-relay'
 import React from 'react'
-import { ScrollView, View, Dimensions } from 'react-native'
+import { ScrollView, View, Dimensions, StyleSheet } from 'react-native'
 
 import Events from '../native_modules/events'
 
@@ -14,6 +14,8 @@ import Artworks from '../components/artist/artworks'
 
 import TabView from '../components/tab_view'
 import type TabSelectionEvent from '../components/events'
+
+const isPad = Dimensions.get('window').width > 700
 
 const TABS = {
   ABOUT: 'ABOUT',
@@ -83,7 +85,7 @@ class Artist extends React.Component {
 
   renderTabView() {
     return (
-      <TabView titles={this.availableTabs()} selectedIndex={this.state.selectedTabIndex} onSelectionChange={this.tabSelectionDidChange}>
+      <TabView titles={this.availableTabs()} selectedIndex={this.state.selectedTabIndex} onSelectionChange={this.tabSelectionDidChange} style={styles.tabView}>
         { this.renderSelectedTab() }
       </TabView>
     )
@@ -108,6 +110,15 @@ class Artist extends React.Component {
     )
   }
 }
+
+const styles = StyleSheet.create({
+  tabView: {
+    width: isPad ? 330 : null,
+    marginTop: 30,
+    marginBottom: 30,
+    alignSelf: isPad ? 'center' : null,
+  }
+})
 
 export default Relay.createContainer(Artist, {
   fragments: {


### PR DESCRIPTION
I've updated the `inverted_button` component to be more malleable since it's used in many different places.

It shows up on both iPhone & iPad now:

![simulator screen shot oct 4 2016 3 44 54 pm](https://cloud.githubusercontent.com/assets/2712962/19076440/0f6e72ea-8a49-11e6-8661-d4d9e20e54d8.png)

And it doesn't look weird on iPad anymore:

![simulator screen shot oct 4 2016 3 43 36 pm](https://cloud.githubusercontent.com/assets/2712962/19076439/0f6e62d2-8a49-11e6-9669-e08ba8be466b.png)

Fixes #257 & #285 

Also makes artist view controller more in line with its original spec: https://github.com/artsy/eigen/issues/1132
