### PR TITLE
[Artist Rail] Fix showstoppers 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### 1.1.0-beta.3
-
+- Fix text height and truncation for artist cards - maxim
 - Add hero units - alloy
 - Fix missing image asset issue - alloy
 - [dev] Updates Flow to 0.32 - orta

--- a/lib/components/home/artist_rails/artist_card.js
+++ b/lib/components/home/artist_rails/artist_card.js
@@ -76,9 +76,9 @@ class ArtistCard extends React.Component {
           <View style={styles.touchableContainer}>
             <ImageView style={styles.image} imageURL={imageURL} />
             <View style={styles.textContainer}>
-              <Text style={styles.sansSerifText}>{artist.name.toUpperCase()}</Text>
-              <Text style={styles.serifText}>{artist.formatted_nationality_and_birthday}</Text>
-              <Text style={[styles.serifText, styles.serifWorksText]}>{artist.formatted_artworks_count}</Text>
+              <Text numberOfLines={1} style={styles.sansSerifText}>{artist.name.toUpperCase()}</Text>
+              <Text numberOfLines={1} style={styles.serifText}>{artist.formatted_nationality_and_birthday}</Text>
+              <Text numberOfLines={1} style={[styles.serifText, styles.serifWorksText]}>{artist.formatted_artworks_count}</Text>
             </View>
             <View style={styles.followButton}>
               <InvertedButton text={this.state.following ? 'Following' : 'Follow'}
@@ -134,12 +134,14 @@ const styles = StyleSheet.create({
     marginTop: 12,
   },
   sansSerifText: {
+    marginRight: 12,
     height: 17,
     fontSize: 12,
     textAlign: 'left',
     fontFamily: 'Avant Garde Gothic ITCW01Dm',
   },
   serifText: {
+    marginRight: 12,
     height: 17,
     fontFamily: 'AGaramondPro-Regular',
     fontSize: 16,

--- a/lib/components/home/artist_rails/artist_card.js
+++ b/lib/components/home/artist_rails/artist_card.js
@@ -134,21 +134,22 @@ const styles = StyleSheet.create({
     marginTop: 12,
   },
   sansSerifText: {
+    height: 17,
     fontSize: 12,
     textAlign: 'left',
     fontFamily: 'Avant Garde Gothic ITCW01Dm',
   },
   serifText: {
+    height: 17,
     fontFamily: 'AGaramondPro-Regular',
     fontSize: 16,
-    marginBottom: -4,
     color: '#000000'
   },
     serifWorksText: {
     color: colors['gray-semibold'],
   },
   followButton: {
-    marginTop: 18,
+    marginTop: 12,
     marginLeft: 12,
     width: 196,
     height: 30,


### PR DESCRIPTION
Fix #217 and #303. 

<img width="716" alt="screen shot 2016-10-11 at 12 51 08" src="https://cloud.githubusercontent.com/assets/373860/19269262/93e5d064-8fb1-11e6-8883-04644c85e8b1.png">

@sarahscott apparently you need to explicitly set the `numberOfLines` to 1 so it truncates. Then, you can specify the truncation method (start, middle, end) with `ellipsizeMode` according to [docs](https://facebook.github.io/react-native/docs/text.html#ellipsizemode). 