### PR TITLE
[Home] Reduce memory usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ### 1.1.0-beta.3
+
+- Show refresh control until all Relay requests have finished - alloy
+- Reduce memory usage of home view by using a ListView to remove views not on screen from the hierarchy - alloy
 - Fix text height and truncation for artist cards - maxim
 - Add hero units - alloy
 - Fix missing image asset issue - alloy

--- a/lib/containers/home.js
+++ b/lib/containers/home.js
@@ -3,68 +3,82 @@
 
 import Relay from 'react-relay'
 import React from 'react'
-import { ScrollView, RefreshControl } from 'react-native'
+import { ListView, ListViewDataSource, ScrollView, RefreshControl } from 'react-native'
 
 import HeroUnits from '../components/home/hero_units'
 import ArtworkRail from '../components/home/artwork_rails/artwork_rail'
 import ArtistRail from '../components/home/artist_rails/artist_rail'
 import SearchBar from '../components/home/search_bar'
 
+type DataSourceRow = {
+  type: 'search_bar' | 'hero_units' | 'artwork' | 'artist',
+  data: any,
+}
+
 class Home extends React.Component {
   state: {
     modules: any[],
-    isRefreshing: boolean
+    isRefreshing: boolean,
+    dataSource: ListViewDataSource,
   }
 
-  constructor() {
-    super()
-    this.state = {
-      isRefreshing: false,
-      modules: [],
-    }
-  }
+  constructor(props) {
+    super(props)
 
-  registerModule(module) {
-    if (module) {
-      this.state.modules.push(module)
-    }
-  }
-
-  render() {
-    this.state.modules = []
-
-    const modules = []
-    const artwork_modules = this.props.home.artwork_modules
-    const artist_modules = this.props.home.artist_modules.concat() // create a copy
+    const rows: DataSourceRow[] = [
+      { type: 'search_bar', data: null },
+      { type: 'hero_units', data: props.home.hero_units },
+    ]
+    const artwork_modules = props.home.artwork_modules
+    const artist_modules = props.home.artist_modules.concat() // create a copy so we can mutate it (with `shift`)
     for (let i = 0; i < artwork_modules.length; i++) {
       const artwork_module = artwork_modules[i]
-      modules.push(<ArtworkRail ref={this.registerModule.bind(this)} key={artwork_module.__id} rail={artwork_module} />)
-      // For now, show an artist rail after each 2 artwork rails, until the artist rails array is depleted.
+      rows.push({ type: 'artwork', data: artwork_module })
       if ((i + 1) % 2 === 0) {
         const artist_module = artist_modules.shift()
         if (artist_module) {
-          modules.push(<ArtistRail ref={this.registerModule.bind(this)} key={artist_module.__id} rail={artist_module} />)
+          rows.push({ type: 'artist', data: artist_module })
         }
       }
     }
-    return (
-      <ScrollView
-        refreshControl={
-          <RefreshControl
-            refreshing={this.state.isRefreshing}
-            onRefresh={this.refresh.bind(this)}
-            />
-        }>
-        <SearchBar />
-        <HeroUnits hero_units={this.props.home.hero_units} />
-        {modules}
-      </ScrollView>
-    )
+
+    const dataSource: ListViewDataSource = new ListView.DataSource({ rowHasChanged: (r1, r2) => r1 !== r2 })
+
+    this.state = {
+      isRefreshing: false,
+      modules: [],
+      dataSource: dataSource.cloneWithRows(rows),
+    }
   }
-  refresh() {
-    this.setState({isRefreshing: true})
+
+  handleRefresh = () => {
+    this.setState({ isRefreshing: true })
     this.state.modules.forEach((module) => module.forceFetch())
-    this.setState({isRefreshing: false})
+    this.setState({ isRefreshing: false })
+  }
+
+  render() {
+    return (
+      <ListView dataSource={this.state.dataSource}
+                renderScrollComponent={(props) => {
+                  return <ScrollView {...props} refreshControl={<RefreshControl refreshing={this.state.isRefreshing}
+                                                                                onRefresh={this.handleRefresh} />} />
+                }}
+                renderRow={({ type, data }, _, row) => {
+                  // Offset row because we don’t store a reference to the search bar and hero units rows.
+                  const registerModule = (module) => this.state.modules[row - 2] = module
+                  switch (type) {
+                    case 'search_bar':
+                      return <SearchBar />
+                    case 'hero_units':
+                      return <HeroUnits hero_units={data} />
+                    case 'artwork':
+                      return <ArtworkRail ref={registerModule} key={data.__id} rail={data} />
+                    case 'artist':
+                      return <ArtistRail ref={registerModule} key={data.__id} rail={data} />
+                  }
+                }} />
+    )
   }
 }
 

--- a/lib/containers/home.js
+++ b/lib/containers/home.js
@@ -53,8 +53,21 @@ class Home extends React.Component {
 
   handleRefresh = () => {
     this.setState({ isRefreshing: true })
-    this.state.modules.forEach((module) => module.forceFetch())
-    this.setState({ isRefreshing: false })
+    const stopRefreshing = () => this.setState({ isRefreshing: false })
+
+    Promise.all(this.state.modules.map(module => {
+      return new Promise((resolve, reject) => {
+        module.forceFetch(null, (readyState) => {
+          if (readyState.error) {
+            reject(readyState.error)
+          } else if (readyState.aborted) {
+            reject()
+          } else if (readyState.done) {
+            resolve()
+          }
+        })
+      })
+    })).then(stopRefreshing, stopRefreshing)
   }
 
   render() {


### PR DESCRIPTION
Oops, seems I exaggerated the amount of memory usage before this change, nonetheless it’s a 30% reduction and, more importantly, the home view now tries to load those rails that are currently on screen instead of possibly those all the way down.

* Before: 135MB
* After: 92MB

----

In addition I made it so that the refresh control is only removed from screen until all Relay requests are finished.