### PR TITLE
[Artist Rail] Fix right margin cutoff of cards by adding spacer view #trivial #tiny

### DIFF
--- a/lib/components/home/artist_rails/artist_rail.js
+++ b/lib/components/home/artist_rails/artist_rail.js
@@ -128,6 +128,11 @@ class ArtistRail extends React.Component {
                     showsHorizontalScrollIndicator={false}
                     scrollsToTop={false}>
           {cards}
+          {
+            // Adding a spacer view to have padding at the end of the rail
+            // If you add marginRight, it will cut off the cards as you scroll through
+          }
+          <View style={{width:15}} />
         </ScrollView>
       )
     } else {
@@ -163,14 +168,13 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     marginTop: 10,
     minHeight: 330,
-    marginRight: 15,
-  },
+ },
   title: {
     marginLeft: 30,
     marginRight: 30,
     marginTop: 40,
-    marginBottom: 10
-  }
+    marginBottom: 10,
+ }
 })
 
 export default Relay.createContainer(ArtistRail, {


### PR DESCRIPTION
Fix #309 

Cards now bleed to the edge:
![simulator screen shot 17 oct 2016 18 19 35](https://cloud.githubusercontent.com/assets/373860/19447684/774c95b6-9496-11e6-8565-6dd8ded61a8e.png)

There's still additional space at the end of the rail:
![simulator screen shot 17 oct 2016 18 19 40](https://cloud.githubusercontent.com/assets/373860/19447687/79b6dc3a-9496-11e6-9c17-f9fb8ffa60ef.png)
