### PR TITLE
[Artwork] Don’t crash if there is no artist.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Master
+
+- Fix crash that would occur for artworks that have no artists - alloy
+
 ### 1.1.0-beta.5
 
 - Fix use of outdated artist follow API that lead to a crash - alloy

--- a/lib/components/artwork_grids/artwork.js
+++ b/lib/components/artwork_grids/artwork.js
@@ -21,13 +21,22 @@ class Artwork extends React.Component {
       <TouchableWithoutFeedback onPress={this.handleTap.bind(this)}>
         <View>
           <ImageView style={styles.image} aspectRatio={artwork.image.aspect_ratio} imageURL={artwork.image.url} />
-          <SerifText style={[styles.text, styles.artist]}>{artwork.artist.name}</SerifText>
+          { this.artist() }
           { this.artworkTitle() }
           { this.props.artwork.partner ? <SerifText style={styles.text}>{ this.props.artwork.partner.name }</SerifText> : null }
           { this.saleMessage() }
         </View>
       </TouchableWithoutFeedback>
     )
+  }
+
+  artist() {
+    const artist = this.props.artwork.artist
+    if (artist) {
+      return <SerifText style={[styles.text, styles.artist]}>{artist.name}</SerifText>
+    } else {
+      return null
+    }
   }
 
   artworkTitle() {


### PR DESCRIPTION
Fixes https://github.com/artsy/eigen/issues/1927

This is simply an educated guess, but it’s a pretty good one.

It’s probably artworks in genes for which we have no associated artists. The existing artwork component didn’t take that into account yet, because previously it was only used for artworks on an artist view, those obviously all have an associated artist.