### PR TITLE
[Home/Artworks] Don’t remove (collapsed) artwork rail too early.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.1.2
+
+- Ensure the artwork rail expand button is not clipped too early - alloy
+
 ### 1.1.1
 
 - Only align home view to top of screen, otherwise default to bottom status bar - alloy

--- a/lib/components/home/artwork_rails/artwork_rail.js
+++ b/lib/components/home/artwork_rails/artwork_rail.js
@@ -122,7 +122,7 @@ class ArtworkRail extends React.Component {
 
   gridContainerHeight() {
     if (this.expandable()) {
-      const initialInternalViewHeight = isPad ? 420 : 520
+      const initialInternalViewHeight = isPad ? 400 : 500
       return this.state.expanded ? this.state.gridHeight : initialInternalViewHeight
     } else {
       return this.state.gridHeight
@@ -170,7 +170,7 @@ class ArtworkRail extends React.Component {
         <View style={[styles.container, { height: this.mainContainerHeight() }]}>
           { this.renderGrid() }
           { this.renderViewAllButton() }
-          <Separator style={{marginTop: this.state.expanded ? 20 : 0 }}/>
+          <Separator />
           { this.renderExpansionButton() }
         </View>
       )
@@ -191,7 +191,7 @@ class ArtworkRail extends React.Component {
       style.minHeight = 400
     }
     return (
-      <View style={{ marginBottom: 20 }}>
+      <View accessibilityLabel="Artwork Rail" style={{ paddingBottom: this.state.expanded ? 0 : 12 }}>
         <Header rail={this.props.rail} handleViewAll={this.handleViewAll}/>
         <View style={style}>
           { this.renderModuleResults() }

--- a/lib/components/home/artwork_rails/artwork_rail_header.js
+++ b/lib/components/home/artwork_rails/artwork_rail_header.js
@@ -11,7 +11,6 @@ import Events from '../../../native_modules/events'
 import SerifText from '../../text/serif'
 import colors from '../../../../data/colors'
 import Button from '../../buttons/inverted_button'
-import SwitchBoard from '../../../native_modules/switch_board'
 import fragments from './relay_fragments'
 import SectionTitle from '../section_title'
 
@@ -95,7 +94,7 @@ class ArtworkRailHeader extends React.Component {
 
 const styles = StyleSheet.create({
   container: {
-    marginTop: 40,
+    marginTop: isPad ? 50 : 40,
     marginBottom: 20,
     marginLeft: 30,
     marginRight: 30,


### PR DESCRIPTION
Fixes #381.

This makes it so that the expand button is part of its parent’s frame, which, as pointed out by @majak, will make it so RN won’t remove the parent view yet:

<img width="238" alt="screen shot 2016-10-28 at 16 03 59" src="https://cloud.githubusercontent.com/assets/2320/19809136/3db9a8a8-9d28-11e6-9370-7d29c6aea376.png">

For context, RN just looks at the frames of the scroll view’s first subviews, not their descendants: https://github.com/alloy/react-native/blob/0.34.1-with-scrollview-fix/React/Views/RCTView.m#L291-L293