### PR TITLE
[Home] Move saved works rail further to the top

### DIFF
--- a/lib/containers/home.js
+++ b/lib/containers/home.js
@@ -110,12 +110,12 @@ export default Relay.createContainer(Home, {
                         order: [
                           RECOMMENDED_WORKS,
                           FOLLOWED_ARTISTS,
-                          SAVED_WORKS,
-                          FOLLOWED_GENES,
-                          FOLLOWED_GALLERIES,
                           RELATED_ARTISTS,
+                          FOLLOWED_GALLERIES,
+                          SAVED_WORKS,
                           LIVE_AUCTIONS,
                           CURRENT_FAIRS,
+                          FOLLOWED_GENES,
                           GENERIC_GENES]) {
           __id
           ${ArtworkRail.getFragment('rail')}

--- a/lib/containers/home.js
+++ b/lib/containers/home.js
@@ -110,9 +110,9 @@ export default Relay.createContainer(Home, {
                         order: [
                           RECOMMENDED_WORKS,
                           FOLLOWED_ARTISTS,
+                          SAVED_WORKS,
                           FOLLOWED_GENES,
                           FOLLOWED_GALLERIES,
-                          SAVED_WORKS,
                           RELATED_ARTISTS,
                           LIVE_AUCTIONS,
                           CURRENT_FAIRS,


### PR DESCRIPTION
For #378. 

Current order:

- Recommended works
- Followed artists
- Related artists
- Followed galleries
- Saved works
- Live auctions
- Current fairs
- Followed genes
- Generic genes


@alloy - it still puts in the artist rail after 2 artwork rails. Is that ok for now / was there a plan to change that in the future? (e.g. in the new order, we sometimes may want a few other rails before showing trending artists, but it's on a case by case basis). 
 