### PR TITLE
[Home] Add resize mode property to chevron image

### DIFF
--- a/lib/components/home/artwork_rails/artwork_rail.js
+++ b/lib/components/home/artwork_rails/artwork_rail.js
@@ -158,7 +158,7 @@ class ArtworkRail extends React.Component {
     if (this.expandable() && !this.state.expanded) {
       return (
         <TouchableHighlight style={styles.expansionButton} onPress={this.expand} underlayColor={'white'}>
-            <Image style={{height: 8, width: 15, alignSelf: 'center'}} source={require('../../../../images/chevron.png')} />
+            <Image style={{height: 8, width: 15, alignSelf: 'center', resizeMode: 'center'}} source={require('../../../../images/chevron.png')} />
         </TouchableHighlight>
       )
     }


### PR DESCRIPTION
Fix #354.

Looks like it wasn't the asset (they were correct). It was just being stretched in the `<image>` view, so I've added `resizeMode: center`, which keeps the original image ratios etc. 

![simulator screen shot 15 nov 2016 10 39 35](https://cloud.githubusercontent.com/assets/373860/20302757/7cc5a9e2-ab20-11e6-94a3-32ba46eb7aa3.png)
