### PR TITLE
[Testing] Added test coverage to Artist container

### DIFF
--- a/lib/containers/__tests__/__snapshots__/artist-tests.js.snap
+++ b/lib/containers/__tests__/__snapshots__/artist-tests.js.snap
@@ -1,0 +1,132 @@
+exports[`layout works as expected with no tabs 1`] = `
+<ScrollView
+  automaticallyAdjustContentInsets={false}
+  scrollsToTop={true}>
+  <View
+    style={
+      Object {
+        "paddingLeft": 20,
+        "paddingRight": 20,
+      }
+    }>
+    <Header
+      artist={
+        Object {
+          "counts": Object {
+            "articles": 0,
+            "artworks": 0,
+            "partner_shows": 0,
+          },
+          "has_metadata": false,
+        }
+      } />
+    <View
+      style={
+        Object {
+          "paddingTop": 30,
+        }
+      } />
+  </View>
+</ScrollView>
+`;
+
+exports[`layout works as expected with one tab 1`] = `
+<ScrollView
+  automaticallyAdjustContentInsets={false}
+  scrollsToTop={true}>
+  <View
+    style={
+      Object {
+        "paddingLeft": 20,
+        "paddingRight": 20,
+      }
+    }>
+    <Header
+      artist={
+        Object {
+          "counts": Object {
+            "articles": 0,
+            "artworks": 0,
+            "partner_shows": 0,
+          },
+          "has_metadata": true,
+        }
+      } />
+    <View
+      style={
+        Object {
+          "paddingTop": 30,
+        }
+      }>
+      <About
+        artist={
+          Object {
+            "counts": Object {
+              "articles": 0,
+              "artworks": 0,
+              "partner_shows": 0,
+            },
+            "has_metadata": true,
+          }
+        } />
+    </View>
+  </View>
+</ScrollView>
+`;
+
+exports[`layout works as expected with three tabs 1`] = `
+<ScrollView
+  automaticallyAdjustContentInsets={false}
+  scrollsToTop={true}>
+  <View
+    style={
+      Object {
+        "paddingLeft": 20,
+        "paddingRight": 20,
+      }
+    }>
+    <Header
+      artist={
+        Object {
+          "counts": Object {
+            "artworks": 2,
+            "partner_shows": 1,
+          },
+          "has_metadata": true,
+        }
+      } />
+    <View>
+      <ARSwitchView
+        onSelectionChange={[Function]}
+        selectedIndex={1}
+        style={
+          Object {
+            "alignSelf": null,
+            "marginBottom": 30,
+            "marginTop": 30,
+            "width": null,
+          }
+        }
+        titles={
+          Array [
+            "ABOUT",
+            "WORKS",
+            "SHOWS",
+          ]
+        } />
+      <View>
+        <Artworks
+          artist={
+            Object {
+              "counts": Object {
+                "artworks": 2,
+                "partner_shows": 1,
+              },
+              "has_metadata": true,
+            }
+          } />
+      </View>
+    </View>
+  </View>
+</ScrollView>
+`;

--- a/lib/containers/__tests__/artist-tests.js
+++ b/lib/containers/__tests__/artist-tests.js
@@ -1,0 +1,102 @@
+// @flow
+
+'use strict'
+import 'react-native'
+import React from 'react'
+import renderer from 'react-test-renderer'
+
+import Artist from '../artist'
+
+jest.mock('../../components/artist/shows', () => 'Shows')
+jest.mock('../../components/artist/artworks', () => 'Artworks')
+jest.mock('../../components/artist/header.js', () => 'Header')
+jest.mock('../../components/artist/about.js', () => 'About')
+
+jest.mock('../../components/spinner.js', () => 'ARSpinner')
+jest.mock('../../components/opaque_image_view.js', () => 'AROpaqueImageView')
+jest.mock('../../components/switch_view.js', () => 'ARSwitchView')
+
+describe('availableTabs', () => {
+  it('returns nothing if artist has no metadata, shows, or works', () => {
+    const artist = new Artist()
+    artist.props = artistProps(false)
+    expect(artist.availableTabs()).toEqual([])
+  })
+
+  it('returns About tab if artist has metadata', () => {
+    const artist = new Artist()
+    artist.props = artistProps(true)
+    expect(artist.availableTabs()).toEqual(['ABOUT'])
+  })
+
+  it('returns About tab if artist has articles', () => {
+    const artist = new Artist()
+    artist.props = artistProps(false, {articles: 1})
+    expect(artist.availableTabs()).toEqual(['ABOUT'])
+  })
+
+  it('returns Shows tab if artist has shows', () => {
+    const artist = new Artist()
+    artist.props = artistProps(false, { partner_shows: 2 })
+    expect(artist.availableTabs()).toEqual(['SHOWS'])
+  })
+
+  it('returns Works tab if artist has works', () => {
+    const artist = new Artist()
+    artist.props = artistProps(false, { artworks: 2 })
+    expect(artist.availableTabs()).toEqual(['WORKS'])
+  })
+
+  it('returns all three tabs if artist has metadata, works, and shows', () => {
+    const artist = new Artist()
+    artist.props = artistProps(true, { artworks: 1, partner_shows: 1 })
+    expect(artist.availableTabs()).toEqual(['ABOUT', 'WORKS', 'SHOWS'])
+  })
+})
+
+describe('after rendering', () => {
+  it('mounts with Works tab selected if works exist', () => {
+    const artist = new Artist()
+    artist.props = artistProps(false, { artworks: 5 })
+
+    const worksTabIndex = artist.availableTabs().indexOf('WORKS')
+
+    artist.componentWillMount()
+    expect(artist.state).toEqual({ selectedTabIndex: worksTabIndex })
+  })
+
+  it('mounts at the first tab index if artist has no works', () => {
+    const artist = new Artist()
+    artist.props = artistProps(true, { partner_shows: 1 })
+
+    artist.componentWillMount()
+    expect(artist.state).toEqual({ selectedTabIndex: 0 })
+  })
+})
+
+describe('layout', () => {
+  it('works as expected with no tabs', () => {
+    const artist = renderer.create(<Artist artist={artistProps(false).artist}/>)
+    expect(artist.toJSON()).toMatchSnapshot()
+ })
+
+  it('works as expected with one tab', () => {
+    const artist = renderer.create(<Artist artist={artistProps(true).artist}/>)
+    expect(artist.toJSON()).toMatchSnapshot()
+  })
+
+  it('works as expected with three tabs', () => {
+    const artist = renderer.create(<Artist artist={artistProps(true, { artworks: 2 , partner_shows: 1 }).artist}/>)
+    expect(artist.toJSON()).toMatchSnapshot()
+  })
+})
+
+var artistProps = (has_metadata: boolean, counts?: any) => {
+  if (!counts) { counts = { articles: 0, partner_shows: 0, artworks: 0 } }
+  return {
+    artist: {
+      has_metadata: has_metadata,
+      counts: counts
+    }
+  }
+}


### PR DESCRIPTION
@xtina-starr first emission pr review 🎉 . All it does is add some tests to our Artist view:

![simulator screen shot dec 14 2016 8 26 54 am](https://cloud.githubusercontent.com/assets/2712962/21190587/27fbe318-c1d7-11e6-9cf4-63064340448c.png)


Many of our tests are similar to what you use in force with the exception of snapshots. The snapshots are the [React trees generated by Jest](https://facebook.github.io/jest/blog/2016/07/27/jest-14.html) and they're useful for catching changes in the component. Since these are the first snapshots for the Artist container, they're not really that interesting, but over time the [diffs become more useful](https://github.com/artsy/emission/pull/409/files#diff-b4f897fde7641a36650c3d7e54682bad).
