### PR TITLE
Use node_modules flow in vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,5 +30,6 @@
 
     // Because we use Flow - see https://github.com/flowtype/flow-for-vscode#setup
     "javascript.validate.enable": false,
-    "clang.compilationDatabase": "${workspaceRoot}/Example/compile_commands.json"
+    "clang.compilationDatabase": "${workspaceRoot}/Example/compile_commands.json",
+    "flow.useNPMPackagedFlow": true
 }


### PR DESCRIPTION
I added this setting for us to get a consistent flow working in the vscode extension, sure #18 is happening, but better to get this in until then.