### PR TITLE
Update Dangerfile for noting tests, and stories on a PR

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -1,8 +1,12 @@
+
 import { danger, fail, warn } from "danger"
-import fs from "fs"
 import { compact, includes, remove } from "lodash"
-import os from "os"
-import path from "path"
+
+// For now you can ignore these 3 errors, I'm not sure why
+// they are being raised. They definitely exist in the node runtime.
+import * as fs from "fs"
+import * as os from "os"
+import * as path from "path"
 
 // Setup
 
@@ -16,16 +20,16 @@ const trivialPR = bodyAndTitle.includes("trivial")
 const acceptedNoTests = bodyAndTitle.includes("skip new tests")
 
 // Custom subsets of known files
-const modifiedAppFiles = modified.filter(path => path.includes("lib/"))
-const modifiedTestFiles = modified.filter(path => path.includes("__tests__"))
+const modifiedAppFiles = modified.filter(path => includes(path, "lib/"))
+const modifiedTestFiles = modified.filter(path => includes(path, "__tests__"))
 
 // Modified or Created can be treated the same a lot of the time
 const touchedFiles = modified.concat(danger.git.created_files)
-const touchedAppOnlyFiles = touchedFiles.filter(path => path.includes("src/lib/") && !path.includes("__tests__"))
-const touchedComponents = touchedFiles.filter(path => path.includes("src/lib/components"), !path.includes("__tests__"))
+const touchedAppOnlyFiles = touchedFiles.filter(path => includes(path, "src/lib/") && !includes(path, "__tests__"))
+const touchedComponents = touchedFiles.filter(p => includes(p, "src/lib/components") && !includes(p, "__tests__"))
 
-const touchedTestFiles = touchedFiles.filter(path => path.includes("__tests__"))
-const touchedStoryFiles = touchedFiles.filter(path => path.includes("src/stories"))
+const touchedTestFiles = touchedFiles.filter(path => includes(path, "__tests__"))
+const touchedStoryFiles = touchedFiles.filter(path => includes(path, "src/stories"))
 
 // Rules
 
@@ -36,7 +40,7 @@ if (modifiedAppFiles.length > 0 && !trivialPR && !changelogChanges) {
   fail("No CHANGELOG added.")
 }
 
-// No PR is too small to warrent a paragraph or two of summary
+// No PR is too small to warrant a paragraph or two of summary
 if (pr.body.length === 0) {
   fail("Please add a description to your PR.")
 }
@@ -50,7 +54,7 @@ if (packageChanged && !lockfileChanged) {
   warn(`${message} - <i>${idea}</i>`)
 }
 
-// Always ensure we assign someone, so that our Slackbot can do it's work correctly
+// Always ensure we assign someone, so that our Slackbot can do its work correctly
 if (pr.assignee === null) {
   fail("Please assign someone to merge this PR, and optionally include people who should review.")
 }
@@ -94,7 +98,7 @@ let componentsForFiles = compact(touchedComponents.map(reactComponentForPath))
 const storyFiles = fs.readdirSync("src/stories")
 
 storyFiles.forEach(story => {
-  const content = fs.readFileSync(story)
+  const content = fs.readFileSync("src/stories/" + story)
   componentsForFiles.forEach(component => {
     if (content.includes(component)) {
       componentsForFiles = componentsForFiles.filter(f => f !== component)

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "babel-preset-react-native": "^1.9.1",
     "babel-relay-plugin": "https://github.com/alloy/relay/releases/download/v0.9.3/babel-relay-plugin-0.9.3.tgz",
     "concurrently": "^2.2.0",
-    "danger": "^0.12.1",
+    "danger": "^0.14.1",
     "jest": "^19.0.2",
     "jest-cli": "^18.1.0",
     "jest-fetch-mock": "^1.0.7",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
         "rootDir": "src",
         "outDir": "build",
         "allowJs": true,
+        "pretty": true,
         "moduleResolution": "node",
         "strictNullChecks": false
     },
@@ -15,6 +16,7 @@
         "src/**/*.tsx"
     ],
     "exclude": [
+        "dangerfile.ts",
         "node_modules",
         "Pod/Assets",
         "Example/Build",

--- a/yarn.lock
+++ b/yarn.lock
@@ -58,6 +58,10 @@
     react-modal "^1.2.1"
     redux "^3.5.2"
 
+"@types/chalk@^0.4.31":
+  version "0.4.31"
+  resolved "https://registry.yarnpkg.com/@types/chalk/-/chalk-0.4.31.tgz#a31d74241a6b1edbb973cf36d97a2896834a51f9"
+
 "@types/jest@^19.2.2":
   version "19.2.2"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-19.2.2.tgz#71f428be2fa6eb9f15bb0abc3cade67905f94839"
@@ -1447,21 +1451,28 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-danger@^0.12.1:
-  version "0.12.1"
-  resolved "https://registry.yarnpkg.com/danger/-/danger-0.12.1.tgz#121aeded2d7105fa441d3722e5080c4e94549a2f"
+danger@^0.14.1:
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/danger/-/danger-0.14.1.tgz#6b52ee954d7a5c028c6265ba1cc56746faa1ec95"
   dependencies:
+    "@types/chalk" "^0.4.31"
     babel-polyfill "^6.20.0"
     chalk "^1.1.1"
     commander "^2.9.0"
     debug "^2.6.0"
+    jest-config "^18.0.0"
     jest-environment-node "^18.1.0"
     jest-runtime "^18.0.0"
     jsome "^2.3.25"
+    jsonpointer "^4.0.1"
     lodash.find "^4.6.0"
     lodash.includes "^4.3.0"
+    lodash.isarray "^4.0.0"
+    lodash.isobject "^2.4.1"
+    lodash.keys "^4.0.8"
     node-fetch "^1.6.3"
     parse-diff "^0.4.0"
+    rfc6902 "^1.3.0"
     voca "^1.2.0"
 
 dashdash@^1.12.0:
@@ -2656,7 +2667,7 @@ jest-cli@^19.0.2:
     worker-farm "^1.3.1"
     yargs "^6.3.0"
 
-jest-config@^18.1.0:
+jest-config@^18.0.0, jest-config@^18.1.0:
   version "18.1.0"
   resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-18.1.0.tgz#6111740a6d48aab86ff5a9e6ab0b98bd993b6ff4"
   dependencies:
@@ -3083,7 +3094,7 @@ jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
 
-jsonpointer@^4.0.0:
+jsonpointer@^4.0.0, jsonpointer@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.0.1.tgz#4fd92cb34e0e9db3c89c8622ecf51f9b978c6cb9"
 
@@ -3248,6 +3259,10 @@ lodash._isiterateecall@^3.0.0:
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz#5203ad7ba425fae842460e696db9cf3e6aac057c"
 
+lodash._objecttypes@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz#7c0b7f69d98a1f76529f890b0cdb1b4dfec11c11"
+
 lodash._reescape@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reescape/-/lodash._reescape-3.0.0.tgz#2b1d6f5dfe07c8a355753e5f27fac7f1cde1616a"
@@ -3297,6 +3312,16 @@ lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
 
+lodash.isarray@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-4.0.0.tgz#2aca496b28c4ca6d726715313590c02e6ea34403"
+
+lodash.isobject@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash.isobject/-/lodash.isobject-2.4.1.tgz#5a2e47fe69953f1ee631a7eba1fe64d2d06558f5"
+  dependencies:
+    lodash._objecttypes "~2.4.1"
+
 lodash.keys@^3.0.0, lodash.keys@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-3.1.2.tgz#4dbc0472b156be50a0b286855d1bd0b0c656098a"
@@ -3304,6 +3329,10 @@ lodash.keys@^3.0.0, lodash.keys@^3.1.2:
     lodash._getnative "^3.0.0"
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
+
+lodash.keys@^4.0.8:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-4.2.0.tgz#a08602ac12e4fb83f91fc1fb7a360a4d9ba35205"
 
 lodash.once@^4.0.0:
   version "4.1.1"
@@ -4450,6 +4479,10 @@ restore-cursor@^1.0.1:
   dependencies:
     exit-hook "^1.0.0"
     onetime "^1.0.0"
+
+rfc6902@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/rfc6902/-/rfc6902-1.3.0.tgz#85b2c69c42dcf116082437b9829a962446b4c4a5"
 
 right-align@^0.1.1:
   version "0.1.3"


### PR DESCRIPTION
Adds the following:

* Any touched (new/modified) react components warn if they are not somewhere inside the storybook stories
* Any touched app files fails if there are no corresponding test files (not changes) - you need to specify that you are not writing tests in the PR body/title

---

WIP as I'm not sure it'll compile etc, I did it offline