### PR TITLE
Use a determinate cache folder, which can be cached by Travis in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ Example/Emission/Configuration.h
 typings
 .apphub
 coverage
+
+# Use a custom, cached location for Jest to save transpiling
+# on every PR
+.jest/cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,4 @@ cache:
   yarn: true
   directories:
     - node_modules
+    - .jest/cache

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     ],
     "setupFiles": [
       "./src/setupJest.ts"
-    ]
+    ],
+    "cacheDirectory": ".jest/cache"
   },
   "graphql": {
     "file": "data/schema.json",


### PR DESCRIPTION
Before:

```js
Test Suites: 28 passed, 28 total
Tests:       1 skipped, 53 passed, 54 total
Snapshots:   32 passed, 32 total
Time:        21.435s
```

Second run:

```js
Test Suites: 28 passed, 28 total
Tests:       1 skipped, 53 passed, 54 total
Snapshots:   32 passed, 32 total
Time:        5.293s, estimated 18s
```

I noted in #457 that Tests are slow, and they are when you first run them on a fresh clone. This PR means that we can cache the transpiled Jest test objects.