### PR TITLE
Update fonts for OSS consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Added a Works For You container - sarah
 - Upgrade to RN 0.42-rc.3 - alloy
 - Made Gene view work with new relay-based infinite scroll grid - cab
+- Updated our fonts lib - orta
+- Converted to TypeScript - luc, sarah, alloy, orta
 
 ### 1.2.1
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
     - ISO8601DateFormatter
     - NSURL+QueryDictionary
   - Artsy+UIColors (3.1.0)
-  - Artsy+UIFonts (3.0.0)
+  - Artsy+UIFonts (3.1.0)
   - Artsy-UIButtons (2.1.0):
     - Artsy+UIColors (~> 3.0)
     - Artsy+UIFonts
@@ -109,7 +109,7 @@ SPEC CHECKSUMS:
   ARGenericTableViewController: 61a0897ba66c35111b5d1cc3b44884282bd3c1a5
   Artsy+Authentication: 3bf11ceca61c52e9e31490535bf5798f625406fa
   Artsy+UIColors: 31c03c4146f5e6618a9b950f37dfe02dd9ac09a6
-  Artsy+UIFonts: eb25b56a47550acd70b536f9084cdb34b4f42c3b
+  Artsy+UIFonts: e951d596dad71112f16b475880b6c60904ada608
   Artsy-UIButtons: cdcc3ccf4d0d31ee80f45c1d11ffd2d772695b74
   Emission: d3a2a12e1a953cdf9605d0d4bbf028680a40b199
   Extraction: 612cf0866f74d4c0dd616677ff24146efa200958


### PR DESCRIPTION
No changes from artsy-dev side, updates it with https://github.com/artsy/Artsy-OSSUIFonts/pull/10 and https://github.com/artsy/Artsy-OSSUIFonts/pull/9

![screen shot 2017-03-23 at 14 09 20](https://cloud.githubusercontent.com/assets/49038/24251584/874b5dd2-0fd2-11e7-879f-b7b862b774aa.png)