### PR TITLE
[Home] Move active bids module to the top of the feed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Updated our fonts lib - orta
 - Converted to TypeScript - luc, sarah, alloy, orta
 
+### 1.2.2
+
+- Move active bids home module to the top of the feed - alloy
+
 ### 1.2.1
 
 - Build with correct react-native version - alloy

--- a/src/lib/containers/home.tsx
+++ b/src/lib/containers/home.tsx
@@ -111,6 +111,7 @@ export default Relay.createContainer(Home, {
         artwork_modules(max_rails: -1,
                         max_followed_gene_rails: -1,
                         order: [
+                          ACTIVE_BIDS,
                           RECOMMENDED_WORKS,
                           FOLLOWED_ARTISTS,
                           RELATED_ARTISTS,


### PR DESCRIPTION
Same as #466, but this merges what went into [the 1.2.2 release](https://github.com/artsy/emission/tree/v1.2.2) back into master.

Related to https://github.com/artsy/eigen/issues/2237