### PR TITLE
[Dev] Adds an API call to ensure authentication is valid on launch

### DIFF
--- a/Example/Emission/AppDelegate.m
+++ b/Example/Emission/AppDelegate.m
@@ -70,7 +70,15 @@ randomBOOL(void)
   if ([auth isAuthenticated]) {
     NSString *accessToken = [auth token];
     if (accessToken) {
-      [self setupEmissionWithUserID:[auth userID] accessToken:accessToken keychainService:service];
+
+      [auth validateStoredCredentialsPassing:^{
+        [self setupEmissionWithUserID:[auth userID] accessToken:accessToken keychainService:service];
+      } failing:^{
+        [auth presentAuthenticationPromptOnViewController:rootVC completion:^{
+          NSLog(@"Logged in successfully :)");
+          [self setupEmissionWithUserID:[auth userID] accessToken:[auth token] keychainService:service];
+        }];
+      }];
     }
   } else {
     [auth presentAuthenticationPromptOnViewController:rootVC completion:^{

--- a/Example/Emission/AuthenticationManager.h
+++ b/Example/Emission/AuthenticationManager.h
@@ -10,6 +10,8 @@
 
 - (void)presentAuthenticationPromptOnViewController:(UIViewController *)viewController completion:(dispatch_block_t)completion;
 
+- (void)validateStoredCredentialsPassing:(dispatch_block_t)pass failing:(dispatch_block_t)fail;
+
 /// Is there a userID & token?
 @property (readonly) BOOL isAuthenticated;
 


### PR DESCRIPTION
Sibling PR to #522 - it's an alternative, or it can enhance. 

When the debugging app launches, it makes a call for the user's profile. If that API request passes because authorisation is 👍 then it will let you into the app. If it doesn't, then it will present the setup interface.