### PR TITLE
Adds bid information for artworks in sale.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [dev] Updates TypeScript to 2.3 - orta
 - [dev] Adds back storybooks - orta
 - [dev] Automates TS linting at dev time - orta
+- Adds inline bid info to artist grid elements - ash
 
 ### 1.3.2
 

--- a/src/lib/components/artwork_grids/__tests__/__snapshots__/artwork-tests.tsx.snap
+++ b/src/lib/components/artwork_grids/__tests__/__snapshots__/artwork-tests.tsx.snap
@@ -1,5 +1,335 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`in a sale renders with current bid 1`] = `
+<View
+  accessibilityComponentType={undefined}
+  accessibilityLabel={undefined}
+  accessibilityTraits={undefined}
+  accessible={true}
+  hitSlop={undefined}
+  onLayout={undefined}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={undefined}
+  testID={undefined}
+>
+  <AROpaqueImageView
+    aspectRatio={0.74}
+    imageURL="artsy.net/image-url"
+    style={
+      Object {
+        "marginBottom": 10,
+      }
+    }
+  />
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    numberOfLines={1}
+    style={
+      Array [
+        Object {
+          "fontSize": 17,
+        },
+        Array [
+          Object {
+            "color": "#666666",
+            "fontSize": 12,
+          },
+          Object {
+            "fontWeight": "bold",
+          },
+        ],
+        Object {
+          "fontFamily": "AGaramondPro-Regular",
+        },
+      ]
+    }
+  >
+    Mikael Olson
+  </Text>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    numberOfLines={1}
+    style={
+      Array [
+        Object {
+          "fontSize": 17,
+        },
+        Object {
+          "color": "#666666",
+          "fontSize": 12,
+        },
+        Object {
+          "fontFamily": "AGaramondPro-Regular",
+        },
+      ]
+    }
+  >
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      numberOfLines={1}
+      style={
+        Array [
+          Object {
+            "fontSize": 17,
+          },
+          Array [
+            Object {
+              "color": "#666666",
+              "fontSize": 12,
+            },
+            Object {
+              "fontStyle": "italic",
+            },
+          ],
+          Object {
+            "fontFamily": "AGaramondPro-Regular",
+          },
+        ]
+      }
+    >
+      Some Kind of Dinosaur
+    </Text>
+    , 2015
+  </Text>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    numberOfLines={1}
+    style={
+      Array [
+        Object {
+          "fontSize": 17,
+        },
+        Object {
+          "color": "#666666",
+          "fontSize": 12,
+        },
+        Object {
+          "fontFamily": "AGaramondPro-Regular",
+        },
+      ]
+    }
+  >
+    Gallery 1261
+  </Text>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+      }
+    }
+  >
+    <Image
+      source={1}
+      style={
+        Object {
+          "marginRight": 4,
+        }
+      }
+    />
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      numberOfLines={1}
+      style={
+        Array [
+          Object {
+            "fontSize": 17,
+          },
+          Object {
+            "color": "#666666",
+            "fontSize": 12,
+          },
+          Object {
+            "fontFamily": "AGaramondPro-Regular",
+          },
+        ]
+      }
+    >
+      $200 (1 bid)
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`in a sale renders with starting bid 1`] = `
+<View
+  accessibilityComponentType={undefined}
+  accessibilityLabel={undefined}
+  accessibilityTraits={undefined}
+  accessible={true}
+  hitSlop={undefined}
+  onLayout={undefined}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={undefined}
+  testID={undefined}
+>
+  <AROpaqueImageView
+    aspectRatio={0.74}
+    imageURL="artsy.net/image-url"
+    style={
+      Object {
+        "marginBottom": 10,
+      }
+    }
+  />
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    numberOfLines={1}
+    style={
+      Array [
+        Object {
+          "fontSize": 17,
+        },
+        Array [
+          Object {
+            "color": "#666666",
+            "fontSize": 12,
+          },
+          Object {
+            "fontWeight": "bold",
+          },
+        ],
+        Object {
+          "fontFamily": "AGaramondPro-Regular",
+        },
+      ]
+    }
+  >
+    Mikael Olson
+  </Text>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    numberOfLines={1}
+    style={
+      Array [
+        Object {
+          "fontSize": 17,
+        },
+        Object {
+          "color": "#666666",
+          "fontSize": 12,
+        },
+        Object {
+          "fontFamily": "AGaramondPro-Regular",
+        },
+      ]
+    }
+  >
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      numberOfLines={1}
+      style={
+        Array [
+          Object {
+            "fontSize": 17,
+          },
+          Array [
+            Object {
+              "color": "#666666",
+              "fontSize": 12,
+            },
+            Object {
+              "fontStyle": "italic",
+            },
+          ],
+          Object {
+            "fontFamily": "AGaramondPro-Regular",
+          },
+        ]
+      }
+    >
+      Some Kind of Dinosaur
+    </Text>
+    , 2015
+  </Text>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    numberOfLines={1}
+    style={
+      Array [
+        Object {
+          "fontSize": 17,
+        },
+        Object {
+          "color": "#666666",
+          "fontSize": 12,
+        },
+        Object {
+          "fontFamily": "AGaramondPro-Regular",
+        },
+      ]
+    }
+  >
+    Gallery 1261
+  </Text>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+      }
+    }
+  >
+    <Image
+      source={1}
+      style={
+        Object {
+          "marginRight": 4,
+        }
+      }
+    />
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      numberOfLines={1}
+      style={
+        Array [
+          Object {
+            "fontSize": 17,
+          },
+          Object {
+            "color": "#666666",
+            "fontSize": 12,
+          },
+          Object {
+            "fontFamily": "AGaramondPro-Regular",
+          },
+        ]
+      }
+    >
+      $100
+    </Text>
+  </View>
+</View>
+`;
+
 exports[`renders properly 1`] = `
 <View
   accessibilityComponentType={undefined}

--- a/src/lib/components/artwork_grids/__tests__/artwork-tests.tsx
+++ b/src/lib/components/artwork_grids/__tests__/artwork-tests.tsx
@@ -11,6 +11,7 @@ it("renders properly", () => {
     date: "2015",
     sale_message: "$875",
     is_in_auction: false,
+    sale_artwork: null,
     image: {
       url: "artsy.net/image-url",
       aspect_ratio: 0.74,

--- a/src/lib/components/artwork_grids/__tests__/artwork-tests.tsx
+++ b/src/lib/components/artwork_grids/__tests__/artwork-tests.tsx
@@ -6,12 +6,39 @@ import * as renderer from "react-test-renderer"
 import Artwork from "../artwork"
 
 it("renders properly", () => {
-  const artworkProps = {
+  const artwork = renderer.create(<Artwork artwork={artworkProps()} />).toJSON()
+  expect(artwork).toMatchSnapshot()
+})
+
+describe("in a sale", () => {
+  it("renders with starting bid", () => {
+    const saleArtwork = {
+      opening_bid: { display: "$100" },
+      current_bid: null,
+      bidder_positions_count: 0,
+    }
+    const artwork = renderer.create(<Artwork artwork={artworkProps(saleArtwork)} />).toJSON()
+    expect(artwork).toMatchSnapshot()
+  })
+
+  it("renders with current bid", () => {
+    const saleArtwork = {
+      opening_bid: { display: "$100" },
+      current_bid: { display: "$200" },
+      bidder_positions_count: 1,
+    }
+    const artwork = renderer.create(<Artwork artwork={artworkProps(saleArtwork)} />).toJSON()
+    expect(artwork).toMatchSnapshot()
+  })
+})
+
+let artworkProps = (saleArtwork = null) => {
+  return {
     title: "Some Kind of Dinosaur",
     date: "2015",
     sale_message: "$875",
-    is_in_auction: false,
-    sale_artwork: null,
+    is_in_auction: (saleArtwork !== null),
+    sale_artwork: saleArtwork,
     image: {
       url: "artsy.net/image-url",
       aspect_ratio: 0.74,
@@ -26,7 +53,4 @@ it("renders properly", () => {
     },
     href: "/artwork/mikael-olson-some-kind-of-dinosaur",
   }
-
-  const artwork = renderer.create(<Artwork artwork={artworkProps} />).toJSON()
-  expect(artwork).toMatchSnapshot()
-})
+}

--- a/src/lib/components/artwork_grids/artwork.tsx
+++ b/src/lib/components/artwork_grids/artwork.tsx
@@ -59,10 +59,15 @@ class Artwork extends React.Component<RelayProps, any> {
   saleMessage() {
     const artwork = this.props.artwork
     if (artwork.is_in_auction) {
+      const numberOfBids = artwork.sale_artwork.bidder_positions_count
+      let text = artwork.sale_artwork.opening_bid.display
+      if (numberOfBids > 0 ) {
+        text = `${artwork.sale_artwork.current_bid.display} (${numberOfBids} bid${numberOfBids === 1 ? "" : "s"})`
+      }
       return (
         <View style={{flexDirection: "row"}}>
           <Image style={{ marginRight: 4 }} source={require("../../../../images/paddle.png")} />
-          <SerifText style={styles.text}>Bid now</SerifText>
+          <SerifText style={styles.text}>{text}</SerifText>
         </View>
       )
     } else {
@@ -95,6 +100,11 @@ export default Relay.createContainer(Artwork, {
         date
         sale_message
         is_in_auction
+        sale_artwork {
+          opening_bid { display }
+          current_bid { display }
+          bidder_positions_count
+        }
         image {
           url(version: "large")
           aspect_ratio

--- a/src/lib/components/artwork_grids/artwork.tsx
+++ b/src/lib/components/artwork_grids/artwork.tsx
@@ -127,6 +127,15 @@ interface RelayProps {
     date: string | null,
     sale_message: string | null,
     is_in_auction: boolean | null,
+    sale_artwork: {
+      opening_bid: {
+        display: string | null,
+      } | null,
+      current_bid: {
+        display: string | null,
+      } | null,
+      bidder_positions_count: number | null,
+    } | null,
     image: {
       url: string | null,
       aspect_ratio: number | null,


### PR DESCRIPTION
Adds bid info for artworks in a sale. Here's a screenshot:

![screen shot 2017-05-09 at 5 48 38 pm](https://cloud.githubusercontent.com/assets/498212/25874269/c47cdf50-34df-11e7-8f96-5a2f23832f15.png)

Fixes https://github.com/artsy/emission/issues/487 .

<details>
<summary>The pre-push hook was giving me trouble but I wanted to get this up so I can access it on other machines. I'll take a look at the error tomorrow.</summary>

```
Found '/Users/ash/bin/emission/.nvmrc' with version <6.9>
N/A: version "6.9 -> N/A" is not yet installed.

You need to run "nvm install 6.9" to install it before using it.
Found '/Users/ash/bin/emission/.nvmrc' with version <6.9>
N/A: version "6.9 -> N/A" is not yet installed.

You need to run "nvm install 6.9" to install it before using it.

> husky - npm run -s prepush

yarn run v0.21.3
$ tsc --noEmit --pretty

62       const numberOfBids = artwork.sale_artwork.bidder_positions_count
                                      ~~~~~~~~~~~~

src/lib/components/artwork_grids/artwork.tsx(62,36): error TS2339: Property 'sale_artwork' does not exist on type '{ title: string; date: string; sale_message: string; is_in_auction: boolean; image: { url: string...'.


63       let text = artwork.sale_artwork.opening_bid.display
                            ~~~~~~~~~~~~

src/lib/components/artwork_grids/artwork.tsx(63,26): error TS2339: Property 'sale_artwork' does not exist on type '{ title: string; date: string; sale_message: string; is_in_auction: boolean; image: { url: string...'.


65         text = `${artwork.sale_artwork.current_bid.display} (${numberOfBids} bid${numberOfBids === 1 ? "" : "s"})`
                             ~~~~~~~~~~~~

src/lib/components/artwork_grids/artwork.tsx(65,27): error TS2339: Property 'sale_artwork' does not exist on type '{ title: string; date: string; sale_message: string; is_in_auction: boolean; image: { url: string...'.

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

> husky - pre-push hook failed (add --no-verify to bypass)
> husky - to debug, use 'npm run prepush'
error: failed to push some refs to 'https://github.com/artsy/emission.git'
```
</details>