### PR TITLE
[Dev] Use match's Emission profiles for signing.

### DIFF
--- a/Example/Emission.xcodeproj/project.pbxproj
+++ b/Example/Emission.xcodeproj/project.pbxproj
@@ -395,6 +395,7 @@
 					510DCB0D1CCA69EC0075E8CB = {
 						CreatedOnToolsVersion = 7.2.1;
 						DevelopmentTeam = 23KMWZ572J;
+						ProvisioningStyle = Manual;
 						SystemCapabilities = {
 							com.apple.Keychain = {
 								enabled = 1;
@@ -700,6 +701,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CC = "${SRCROOT}/compile_commands_emitting_clang";
 				CODE_SIGN_ENTITLEMENTS = Emission/Emission.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = 23KMWZ572J;
 				GCC_WARN_PEDANTIC = YES;
@@ -712,7 +714,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = net.artsy.Emission;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE = "23767ec5-72d8-401e-9dfd-e58dba5920e7";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore net.artsy.Emission";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -724,6 +727,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CC = "${SRCROOT}/compile_commands_emitting_clang";
 				CODE_SIGN_ENTITLEMENTS = Emission/Emission.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				DEVELOPMENT_TEAM = 23KMWZ572J;
 				GCC_WARN_PEDANTIC = YES;
 				INFOPLIST_FILE = Emission/Info.plist;
@@ -735,7 +739,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = net.artsy.Emission;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE = "23767ec5-72d8-401e-9dfd-e58dba5920e7";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore net.artsy.Emission";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -853,7 +858,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = net.artsy.Emission;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE = "23767ec5-72d8-401e-9dfd-e58dba5920e7";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore net.artsy.Emission";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Deploy;


### PR DESCRIPTION
This converts the code-signing to use [fastlane match](https://artsy.github.io/blog/2017/04/05/what-is-fastlane-match/) so that the build can be deployed via https://github.com/artsy/emission-nebula/pull/1

Self-merging as it shouldn't affect devs working day to day.