### PR TITLE
Fixes display of artworks in non-expanding grids in artwork rails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Adds initial work on a new personal profile page - orta
 - [dev] Automates TS linting at dev time - orta
 - Adds inline bid info to artist grid elements - ash
+- Fixes display of artworks in non-expanding grids in artwork rails - ash
 
 ### 1.3.2
 

--- a/src/lib/components/home/artwork_rails/artwork_rail.tsx
+++ b/src/lib/components/home/artwork_rails/artwork_rail.tsx
@@ -122,7 +122,10 @@ class ArtworkRail extends React.Component<Props & RelayPropsWorkaround, State> {
   }
 
   onGridLayout(event) {
-    this.setState({ gridHeight: event.nativeEvent.layout.height })
+    let { height } = event.nativeEvent.layout
+    // Non-expandable rails require a non-zero height for an initial render pass,
+    // So that we can rely on their subsequent, accurate calls to this function.
+    this.setState({ gridHeight: height > 0 ? height : 1 })
   }
 
   expandable() {


### PR DESCRIPTION
A repeat of https://github.com/artsy/emission/pull/469 which was merged into a 1.2.3 release (that was never merged into master). Fixes #528. Skip New Tests.