### PR TITLE
Adds Sentry for React Native

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [dev] Automates TS linting at dev time - orta
 - Adds inline bid info to artist grid elements - ash
 - Fixes display of artworks in non-expanding grids in artwork rails - ash
+- Adds Sentry for React Native which integrates with Eigen’s use of Sentry - alloy
 
 ### 1.3.2
 

--- a/Emission.podspec
+++ b/Emission.podspec
@@ -22,15 +22,18 @@ Pod::Spec.new do |s|
   s.source_files   = 'Pod/Classes/**/*.{h,m}'
   s.resources      = 'Pod/Assets/{Emission.js,assets}'
 
-  # Artsy pods
   s.dependency 'Artsy+UIFonts', '>= 3.0.0'
   s.dependency 'Extraction', '>= 1.2.1'
 
-  # 3rd-party pods
-  s.dependency 'SDWebImage', '>= 3.7.2'
   s.dependency 'Yoga', "#{react_native_version}.React"
   s.dependency 'React/Core', react_native_version
   s.dependency 'React/RCTText', react_native_version
   s.dependency 'React/RCTImage', react_native_version
   s.dependency 'React/RCTNetwork', react_native_version
+
+  s.dependency 'SDWebImage', '>= 3.7.2'
+  # This needs to be locked down because we’re including this specific version’s JS in our bundle, so it needs to match
+  # with the SentryReactNative version that CocoaPods would pull into Eigen.
+  s.dependency 'SentryReactNative', '0.8.1'
+  s.dependency 'Sentry', '>= 2.1.9' # This is for until SentryReactNative specifies the right minimum version.
 end

--- a/Example/Emission.xcodeproj/project.pbxproj
+++ b/Example/Emission.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1566AC3870F7D54FFA2421F9 /* Pods_EmissionTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FE795C7671E7B1D3ABE5E701 /* Pods_EmissionTests.framework */; };
 		510DCB121CCA69EC0075E8CB /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 510DCB111CCA69EC0075E8CB /* main.m */; };
 		510DCB151CCA69EC0075E8CB /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 510DCB141CCA69EC0075E8CB /* AppDelegate.m */; };
 		510DCB1D1CCA69EC0075E8CB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 510DCB1C1CCA69EC0075E8CB /* Assets.xcassets */; };
@@ -28,8 +29,7 @@
 		60A1A7801DA3A23C005E3357 /* BackArrowBlack@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 60A1A77D1DA3A23C005E3357 /* BackArrowBlack@2x.png */; };
 		60B743B71D3EB12600E6B2A3 /* ARStorybookComponentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 60B743B61D3EB12600E6B2A3 /* ARStorybookComponentViewController.m */; };
 		60F61A8B1DAF982B00A72101 /* AuthenticationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 60F61A8A1DAF982B00A72101 /* AuthenticationManager.m */; };
-		624581405B61C939EAE4A655 /* libPods-Emission.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E978F1FD602B34E9DAFC814 /* libPods-Emission.a */; };
-		BFFC3EFE98AA73E0F8D0C036 /* libPods-EmissionTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9D1A12CD073216EBD0EEF727 /* libPods-EmissionTests.a */; };
+		F67E525D8D9365584567DB3C /* Pods_Emission.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3284CF8C4778739FA0B7F1EB /* Pods_Emission.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -51,8 +51,8 @@
 
 /* Begin PBXFileReference section */
 		186D8F421D3B6F269A41D65F /* Pods-EmissionTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-EmissionTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-EmissionTests/Pods-EmissionTests.release.xcconfig"; sourceTree = "<group>"; };
+		3284CF8C4778739FA0B7F1EB /* Pods_Emission.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Emission.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3CA8129D4B3357E4EDA54CF0 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
-		3E978F1FD602B34E9DAFC814 /* libPods-Emission.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Emission.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		40768F1EE5F58B77D2C7E598 /* Pods_Emission_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Emission_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		510DCB0E1CCA69EC0075E8CB /* Emission.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Emission.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		510DCB111CCA69EC0075E8CB /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
@@ -98,12 +98,12 @@
 		7F3A1FEFE0AEAB158547A0BB /* Pods-Emission.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Emission.release.xcconfig"; path = "Pods/Target Support Files/Pods-Emission/Pods-Emission.release.xcconfig"; sourceTree = "<group>"; };
 		822BF881E9F1716840710C01 /* Pods-Emission.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Emission.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Emission/Pods-Emission.debug.xcconfig"; sourceTree = "<group>"; };
 		8AE50579AAAEFF0316B49796 /* Pods_Emission_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Emission_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		9D1A12CD073216EBD0EEF727 /* libPods-EmissionTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-EmissionTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A9EDBCE5F6E1D1A6CEA0264A /* Pods-Emission.deploy.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Emission.deploy.xcconfig"; path = "Pods/Target Support Files/Pods-Emission/Pods-Emission.deploy.xcconfig"; sourceTree = "<group>"; };
 		BD6A42932C7B5D57AE022D1A /* Emission.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Emission.podspec; path = ../Emission.podspec; sourceTree = "<group>"; };
 		DB1BB078CB1708CE8106DA15 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		E8B24D636FF40683E534C17A /* Pods-EmissionTests.deploy.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-EmissionTests.deploy.xcconfig"; path = "Pods/Target Support Files/Pods-EmissionTests/Pods-EmissionTests.deploy.xcconfig"; sourceTree = "<group>"; };
 		EC7AE6B33EE1261C1E96D2FC /* Pods-EmissionTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-EmissionTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-EmissionTests/Pods-EmissionTests.debug.xcconfig"; sourceTree = "<group>"; };
+		FE795C7671E7B1D3ABE5E701 /* Pods_EmissionTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_EmissionTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -111,7 +111,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				624581405B61C939EAE4A655 /* libPods-Emission.a in Frameworks */,
+				F67E525D8D9365584567DB3C /* Pods_Emission.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -119,7 +119,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BFFC3EFE98AA73E0F8D0C036 /* libPods-EmissionTests.a in Frameworks */,
+				1566AC3870F7D54FFA2421F9 /* Pods_EmissionTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -296,8 +296,8 @@
 			children = (
 				8AE50579AAAEFF0316B49796 /* Pods_Emission_Example.framework */,
 				40768F1EE5F58B77D2C7E598 /* Pods_Emission_Tests.framework */,
-				3E978F1FD602B34E9DAFC814 /* libPods-Emission.a */,
-				9D1A12CD073216EBD0EEF727 /* libPods-EmissionTests.a */,
+				3284CF8C4778739FA0B7F1EB /* Pods_Emission.framework */,
+				FE795C7671E7B1D3ABE5E701 /* Pods_EmissionTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/Example/Emission/ARAdminTableViewCell.m
+++ b/Example/Emission/ARAdminTableViewCell.m
@@ -1,6 +1,6 @@
 #import "ARAdminTableViewCell.h"
-#import <Artsy+UIFonts/UIFont+ArtsyFonts.h>
-#import <Artsy+UIColors/UIColor+ArtsyColors.h>
+#import <Artsy_UIFonts/UIFont+ArtsyFonts.h>
+#import <Artsy_UIColors/UIColor+ArtsyColors.h>
 
 CGFloat ARTableViewCellSettingsHeight = 60;
 

--- a/Example/Emission/ARAnimatedTickView.m
+++ b/Example/Emission/ARAnimatedTickView.m
@@ -1,5 +1,5 @@
 #import "ARAnimatedTickView.h"
-#import <Artsy+UIColors/UIColor+ArtsyColors.h>
+#import <Artsy_UIColors/UIColor+ArtsyColors.h>
 
 #define TICK_DIMENSION 32
 

--- a/Example/Emission/AppDelegate.m
+++ b/Example/Emission/AppDelegate.m
@@ -100,7 +100,8 @@ randomBOOL(void)
   emission = [[AREmission alloc] initWithUserID:userID
                             authenticationToken:accessToken
                                     packagerURL:packagerURL
-                          useStagingEnvironment:useStaging];
+                          useStagingEnvironment:useStaging
+                                      sentryDSN:nil];
 #else
 #ifdef DEPLOY
   AHBuild *build = [[AppHub buildManager] currentBuild];

--- a/Example/Emission/AuthenticationManager.m
+++ b/Example/Emission/AuthenticationManager.m
@@ -4,9 +4,9 @@
 #import <Extraction/ARSpinner.h>
 #import <SAMKeychain/SAMKeychain.h>
 
-#import <Artsy+Authentication/ArtsyAuthentication.h>
-#import <Artsy+Authentication/ArtsyAuthenticationRouter.h>
-#import <Artsy+Authentication/ArtsyToken.h>
+#import <Artsy_Authentication/ArtsyAuthentication.h>
+#import <Artsy_Authentication/ArtsyAuthenticationRouter.h>
+#import <Artsy_Authentication/ArtsyToken.h>
 
 @interface AuthenticationManager()
 @property (nonatomic, strong) UIViewController *authenticationSpinnerController;

--- a/Example/Emission/EigenLikeAdminViewController.m
+++ b/Example/Emission/EigenLikeAdminViewController.m
@@ -1,5 +1,5 @@
 #import "EigenLikeAdminViewController.h"
-#import <Artsy+UIFonts/UIFont+ArtsyFonts.h>
+#import <Artsy_UIFonts/UIFont+ArtsyFonts.h>
 
 NSString *const AROptionCell = @"OptionCell";
 NSString *const ARLabOptionCell = @"LabOptionCell";

--- a/Example/Emission/UnroutedViewController.m
+++ b/Example/Emission/UnroutedViewController.m
@@ -1,5 +1,5 @@
 #import "UnroutedViewController.h"
-#import <Artsy+UIFonts/UIFont+ArtsyFonts.h>
+#import <Artsy_UIFonts/UIFont+ArtsyFonts.h>
 #import <FLKAutoLayout/FLKAutoLayout.h>
 
 @interface UnroutedViewController()

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -2,6 +2,7 @@ source 'https://github.com/artsy/Specs.git'
 source 'https://github.com/CocoaPods/Specs.git'
 
 platform :ios, '9.0'
+use_frameworks!
 # FIXME: Figure out why we are getting hit by this issue.
 install! 'cocoapods', :deterministic_uuids => false
 

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -6,8 +6,10 @@ use_frameworks!
 # FIXME: Figure out why we are getting hit by this issue.
 install! 'cocoapods', :deterministic_uuids => false
 
-react_path = '../node_modules/react-native'
+node_modules_path = '../node_modules'
+react_path = File.join(node_modules_path, 'react-native')
 yoga_path = File.join(react_path, 'ReactCommon/yoga')
+sentry_path = File.join(node_modules_path, 'react-native-sentry')
 
 target 'Emission' do
   pod 'Emission', :path => '../'
@@ -15,6 +17,8 @@ target 'Emission' do
   # As this runs dev, we need the developer web socket
   pod 'React', :path => react_path, :subspecs => %w(RCTWebSocket)
   pod 'Yoga', :path => yoga_path
+
+  pod 'SentryReactNative', :path => sentry_path
 
   # Got to make it look right
   pod 'Artsy+UIFonts'
@@ -43,5 +47,12 @@ target 'Emission' do
 
     pod 'Specta'
     # pod 'Expecta'
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.build_configurations.each do |config|
+    config.build_settings['SWIFT_VERSION'] = '3.0'
+    config.build_settings['ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES'] = 'YES'
   end
 end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -19,6 +19,8 @@ PODS:
     - React/RCTNetwork (= 0.42.0)
     - React/RCTText (= 0.42.0)
     - SDWebImage (>= 3.7.2)
+    - Sentry (>= 2.1.9)
+    - SentryReactNative (= 0.8.1)
     - Yoga (= 0.42.0.React)
   - Extraction (1.2.3):
     - Extraction/ARAnimationContinuation (= 1.2.3)
@@ -45,6 +47,69 @@ PODS:
     - Extraction/ARAnimationContinuation
   - FLKAutoLayout (1.0.0)
   - ISO8601DateFormatter (0.8)
+  - KSCrash (1.15.8):
+    - KSCrash/Installations (= 1.15.8)
+  - KSCrash/Installations (1.15.8):
+    - KSCrash/Recording
+    - KSCrash/Reporting
+  - KSCrash/Recording (1.15.8):
+    - KSCrash/Recording/Tools (= 1.15.8)
+  - KSCrash/Recording/Tools (1.15.8)
+  - KSCrash/Reporting (1.15.8):
+    - KSCrash/Recording
+    - KSCrash/Reporting/Filters (= 1.15.8)
+    - KSCrash/Reporting/MessageUI (= 1.15.8)
+    - KSCrash/Reporting/Sinks (= 1.15.8)
+    - KSCrash/Reporting/Tools (= 1.15.8)
+  - KSCrash/Reporting/Filters (1.15.8):
+    - KSCrash/Recording
+    - KSCrash/Reporting/Filters/Alert (= 1.15.8)
+    - KSCrash/Reporting/Filters/AppleFmt (= 1.15.8)
+    - KSCrash/Reporting/Filters/Base (= 1.15.8)
+    - KSCrash/Reporting/Filters/Basic (= 1.15.8)
+    - KSCrash/Reporting/Filters/GZip (= 1.15.8)
+    - KSCrash/Reporting/Filters/JSON (= 1.15.8)
+    - KSCrash/Reporting/Filters/Sets (= 1.15.8)
+    - KSCrash/Reporting/Filters/Stringify (= 1.15.8)
+    - KSCrash/Reporting/Filters/Tools (= 1.15.8)
+  - KSCrash/Reporting/Filters/Alert (1.15.8):
+    - KSCrash/Recording
+    - KSCrash/Reporting/Filters/Base
+  - KSCrash/Reporting/Filters/AppleFmt (1.15.8):
+    - KSCrash/Recording
+    - KSCrash/Reporting/Filters/Base
+  - KSCrash/Reporting/Filters/Base (1.15.8):
+    - KSCrash/Recording
+  - KSCrash/Reporting/Filters/Basic (1.15.8):
+    - KSCrash/Recording
+    - KSCrash/Reporting/Filters/Base
+  - KSCrash/Reporting/Filters/GZip (1.15.8):
+    - KSCrash/Recording
+    - KSCrash/Reporting/Filters/Base
+  - KSCrash/Reporting/Filters/JSON (1.15.8):
+    - KSCrash/Recording
+    - KSCrash/Reporting/Filters/Base
+  - KSCrash/Reporting/Filters/Sets (1.15.8):
+    - KSCrash/Recording
+    - KSCrash/Reporting/Filters/AppleFmt
+    - KSCrash/Reporting/Filters/Base
+    - KSCrash/Reporting/Filters/Basic
+    - KSCrash/Reporting/Filters/GZip
+    - KSCrash/Reporting/Filters/JSON
+    - KSCrash/Reporting/Filters/Stringify
+  - KSCrash/Reporting/Filters/Stringify (1.15.8):
+    - KSCrash/Recording
+    - KSCrash/Reporting/Filters/Base
+  - KSCrash/Reporting/Filters/Tools (1.15.8):
+    - KSCrash/Recording
+  - KSCrash/Reporting/MessageUI (1.15.8):
+    - KSCrash/Recording
+  - KSCrash/Reporting/Sinks (1.15.8):
+    - KSCrash/Recording
+    - KSCrash/Reporting/Filters
+    - KSCrash/Reporting/Tools
+  - KSCrash/Reporting/Tools (1.15.8):
+    - KSCrash/Recording
   - NSURL+QueryDictionary (1.2.0)
   - ORStackView (2.0.3):
     - FLKAutoLayout
@@ -67,10 +132,17 @@ PODS:
     - React/Core
   - React/RCTWebSocket (0.42.0):
     - React/Core
+  - RSSwizzle (0.1.0)
   - SAMKeychain (1.5.0)
   - SDWebImage (3.7.5):
     - SDWebImage/Core (= 3.7.5)
   - SDWebImage/Core (3.7.5)
+  - Sentry (2.1.9):
+    - KSCrash (~> 1.15.5)
+  - SentryReactNative (0.8.1):
+    - React
+    - RSSwizzle (~> 0.1.0)
+    - Sentry (~> 2.1.9)
   - Specta (1.0.5)
   - UIView+BooleanAnimations (1.0.2)
   - Yoga (0.42.0.React)
@@ -85,6 +157,7 @@ DEPENDENCIES:
   - React/RCTTest (from `../node_modules/react-native`)
   - React/RCTWebSocket (from `../node_modules/react-native`)
   - SAMKeychain
+  - SentryReactNative (from `../node_modules/react-native-sentry`)
   - Specta
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
@@ -96,6 +169,8 @@ EXTERNAL SOURCES:
     :path: "../"
   React:
     :path: "../node_modules/react-native"
+  SentryReactNative:
+    :path: "../node_modules/react-native-sentry"
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
@@ -111,19 +186,23 @@ SPEC CHECKSUMS:
   Artsy+UIColors: 31c03c4146f5e6618a9b950f37dfe02dd9ac09a6
   Artsy+UIFonts: e66afb5c40100e2fc5bba28feb7487e252f2d06f
   Artsy-UIButtons: cdcc3ccf4d0d31ee80f45c1d11ffd2d772695b74
-  Emission: 8f3738a955654eac6f4a038190d2f8993ee08436
+  Emission: 8d3cbe01e1173420adbe3c18389a409cde8d3719
   Extraction: 612cf0866f74d4c0dd616677ff24146efa200958
   FLKAutoLayout: 106b14dbae09d32c6730190f4e78a959759ba4a4
   ISO8601DateFormatter: 4551b6ce4f83185425f583b0b3feb3c7b59b942c
+  KSCrash: 4acb0f9cdb0b1ce7155c608dc175d91d750a8c3a
   NSURL+QueryDictionary: bae616404e2adf6409d3d5c02a093cbf44c8a236
   ORStackView: b9507271cb41fb9e0b3eecc6414d831201e7cf7c
   React: 8ec97f0d79ba31892c526cf56425937926cc9b48
+  RSSwizzle: d561958f595028bfcef98c7d55c318b3878a61c6
   SAMKeychain: 1fc9ae02f576365395758b12888c84704eebc423
   SDWebImage: 69c6303e3348fba97e03f65d65d4fbc26740f461
+  Sentry: 0025c374b2f9fb0da8185a45199de985408a40b2
+  SentryReactNative: be48c493b658b556c64006c330ae2333de399e6e
   Specta: ac94d110b865115fe60ff2c6d7281053c6f8e8a2
   UIView+BooleanAnimations: a760be9a066036e55f298b7b7350a6cb14cfcd97
   Yoga: 4183cc70cae189d73f996b1e40c3078aca9f96ef
 
-PODFILE CHECKSUM: 990bd33b5f7498ce22f8913c5c5d09ff6f1ce39e
+PODFILE CHECKSUM: f5d89b564529ea868668555a1fd91a7bcfc038ce
 
 COCOAPODS: 1.2.1

--- a/Pod/Classes/Core/AREmission.h
+++ b/Pod/Classes/Core/AREmission.h
@@ -22,7 +22,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithUserID:(NSString *)userID
            authenticationToken:(NSString *)authenticationToken
                    packagerURL:(nullable NSURL *)packagerURL
-         useStagingEnvironment:(BOOL)useStagingEnvironment NS_DESIGNATED_INITIALIZER;
+         useStagingEnvironment:(BOOL)useStagingEnvironmen;
+
+- (instancetype)initWithUserID:(NSString *)userID
+           authenticationToken:(NSString *)authenticationToken
+                   packagerURL:(nullable NSURL *)packagerURL
+         useStagingEnvironment:(BOOL)useStagingEnvironment
+                     sentryDSN:(nullable NSString *)sentryDSN NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/Pod/Classes/Core/AREmission.m
+++ b/Pod/Classes/Core/AREmission.m
@@ -11,9 +11,9 @@
 
 
 @interface AREmissionConfiguration : NSObject <RCTBridgeModule>
-@property (nonatomic, strong, readwrite) NSString *userID;
-@property (nonatomic, strong, readwrite) NSString *authenticationToken;
-@property (nonatomic, strong, readwrite) NSString *sentryDSN;
+@property (nonatomic, copy, readwrite) NSString *userID;
+@property (nonatomic, copy, readwrite) NSString *authenticationToken;
+@property (nonatomic, copy, readwrite) NSString *sentryDSN;
 @property (nonatomic, assign, readwrite) BOOL useStagingEnvironment;
 @end
 

--- a/Pod/Classes/Core/AREmission.m
+++ b/Pod/Classes/Core/AREmission.m
@@ -7,11 +7,13 @@
 
 #import <React/RCTBridge.h>
 #import <React/RCTBridgeModule.h>
+#import <SentryReactNative/RNSentry.h>
 
 
 @interface AREmissionConfiguration : NSObject <RCTBridgeModule>
 @property (nonatomic, strong, readwrite) NSString *userID;
 @property (nonatomic, strong, readwrite) NSString *authenticationToken;
+@property (nonatomic, strong, readwrite) NSString *sentryDSN;
 @property (nonatomic, assign, readwrite) BOOL useStagingEnvironment;
 @end
 
@@ -25,6 +27,7 @@ RCT_EXPORT_MODULE(Emission);
     @"userID": self.userID,
     @"authenticationToken": self.authenticationToken,
     @"useStagingEnvironment": @(self.useStagingEnvironment),
+    @"sentryDSN": self.sentryDSN ?: @"", // Empty is falsy in JS, so this is fine too.
   };
 }
 
@@ -64,6 +67,19 @@ static AREmission *_sharedInstance = nil;
                    packagerURL:(nullable NSURL *)packagerURL
          useStagingEnvironment:(BOOL)useStagingEnvironment;
 {
+  return [self initWithUserID:userID
+          authenticationToken:authenticationToken
+                  packagerURL:packagerURL
+        useStagingEnvironment:useStagingEnvironment
+                    sentryDSN:nil];
+}
+
+- (instancetype)initWithUserID:(NSString *)userID
+           authenticationToken:(NSString *)authenticationToken
+                   packagerURL:(nullable NSURL *)packagerURL
+         useStagingEnvironment:(BOOL)useStagingEnvironment
+                     sentryDSN:(nullable NSString *)sentryDSN;
+{
   NSParameterAssert(userID);
   NSParameterAssert(authenticationToken);
 
@@ -78,12 +94,17 @@ static AREmission *_sharedInstance = nil;
     _configurationModule.userID = userID;
     _configurationModule.authenticationToken = authenticationToken;
     _configurationModule.useStagingEnvironment = useStagingEnvironment;
+    _configurationModule.sentryDSN = sentryDSN;
 
     NSArray *modules = @[_APIModule, _configurationModule, _eventsModule, _switchBoardModule, _refineModule, _worksForYouModule];
 
     _bridge = [[RCTBridge alloc] initWithBundleURL:(packagerURL ?: self.releaseBundleURL)
                                     moduleProvider:^{ return modules; }
                                      launchOptions:nil];
+    
+    if (sentryDSN) {
+      [RNSentry installWithBridge:_bridge];
+    }
   }
   return self;
 }

--- a/index.ios.js
+++ b/index.ios.js
@@ -1,9 +1,12 @@
-import Containers from './src/lib/containers'
-import Components from './src/lib/components'
-import Routes from './src/lib/relay/routes'
+// First things first.
+import "./src/lib/error_reporting"
 
-import './src/lib/relay/config'
-import './src/lib/app_registry'
+import Containers from "./src/lib/containers"
+import Components from "./src/lib/components"
+import Routes from "./src/lib/relay/routes"
+
+import "./src/lib/relay/config"
+import "./src/lib/app_registry"
 
 export default {
   Containers,

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "react": "latest",
     "react-native": "https://github.com/alloy/react-native.git#v0.42.0-with-customisable-source-exts",
     "react-native-parallax-scroll-view": "https://github.com/orta/react-native-parallax-scroll-view",
+    "react-native-sentry": "https://github.com/alloy/react-native-sentry.git#fix-podspec",
     "react-relay": "https://github.com/alloy/relay/releases/download/v0.9.3/react-relay-0.9.3.tgz",
     "remove-markdown": "0.1.0",
     "typescript": "^2.3.2"

--- a/src/lib/error_reporting.ts
+++ b/src/lib/error_reporting.ts
@@ -1,0 +1,9 @@
+import { NativeModules } from "react-native"
+const { Emission } = NativeModules
+
+import { Sentry } from "react-native-sentry"
+
+// AREmission sets this to "" if not configured, which is falsy in JS so this conditional is fine.
+if (Emission.sentryDSN) {
+  Sentry.config(Emission.sentryDSN).install()
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1806,6 +1806,12 @@ cli-cursor@^1.0.1, cli-cursor@^1.0.2:
   dependencies:
     restore-cursor "^1.0.1"
 
+cli-cursor@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
+  dependencies:
+    restore-cursor "^2.0.0"
+
 cli-spinners@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-0.1.2.tgz#bb764d88e185fb9e1e6a2a1f19772318f605e31c"
@@ -2628,6 +2634,12 @@ extend@3, extend@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.0.tgz#5a474353b9f3353ddd8176dfd37b91c83a46f1d4"
 
+external-editor@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.0.1.tgz#4c597c6c88fa6410e41dbbaa7b1be2336aa31095"
+  dependencies:
+    tmp "^0.0.31"
+
 extglob@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
@@ -2696,6 +2708,12 @@ figures@^1.3.5, figures@^1.7.0:
   dependencies:
     escape-string-regexp "^1.0.5"
     object-assign "^4.1.0"
+
+figures@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
+  dependencies:
+    escape-string-regexp "^1.0.5"
 
 file-loader@^0.9.0:
   version "0.9.0"
@@ -2948,17 +2966,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@^5.0.15, glob@~5.0.0:
-  version "5.0.15"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
-  dependencies:
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "2 || 3"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1:
+glob@7.1.1, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -2966,6 +2974,16 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1:
     inflight "^1.0.4"
     inherits "2"
     minimatch "^3.0.2"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^5.0.15, glob@~5.0.0:
+  version "5.0.15"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
+  dependencies:
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "2 || 3"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -3275,6 +3293,24 @@ inherits@2.0.1:
 ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
+
+inquirer@3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.0.6.tgz#e04aaa9d05b7a3cb9b0f407d04375f0447190347"
+  dependencies:
+    ansi-escapes "^1.1.0"
+    chalk "^1.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^2.0.1"
+    figures "^2.0.0"
+    lodash "^4.3.0"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rx "^4.1.0"
+    string-width "^2.0.0"
+    strip-ansi "^3.0.0"
+    through "^2.3.6"
 
 inquirer@^0.12.0:
   version "0.12.0"
@@ -4419,6 +4455,10 @@ mime@1.3.4, mime@1.3.x, mime@^1.2.11, mime@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.4.tgz#115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
 
+mimic-fn@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
+
 min-document@^2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/min-document/-/min-document-2.19.0.tgz#7bd282e3f5842ed295bb748cdd9f1ffa2c824685"
@@ -4500,6 +4540,10 @@ multipipe@^0.1.2:
 mute-stream@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
+
+mute-stream@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
 nan@^2.3.0:
   version "2.6.2"
@@ -4728,6 +4772,12 @@ onetime@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
 
+onetime@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
+  dependencies:
+    mimic-fn "^1.0.0"
+
 opn@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/opn/-/opn-3.0.3.tgz#b6d99e7399f78d65c3baaffef1fb288e9b85243a"
@@ -4779,7 +4829,7 @@ os-locale@^1.4.0:
   dependencies:
     lcid "^1.0.0"
 
-os-tmpdir@^1.0.0, os-tmpdir@^1.0.1:
+os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
@@ -5302,6 +5352,10 @@ range-parser@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.0.3.tgz#6872823535c692e2c2a0103826afd82c2e0ff175"
 
+raven-js@^3.15.0:
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.15.0.tgz#ebf95466b7d40fbbc3d6a5085af7c1431607926c"
+
 raw-body@~2.1.2:
   version "2.1.7"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.1.7.tgz#adfeace2e4fb3098058014d08c072dcc59758774"
@@ -5382,6 +5436,15 @@ react-modal@^1.2.1:
 "react-native-parallax-scroll-view@https://github.com/orta/react-native-parallax-scroll-view":
   version "0.18.2"
   resolved "https://github.com/orta/react-native-parallax-scroll-view#4e20440f9cd0b6280303b57124c0348c0e63b7c0"
+
+"react-native-sentry@https://github.com/alloy/react-native-sentry.git#fix-podspec":
+  version "0.8.1"
+  resolved "https://github.com/alloy/react-native-sentry.git#e3b7fa8271fb6746c799abfdf31dad4d9c5b4e20"
+  dependencies:
+    glob "7.1.1"
+    inquirer "3.0.6"
+    raven-js "^3.15.0"
+    sentry-cli-binary "^1.9.0"
 
 "react-native@https://github.com/alloy/react-native.git#v0.42.0-with-customisable-source-exts":
   version "0.42.0"
@@ -5811,6 +5874,13 @@ restore-cursor@^1.0.1:
     exit-hook "^1.0.0"
     onetime "^1.0.0"
 
+restore-cursor@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
+  dependencies:
+    onetime "^2.0.0"
+    signal-exit "^3.0.2"
+
 rfc6902@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/rfc6902/-/rfc6902-1.3.0.tgz#85b2c69c42dcf116082437b9829a962446b4c4a5"
@@ -5845,6 +5915,12 @@ run-async@^0.1.0:
   dependencies:
     once "^1.3.0"
 
+run-async@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
+  dependencies:
+    is-promise "^2.1.0"
+
 rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
@@ -5852,6 +5928,10 @@ rx-lite@^3.1.2:
 rx@2.3.24:
   version "2.3.24"
   resolved "https://registry.yarnpkg.com/rx/-/rx-2.3.24.tgz#14f950a4217d7e35daa71bbcbe58eff68ea4b2b7"
+
+rx@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/rx/-/rx-4.1.0.tgz#a5f13ff79ef3b740fe30aa803fb09f98805d4782"
 
 rxjs@^5.0.0-beta.11:
   version "5.3.1"
@@ -5942,6 +6022,10 @@ send@0.15.1:
     on-finished "~2.3.0"
     range-parser "~1.2.0"
     statuses "~1.3.1"
+
+sentry-cli-binary@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/sentry-cli-binary/-/sentry-cli-binary-1.9.0.tgz#99d7b62480cf85d674dbb193e7da313cdf820a06"
 
 serve-favicon@~2.3.0:
   version "2.3.2"
@@ -6038,7 +6122,7 @@ shellwords@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.0.tgz#66afd47b6a12932d9071cbfd98a52e785cd0ba14"
 
-signal-exit@^3.0.0:
+signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
@@ -6393,6 +6477,12 @@ timers-browserify@^2.0.2:
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.2.tgz#ab4883cf597dcd50af211349a00fbca56ac86b86"
   dependencies:
     setimmediate "^1.0.4"
+
+tmp@^0.0.31:
+  version "0.0.31"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.31.tgz#8f38ab9438e17315e5dbd8b3657e8bfb277ae4a7"
+  dependencies:
+    os-tmpdir "~1.0.1"
 
 tmpl@1.0.x:
   version "1.0.4"


### PR DESCRIPTION
Currently need to use this until it’s merged and released https://github.com/getsentry/react-native-sentry/pull/50. It’s important that we don’t forget to configure Eigen to use this fork as well!

Closes #511