### PR TITLE
[package] Switch back to upstream Sentry SDK. #trivial

### DIFF
--- a/Emission.podspec
+++ b/Emission.podspec
@@ -6,6 +6,7 @@ end
 
 emission_version = pkg_version.call('.')
 react_native_version = pkg_version.call('node_modules/react-native')
+sentry_version = pkg_version.call('node_modules/react-native-sentry')
 
 Pod::Spec.new do |s|
   s.name           = 'Emission'
@@ -34,6 +35,5 @@ Pod::Spec.new do |s|
   s.dependency 'SDWebImage', '>= 3.7.2'
   # This needs to be locked down because we’re including this specific version’s JS in our bundle, so it needs to match
   # with the SentryReactNative version that CocoaPods would pull into Eigen.
-  s.dependency 'SentryReactNative', '0.8.1'
-  s.dependency 'Sentry', '>= 2.1.9' # This is for until SentryReactNative specifies the right minimum version.
+  s.dependency 'SentryReactNative', sentry_version
 end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -19,8 +19,7 @@ PODS:
     - React/RCTNetwork (= 0.42.0)
     - React/RCTText (= 0.42.0)
     - SDWebImage (>= 3.7.2)
-    - Sentry (>= 2.1.9)
-    - SentryReactNative (= 0.8.1)
+    - SentryReactNative (= 0.8.3)
     - Yoga (= 0.42.0.React)
   - Extraction (1.2.3):
     - Extraction/ARAnimationContinuation (= 1.2.3)
@@ -139,7 +138,7 @@ PODS:
   - SDWebImage/Core (3.7.5)
   - Sentry (2.1.9):
     - KSCrash (~> 1.15.5)
-  - SentryReactNative (0.8.1):
+  - SentryReactNative (0.8.3):
     - React
     - RSSwizzle (~> 0.1.0)
     - Sentry (~> 2.1.9)
@@ -186,7 +185,7 @@ SPEC CHECKSUMS:
   Artsy+UIColors: 31c03c4146f5e6618a9b950f37dfe02dd9ac09a6
   Artsy+UIFonts: e66afb5c40100e2fc5bba28feb7487e252f2d06f
   Artsy-UIButtons: cdcc3ccf4d0d31ee80f45c1d11ffd2d772695b74
-  Emission: 8d3cbe01e1173420adbe3c18389a409cde8d3719
+  Emission: 575bcf95d8ae22e9de1c890d8edd5dfed6c20e90
   Extraction: 612cf0866f74d4c0dd616677ff24146efa200958
   FLKAutoLayout: 106b14dbae09d32c6730190f4e78a959759ba4a4
   ISO8601DateFormatter: 4551b6ce4f83185425f583b0b3feb3c7b59b942c
@@ -198,7 +197,7 @@ SPEC CHECKSUMS:
   SAMKeychain: 1fc9ae02f576365395758b12888c84704eebc423
   SDWebImage: 69c6303e3348fba97e03f65d65d4fbc26740f461
   Sentry: 0025c374b2f9fb0da8185a45199de985408a40b2
-  SentryReactNative: be48c493b658b556c64006c330ae2333de399e6e
+  SentryReactNative: 3de8c386dfebb9f42c5e989adb7060b3f2dc4878
   Specta: ac94d110b865115fe60ff2c6d7281053c6f8e8a2
   UIView+BooleanAnimations: a760be9a066036e55f298b7b7350a6cb14cfcd97
   Yoga: 4183cc70cae189d73f996b1e40c3078aca9f96ef

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "react": "latest",
     "react-native": "https://github.com/alloy/react-native.git#v0.42.0-with-customisable-source-exts",
     "react-native-parallax-scroll-view": "https://github.com/orta/react-native-parallax-scroll-view",
-    "react-native-sentry": "https://github.com/alloy/react-native-sentry.git#fix-podspec",
+    "react-native-sentry": "^0.8.3",
     "react-relay": "https://github.com/alloy/relay/releases/download/v0.9.3/react-relay-0.9.3.tgz",
     "remove-markdown": "0.1.0",
     "typescript": "^2.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5437,9 +5437,9 @@ react-modal@^1.2.1:
   version "0.18.2"
   resolved "https://github.com/orta/react-native-parallax-scroll-view#4e20440f9cd0b6280303b57124c0348c0e63b7c0"
 
-"react-native-sentry@https://github.com/alloy/react-native-sentry.git#fix-podspec":
-  version "0.8.1"
-  resolved "https://github.com/alloy/react-native-sentry.git#e3b7fa8271fb6746c799abfdf31dad4d9c5b4e20"
+react-native-sentry@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/react-native-sentry/-/react-native-sentry-0.8.3.tgz#14c72df5aeae01431059d9acd515313da40ba9f7"
   dependencies:
     glob "7.1.1"
     inquirer "3.0.6"
@@ -6024,8 +6024,8 @@ send@0.15.1:
     statuses "~1.3.1"
 
 sentry-cli-binary@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/sentry-cli-binary/-/sentry-cli-binary-1.9.0.tgz#99d7b62480cf85d674dbb193e7da313cdf820a06"
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/sentry-cli-binary/-/sentry-cli-binary-1.9.1.tgz#a99d5ce4e1f480e16efe64f83e65596d1123b926"
 
 serve-favicon@~2.3.0:
   version "2.3.2"


### PR DESCRIPTION
My PR got merged and released, so this just switches back from my fork.