### PR TITLE
Adds support for browsing storybooks from the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Consignments
 
+- Users now can access stories from inside the app - orta
 - [dev] Adds component for consignments todo  - orta
 - [dev] Adds a root component for the Consignments flow  - orta
 - [dev] Adds storybooks for consignments  - orta

--- a/Example/Emission/ARRootViewController.m
+++ b/Example/Emission/ARRootViewController.m
@@ -31,6 +31,9 @@
   [appData addCellData:self.generateStagingSwitch];
   [tableViewData addSectionData:appData];
 
+  ARSectionData *userSection = [self userSection];
+  [tableViewData addSectionData:userSection];
+
   ARSectionData *viewControllerSection = [self jumpToViewControllersSection];
   [tableViewData addSectionData:viewControllerSection];
 
@@ -38,9 +41,6 @@
   ARSectionData *developerSection = [self developersSection];
   [tableViewData addSectionData:developerSection];
 #endif
-
-  ARSectionData *userSection = [self userSection];
-  [tableViewData addSectionData:userSection];
 
   self.tableViewData = tableViewData;
 }
@@ -69,6 +69,7 @@
   [self setupSection:sectionData withTitle:@"Developer"];
 
   [sectionData addCellData:self.jumpToStorybooks];
+
   return sectionData;
 }
 
@@ -77,8 +78,17 @@
 
 - (ARCellData *)jumpToStorybooks
 {
-  return [self tappableCellDataWithTitle:@"Open Storybooks" selection: ^{
+  return [self tappableCellDataWithTitle:@"Open Storybook" selection: ^{
     id viewController = [ARStorybookComponentViewController new];
+    [self.navigationController pushViewController:viewController animated:YES];
+  }];
+}
+
+- (ARCellData *)jumpToEndUserStorybooks
+{
+  return [self tappableCellDataWithTitle:@"Open Storybook Browser" selection: ^{
+    id viewController = [[ARComponentViewController alloc] initWithEmission:nil moduleName:@"StorybookBrowser" initialProperties: @{}];
+
     [self.navigationController pushViewController:viewController animated:YES];
   }];
 }
@@ -185,6 +195,7 @@
   ARSectionData *sectionData = [[ARSectionData alloc] init];
   [self setupSection:sectionData withTitle:@"User"];
 
+  [sectionData addCellData:self.jumpToEndUserStorybooks];
   [sectionData addCellData:self.logOutButton];
   return sectionData;
 }

--- a/Example/Emission/EigenLikeNavigationController.m
+++ b/Example/Emission/EigenLikeNavigationController.m
@@ -34,7 +34,14 @@
 
 - (void)pop
 {
-  [self popViewControllerAnimated:YES];
+  // Support popping inside NavigatorIOS before falling back to our navigation VC
+  UINavigationController *targetNav = self;
+  for (UIViewController *controller in self.topViewController.childViewControllers) {
+    if ([controller isKindOfClass:UINavigationController.class]) {
+      if (controller.childViewControllers.count > 1) { targetNav = (id)controller; }
+    }
+  }
+  [targetNav popViewControllerAnimated:YES];
 }
 
 - (UIButton *)createBackButton

--- a/Example/Emission/index.ios.js
+++ b/Example/Emission/index.ios.js
@@ -1,3 +1,4 @@
 import './index.storybooks'
+import '../../src/lib/components/storybooks/'
 import 'emission';
 

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "react-native-sentry": "^0.8.3",
     "react-relay": "https://github.com/alloy/relay/releases/download/v0.9.3/react-relay-0.9.3.tgz",
     "remove-markdown": "0.1.0",
-    "styled-components": "rc",
+    "styled-components": "^2.0.0",
     "typescript": "^2.3.2"
   },
   "devDependencies": {

--- a/src/lib/components/storybooks/index.tsx
+++ b/src/lib/components/storybooks/index.tsx
@@ -1,0 +1,27 @@
+import * as React from "react"
+import { AppRegistry, NavigatorIOS } from "react-native"
+
+import Browser from "./section_browser"
+
+export interface Story {
+  name: string,
+  render: () => any
+}
+
+export interface StorySection {
+  kind: string,
+  stories: Story[]
+}
+
+const render = (props: any) =>
+  <NavigatorIOS
+    navigationBarHidden={true}
+    initialRoute={{ component: Browser, title: "Welcome" }}
+    style={{ flex: 1 }}
+  />
+
+export default class StorybookBrowser extends React.PureComponent<any, null> {
+  render() { return render(this.props) }
+}
+
+AppRegistry.registerComponent("StorybookBrowser", () => StorybookBrowser)

--- a/src/lib/components/storybooks/section_browser.tsx
+++ b/src/lib/components/storybooks/section_browser.tsx
@@ -1,0 +1,46 @@
+import * as storybook from "@storybook/react-native"
+import * as React from "react"
+import { ListView, NavigatorIOS, Route, TouchableHighlight, View, ViewProperties } from "react-native"
+
+import { StorySection } from "./"
+import StoryBrowser from "./story_browser"
+import { Background, BodyText, Separator, Title } from "./styles"
+
+interface Props extends ViewProperties {
+  navigator: NavigatorIOS,
+  route: Route
+}
+
+const Headline = () => <Title>Stories</Title>
+
+const render = (props: Props) => {
+
+  const ListViewItem = (item: StorySection) => {
+    const showStoriesForSection = () => {
+      props.navigator.push({ title: item.kind, component: StoryBrowser, passProps: { section: item } })
+    }
+
+    return (
+      <View key={item.kind}>
+        <TouchableHighlight onPress={showStoriesForSection}>
+          <BodyText>{item.kind}</BodyText>
+        </TouchableHighlight>
+        <Separator />
+      </View>
+    )
+  }
+
+  const storybookDS = new ListView.DataSource({ rowHasChanged: (r1, r2) => r1 !== r2 })
+    .cloneWithRows(storybook.getStorybook())
+
+  return (
+    <Background>
+      <ListView style={{ flex: 1 }} dataSource={storybookDS} renderRow={ListViewItem} renderHeader={Headline} />
+    </Background>
+  )
+}
+
+// Export a pure component version
+export default class StorybookBrowser extends React.PureComponent<Props, null> {
+  render() { return render(this.props) }
+}

--- a/src/lib/components/storybooks/story_browser.tsx
+++ b/src/lib/components/storybooks/story_browser.tsx
@@ -1,0 +1,44 @@
+import * as React from "react"
+import { ListView, NavigatorIOS, Route, TouchableHighlight, View, ViewProperties } from "react-native"
+
+import { Story, StorySection } from "./"
+import { Background, BodyText, Separator, Title } from "./styles"
+
+interface Props extends ViewProperties {
+  navigator: NavigatorIOS,
+  route: Route,
+  section: StorySection
+}
+
+const Headline = () => <Title>Stories</Title>
+
+const render = (props: Props) => {
+  const ListViewItem = (item: Story) => {
+    const showStory = () => {
+      props.navigator.push({ title: item.name, component: item.render as any })
+    }
+
+    return (
+      <View key={item.name}>
+        <TouchableHighlight onPress={showStory}>
+          <BodyText>{item.name}</BodyText>
+        </TouchableHighlight>
+        <Separator />
+      </View>
+    )
+  }
+
+  const storybookDS = new ListView.DataSource({ rowHasChanged: (r1, r2) => r1 !== r2 })
+    .cloneWithRows(props.section.stories)
+
+  return (
+    <Background>
+      <ListView style={{ flex: 1 }} dataSource={storybookDS} renderRow={ListViewItem} renderHeader={Headline} />
+    </Background>
+  )
+}
+
+// Export a pure component version
+export default class StorybookBrowser extends React.PureComponent<Props, null> {
+  render() { return render(this.props) }
+}

--- a/src/lib/components/storybooks/styles.tsx
+++ b/src/lib/components/storybooks/styles.tsx
@@ -1,0 +1,31 @@
+
+import styled from "styled-components/native"
+import colors from "../../../data/colors"
+import fonts from "../../../data/fonts"
+
+export const Title = styled.Text`
+  font-family: "${fonts["garamond-regular"]}"
+  font-size: 30
+  padding-top: 20
+  padding-left: 60
+`
+
+export const BodyText = styled.Text`
+  font-family: "${fonts["garamond-regular"]}"
+  font-size: 18
+  padding-top: 18
+  padding-bottom: 16
+  padding-left: 20
+  padding-right: 20
+`
+
+export const Background = styled.View`
+  background-color: white
+  flex: 1
+  padding-bottom: 20
+`
+
+export const Separator = styled.View`
+  background-color: ${colors["gray-regular"]}
+  height: 1
+`

--- a/src/storiesRegistry.js
+++ b/src/storiesRegistry.js
@@ -1,4 +1,3 @@
-
 import "./lib/components/text/__stories__/typography.story"
 import "./lib/components/buttons/__stories__/buttons.story"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5987,13 +5987,13 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.4, prop-types@^15.5.8:
+prop-types@^15.5.4, prop-types@^15.5.8, prop-types@~15.5.7:
   version "15.5.8"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
   dependencies:
     fbjs "^0.8.9"
 
-prop-types@^15.5.7, prop-types@^15.5.9, prop-types@~15.5.7:
+prop-types@^15.5.7, prop-types@^15.5.9:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:
@@ -7103,9 +7103,9 @@ style-loader@^0.17.0:
   dependencies:
     loader-utils "^1.0.2"
 
-styled-components@rc:
-  version "2.0.0-18"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-2.0.0-18.tgz#e507e7234b124588bd7d7e08870b0afadcd7b2a6"
+styled-components@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-2.0.0.tgz#0906652b77647e7400ca7e5a6d8d45eba6fa77ec"
   dependencies:
     buffer "^5.0.3"
     css-to-react-native "^2.0.3"


### PR DESCRIPTION
This means we can move away from these root view controllers in the app entirely, letting the JS control a lot more of the Emission app's flow.

![2017-05-26 11_03_40](https://cloud.githubusercontent.com/assets/49038/26490411/04f7ef72-4203-11e7-9a05-3a4388b8caeb.gif)

* Re-jiggers the back button to look inside the top view controller for other navigations
* Updates styled-components to the official 2.0 release, now that it's out

Skip New Tests - not really relevant for the dev side of this.<hr data-danger="yep"/>

### Tested on Device?

- [ ] @orta
- [ ] @ashfurrow

<details>
  <summary>How to get set up with this PR?</summary>
  <p>&nbsp;</p>
   <p><b>To run on your computer:</b></p>
<pre><code>git fetch origin pull/569/head:orta-569-checkout
git checkout orta-569-checkout
yarn install
cd example; pod install; cd ..
open -a Simulator
yarn start</code></pre>
   </p>
   <p>Then run <code>xcrun simctl launch booted net.artsy.Emission</code> once a the simulator has finished booting</p>
   <p><b>To run inside Eigen (prod or beta) or Emission (beta):</b> Shake the phone to get the Admin menu.</p>
   <p>If you see <i>"Use Staging React Env" </i> - click that and restart, then follow the next step.</p>
   <p>Click on <i>"Choose an RN build" </i> - then pick the one that says: "X,Y,Z"</p>
   <p>Note: this is a TODO for PRs, currently  you can only do it on master commits.</p>
</details>
