### PR TITLE
[Dev] Embed Swift libraries

### DIFF
--- a/Example/Emission.xcodeproj/project.pbxproj
+++ b/Example/Emission.xcodeproj/project.pbxproj
@@ -698,6 +698,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 822BF881E9F1716840710C01 /* Pods-Emission.debug.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CC = "${SRCROOT}/compile_commands_emitting_clang";
 				CODE_SIGN_ENTITLEMENTS = Emission/Emission.entitlements;
@@ -724,6 +725,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7F3A1FEFE0AEAB158547A0BB /* Pods-Emission.release.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CC = "${SRCROOT}/compile_commands_emitting_clang";
 				CODE_SIGN_ENTITLEMENTS = Emission/Emission.entitlements;
@@ -842,6 +844,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A9EDBCE5F6E1D1A6CEA0264A /* Pods-Emission.deploy.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CC = "${SRCROOT}/compile_commands_emitting_clang";
 				CODE_SIGN_ENTITLEMENTS = Emission/Emission.entitlements;


### PR DESCRIPTION
Looks like we need to change this setting since Swift is being used inside a Pod:

<img width="747" alt="screen shot 2017-05-27 at 15 51 06" src="https://cloud.githubusercontent.com/assets/49038/26522258/527a7b60-42f4-11e7-98bc-1305a2688c86.png">

[As deploys were failing](https://github.com/artsy/emission-nebula/issues/3#issuecomment-304456477)

<img width="882" alt="screen shot 2017-05-27 at 15 42 09" src="https://cloud.githubusercontent.com/assets/49038/26522247/2d4c70e6-42f4-11e7-9347-946ddf10ba9c.png">

#trivial<hr data-danger="yep"/>

### Tested on Device?

- [x] @orta
- [x] @orta

<details>
  <summary>How to get set up with this PR?</summary>
  <p>&nbsp;</p>
   <p><b>To run on your computer:</b></p>
<pre><code>git fetch origin pull/571/head:orta-571-checkout
git checkout orta-571-checkout
yarn install
cd example; pod install; cd ..
open -a Simulator
yarn start</code></pre>
   </p>
   <p>Then run <code>xcrun simctl launch booted net.artsy.Emission</code> once a the simulator has finished booting</p>
   <p><b>To run inside Eigen (prod or beta) or Emission (beta):</b> Shake the phone to get the Admin menu.</p>
   <p>If you see <i>"Use Staging React Env" </i> - click that and restart, then follow the next step.</p>
   <p>Click on <i>"Choose an RN build" </i> - then pick the one that says: "X,Y,Z"</p>
   <p>Note: this is a TODO for PRs, currently  you can only do it on master commits.</p>
</details>
