### PR TITLE
Add an unused Swift file to ensure the app is usable in release with a Swift library

### DIFF
--- a/Example/Emission.xcodeproj/project.pbxproj
+++ b/Example/Emission.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		6011C24E1DAF697B00CE54E5 /* EigenLikeAdminViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 6011C24D1DAF697B00CE54E5 /* EigenLikeAdminViewController.m */; };
 		6011C2511DAF7B6D00CE54E5 /* UnroutedViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 6011C2501DAF7B6D00CE54E5 /* UnroutedViewController.m */; };
 		6011C2561DAF835900CE54E5 /* logo@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6011C2551DAF835900CE54E5 /* logo@2x.png */; };
+		605D07021ED9D44A0026B56A /* UnusedSwiftFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605D07011ED9D44A0026B56A /* UnusedSwiftFile.swift */; };
 		60A1A77E1DA3A23C005E3357 /* BackArrow@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 60A1A77B1DA3A23C005E3357 /* BackArrow@2x.png */; };
 		60A1A77F1DA3A23C005E3357 /* BackArrow_Highlighted@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 60A1A77C1DA3A23C005E3357 /* BackArrow_Highlighted@2x.png */; };
 		60A1A7801DA3A23C005E3357 /* BackArrowBlack@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 60A1A77D1DA3A23C005E3357 /* BackArrowBlack@2x.png */; };
@@ -87,6 +88,8 @@
 		6011C2501DAF7B6D00CE54E5 /* UnroutedViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UnroutedViewController.m; sourceTree = "<group>"; };
 		6011C2551DAF835900CE54E5 /* logo@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "logo@2x.png"; sourceTree = "<group>"; };
 		60204ADD1D9D590900204628 /* Emission.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Emission.entitlements; sourceTree = "<group>"; };
+		605D07001ED9D44A0026B56A /* Emission-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Emission-Bridging-Header.h"; sourceTree = "<group>"; };
+		605D07011ED9D44A0026B56A /* UnusedSwiftFile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnusedSwiftFile.swift; sourceTree = "<group>"; };
 		60A1A77B1DA3A23C005E3357 /* BackArrow@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "BackArrow@2x.png"; sourceTree = "<group>"; };
 		60A1A77C1DA3A23C005E3357 /* BackArrow_Highlighted@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "BackArrow_Highlighted@2x.png"; sourceTree = "<group>"; };
 		60A1A77D1DA3A23C005E3357 /* BackArrowBlack@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "BackArrowBlack@2x.png"; sourceTree = "<group>"; };
@@ -287,6 +290,8 @@
 				510DCB141CCA69EC0075E8CB /* AppDelegate.m */,
 				60F61A891DAF982A00A72101 /* AuthenticationManager.h */,
 				60F61A8A1DAF982B00A72101 /* AuthenticationManager.m */,
+				605D07011ED9D44A0026B56A /* UnusedSwiftFile.swift */,
+				605D07001ED9D44A0026B56A /* Emission-Bridging-Header.h */,
 			);
 			name = App;
 			sourceTree = "<group>";
@@ -395,6 +400,7 @@
 					510DCB0D1CCA69EC0075E8CB = {
 						CreatedOnToolsVersion = 7.2.1;
 						DevelopmentTeam = 23KMWZ572J;
+						LastSwiftMigration = 0830;
 						ProvisioningStyle = Manual;
 						SystemCapabilities = {
 							com.apple.Keychain = {
@@ -636,6 +642,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6011C2511DAF7B6D00CE54E5 /* UnroutedViewController.m in Sources */,
+				605D07021ED9D44A0026B56A /* UnusedSwiftFile.swift in Sources */,
 				6011C2451DAF61AF00CE54E5 /* ARAdminTableViewCell.m in Sources */,
 				60B743B71D3EB12600E6B2A3 /* ARStorybookComponentViewController.m in Sources */,
 				51F3E9A41CF3B8A4004A2013 /* EigenLikeNavigationController.m in Sources */,
@@ -700,6 +707,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CC = "${SRCROOT}/compile_commands_emitting_clang";
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Emission/Emission.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -716,6 +724,9 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "23767ec5-72d8-401e-9dfd-e58dba5920e7";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore net.artsy.Emission";
+				SWIFT_OBJC_BRIDGING_HEADER = "Emission/Emission-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -726,6 +737,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CC = "${SRCROOT}/compile_commands_emitting_clang";
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Emission/Emission.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				DEVELOPMENT_TEAM = 23KMWZ572J;
@@ -741,6 +753,8 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "23767ec5-72d8-401e-9dfd-e58dba5920e7";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore net.artsy.Emission";
+				SWIFT_OBJC_BRIDGING_HEADER = "Emission/Emission-Bridging-Header.h";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -749,6 +763,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = EC7AE6B33EE1261C1E96D2FC /* Pods-EmissionTests.debug.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				INFOPLIST_FILE = EmissionTests/Info.plist;
@@ -764,6 +779,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 186D8F421D3B6F269A41D65F /* Pods-EmissionTests.release.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				INFOPLIST_FILE = EmissionTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
@@ -777,6 +793,7 @@
 		510DCB3C1CCA69ED0075E8CB /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				INFOPLIST_FILE = EmissionUITests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
@@ -791,6 +808,7 @@
 		510DCB3D1CCA69ED0075E8CB /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				INFOPLIST_FILE = EmissionUITests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -844,6 +862,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CC = "${SRCROOT}/compile_commands_emitting_clang";
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Emission/Emission.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				DEPLOY = 1;
@@ -860,6 +879,8 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "23767ec5-72d8-401e-9dfd-e58dba5920e7";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore net.artsy.Emission";
+				SWIFT_OBJC_BRIDGING_HEADER = "Emission/Emission-Bridging-Header.h";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Deploy;
@@ -868,6 +889,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E8B24D636FF40683E534C17A /* Pods-EmissionTests.deploy.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				INFOPLIST_FILE = EmissionTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
@@ -881,6 +903,7 @@
 		51D5E9131D92814800C74594 /* Deploy */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				INFOPLIST_FILE = EmissionUITests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";

--- a/Example/Emission/Emission-Bridging-Header.h
+++ b/Example/Emission/Emission-Bridging-Header.h
@@ -1,0 +1,4 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+

--- a/Example/Emission/UnusedSwiftFile.swift
+++ b/Example/Emission/UnusedSwiftFile.swift
@@ -1,0 +1,9 @@
+//
+//  UnusedSwiftFile.swift
+//  Emission
+//
+//  Created by Orta Therox on 27/05/2017.
+//  Copyright © 2017 CocoaPods. All rights reserved.
+//
+
+import Foundation


### PR DESCRIPTION
It looks like using Swift requires a few more xcproj changes, so I let Xcode do it instead and added an empty file.

#trivial<hr data-danger="yep"/>

### Tested on Device?

- [x] @orta
- [x] @orta

<details>
  <summary>How to get set up with this PR?</summary>
  <p>&nbsp;</p>
   <p><b>To run on your computer:</b></p>
<pre><code>git fetch origin pull/572/head:orta-572-checkout
git checkout orta-572-checkout
yarn install
cd example; pod install; cd ..
open -a Simulator
yarn start</code></pre>
   </p>
   <p>Then run <code>xcrun simctl launch booted net.artsy.Emission</code> once a the simulator has finished booting</p>
   <p><b>To run inside Eigen (prod or beta) or Emission (beta):</b> Shake the phone to get the Admin menu.</p>
   <p>If you see <i>"Use Staging React Env" </i> - click that and restart, then follow the next step.</p>
   <p>Click on <i>"Choose an RN build" </i> - then pick the one that says: "X,Y,Z"</p>
   <p>Note: this is a TODO for PRs, currently  you can only do it on master commits.</p>
</details>
