### PR TITLE
Undoes the work in #571 to allow CocoaPods to set the BED_SWIFT_STANDARD_LIBRARIES

### DIFF
--- a/Example/Emission.xcodeproj/project.pbxproj
+++ b/Example/Emission.xcodeproj/project.pbxproj
@@ -705,7 +705,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 822BF881E9F1716840710C01 /* Pods-Emission.debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CC = "${SRCROOT}/compile_commands_emitting_clang";
 				CLANG_ENABLE_MODULES = YES;
@@ -736,7 +735,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7F3A1FEFE0AEAB158547A0BB /* Pods-Emission.release.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CC = "${SRCROOT}/compile_commands_emitting_clang";
 				CLANG_ENABLE_MODULES = YES;
@@ -862,7 +860,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A9EDBCE5F6E1D1A6CEA0264A /* Pods-Emission.deploy.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CC = "${SRCROOT}/compile_commands_emitting_clang";
 				CLANG_ENABLE_MODULES = YES;


### PR DESCRIPTION
I've been keeping longer term notes in https://github.com/artsy/emission-nebula/issues/3

This stops the CocoaPods warning:

<img width="1280" alt="screen shot 2017-05-27 at 17 23 07" src="https://cloud.githubusercontent.com/assets/49038/26522830/2f217dd2-4301-11e7-96b4-17c07d36f1bb.png">


#trivial<hr data-danger="yep"/>

### Tested on Device?

- [x] @orta
- [x] @orta

<details>
  <summary>How to get set up with this PR?</summary>
  <p>&nbsp;</p>
   <p><b>To run on your computer:</b></p>
<pre><code>git fetch origin pull/573/head:orta-573-checkout
git checkout orta-573-checkout
yarn install
cd example; pod install; cd ..
open -a Simulator
yarn start</code></pre>
   </p>
   <p>Then run <code>xcrun simctl launch booted net.artsy.Emission</code> once a the simulator has finished booting</p>
   <p><b>To run inside Eigen (prod or beta) or Emission (beta):</b> Shake the phone to get the Admin menu.</p>
   <p>If you see <i>"Use Staging React Env" </i> - click that and restart, then follow the next step.</p>
   <p>Click on <i>"Choose an RN build" </i> - then pick the one that says: "X,Y,Z"</p>
   <p>Note: this is a TODO for PRs, currently  you can only do it on master commits.</p>
</details>
