### PR TITLE
[Dev] Deploy the head commit for a PR to our S3 bucket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,7 @@ coverage
 # Use a custom, cached location for Jest to save transpiling
 # on every PR
 .jest/cache
+
+# A commit deploy using `yarn bundle-with-storybooks` generates these
+Emission.js
+Emission.js.meta

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,9 @@ node_js:
   - "6.7"
 
 script:
+  - scripts/deploy_commit.sh
   - yarn ci
-  - yarn danger
+  - "# yarn danger"
 
 deploy:
   provider: script

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.ios.js",
   "scripts": {
     "bundle": "react-native bundle --config \"$(pwd)\"/rn-cli.config.js --platform=ios --dev=false --entry-file=index.ios.js --bundle-output Pod/Assets/Emission.js --sourcemap-output Pod/Assets/Emission.js.map --assets-dest Pod/Assets && rm -rf Pod/Assets/assets/node_modules",
+    "bundle-with-storybooks": "react-native bundle --config \"$(pwd)\"/rn-cli.config.js --platform=ios --dev=true --entry-file=Example/Emission/index.ios.js --bundle-output Emission.js --assets-dest Pod/Assets",
     "clean-example": "cd Example && xcodebuild -workspace Emission.xcworkspace -scheme Emission -destination 'platform=iOS Simulator,name=iPhone 6' clean",
     "type-check": "tsc --noEmit --pretty",
     "lint": "tslint 'src/**/*.{ts,tsx}'",

--- a/scripts/deploy_commit.sh
+++ b/scripts/deploy_commit.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+if [ -z "$TRAVIS_PULL_REQUEST" ]; then
+    echo "Skipping deploy of the commit"
+    exit 0
+fi
+
+# Give us a CLI to work with
+yarn global add s3-cli
+
+# Createa bundle with embedded storybooks also into Emission.js
+yarn bundle-with-storybooks
+
+# Uploads the file to our s3 bucket - credentials are in the ENV vars for same-repo PRs
+s3-cli put Emission.js "s3://artsy-emission-js/$TRAVIS_PULL_REQUEST.js"


### PR DESCRIPTION
Bundles the JS from head of every PR and places it into an S3 bucket with the name `[PR_ID].js`. Meaning that we can make assumptions from inside Emission about the JS existing. Ergo: we can have testflight Emission testing PRs.

New commits on the same PR will overwrite the JS.