### PR TITLE
[Dev] Allow any PR to be used as a build inside Emission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - [dev] Upgrades React Native to v0.45 - sarah
 - [dev] Allows toggling the back button by pressing space - orta
+- Users/Devs can run any PR from inside beta/sim - orta
 
 ### 1.3.6
 

--- a/Example/Emission.xcodeproj/project.pbxproj
+++ b/Example/Emission.xcodeproj/project.pbxproj
@@ -27,9 +27,13 @@
 		60A1A77E1DA3A23C005E3357 /* BackArrow@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 60A1A77B1DA3A23C005E3357 /* BackArrow@2x.png */; };
 		60A1A77F1DA3A23C005E3357 /* BackArrow_Highlighted@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 60A1A77C1DA3A23C005E3357 /* BackArrow_Highlighted@2x.png */; };
 		60A1A7801DA3A23C005E3357 /* BackArrowBlack@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 60A1A77D1DA3A23C005E3357 /* BackArrowBlack@2x.png */; };
+		60AE1D801EE7DF9C00FC800A /* PRNetworkModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 60AE1D7F1EE7DF9C00FC800A /* PRNetworkModel.m */; };
 		60AEE7A01ECC6237008058E3 /* NSDateFormatter+TimeAgo.m in Sources */ = {isa = PBXBuildFile; fileRef = 60AEE79F1ECC6237008058E3 /* NSDateFormatter+TimeAgo.m */; };
 		60B743B71D3EB12600E6B2A3 /* ARStorybookComponentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 60B743B61D3EB12600E6B2A3 /* ARStorybookComponentViewController.m */; };
+		60DA49A81EE7CF70001FE871 /* ARRootViewController+PRs.m in Sources */ = {isa = PBXBuildFile; fileRef = 60DA49A71EE7CF70001FE871 /* ARRootViewController+PRs.m */; };
+		60DA49AB1EE7D219001FE871 /* EmissionPRChooseViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 60DA49AA1EE7D219001FE871 /* EmissionPRChooseViewController.m */; };
 		60E02A681ECB39630010F5D5 /* ARRootViewController+AppHub.m in Sources */ = {isa = PBXBuildFile; fileRef = 60E02A671ECB39630010F5D5 /* ARRootViewController+AppHub.m */; };
+		60E4ABF71EE7D85000E8C3B1 /* LoadingSpinner.m in Sources */ = {isa = PBXBuildFile; fileRef = 60E4ABF61EE7D85000E8C3B1 /* LoadingSpinner.m */; };
 		60F61A8B1DAF982B00A72101 /* AuthenticationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 60F61A8A1DAF982B00A72101 /* AuthenticationManager.m */; };
 		F67E525D8D9365584567DB3C /* Pods_Emission.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3284CF8C4778739FA0B7F1EB /* Pods_Emission.framework */; };
 /* End PBXBuildFile section */
@@ -88,19 +92,27 @@
 		6011C2501DAF7B6D00CE54E5 /* UnroutedViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UnroutedViewController.m; sourceTree = "<group>"; };
 		6011C2551DAF835900CE54E5 /* logo@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "logo@2x.png"; sourceTree = "<group>"; };
 		60204ADD1D9D590900204628 /* Emission.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Emission.entitlements; sourceTree = "<group>"; };
-		607673A21ECC4C9F005848B5 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		605D07001ED9D44A0026B56A /* Emission-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Emission-Bridging-Header.h"; sourceTree = "<group>"; };
 		605D07011ED9D44A0026B56A /* UnusedSwiftFile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnusedSwiftFile.swift; sourceTree = "<group>"; };
+		607673A21ECC4C9F005848B5 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		60A1A77B1DA3A23C005E3357 /* BackArrow@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "BackArrow@2x.png"; sourceTree = "<group>"; };
 		60A1A77C1DA3A23C005E3357 /* BackArrow_Highlighted@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "BackArrow_Highlighted@2x.png"; sourceTree = "<group>"; };
 		60A1A77D1DA3A23C005E3357 /* BackArrowBlack@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "BackArrowBlack@2x.png"; sourceTree = "<group>"; };
 		60A1A7841DA3A879005E3357 /* ARMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ARMacros.h; sourceTree = "<group>"; };
+		60AE1D7E1EE7DF9C00FC800A /* PRNetworkModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PRNetworkModel.h; sourceTree = "<group>"; };
+		60AE1D7F1EE7DF9C00FC800A /* PRNetworkModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PRNetworkModel.m; sourceTree = "<group>"; };
 		60AEE79E1ECC6237008058E3 /* NSDateFormatter+TimeAgo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDateFormatter+TimeAgo.h"; sourceTree = "<group>"; };
 		60AEE79F1ECC6237008058E3 /* NSDateFormatter+TimeAgo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDateFormatter+TimeAgo.m"; sourceTree = "<group>"; };
 		60B743B51D3EB12600E6B2A3 /* ARStorybookComponentViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARStorybookComponentViewController.h; sourceTree = "<group>"; };
 		60B743B61D3EB12600E6B2A3 /* ARStorybookComponentViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARStorybookComponentViewController.m; sourceTree = "<group>"; };
+		60DA49A61EE7CF70001FE871 /* ARRootViewController+PRs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ARRootViewController+PRs.h"; sourceTree = "<group>"; };
+		60DA49A71EE7CF70001FE871 /* ARRootViewController+PRs.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ARRootViewController+PRs.m"; sourceTree = "<group>"; };
+		60DA49A91EE7D219001FE871 /* EmissionPRChooseViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EmissionPRChooseViewController.h; sourceTree = "<group>"; };
+		60DA49AA1EE7D219001FE871 /* EmissionPRChooseViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EmissionPRChooseViewController.m; sourceTree = "<group>"; };
 		60E02A661ECB39630010F5D5 /* ARRootViewController+AppHub.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ARRootViewController+AppHub.h"; sourceTree = "<group>"; };
 		60E02A671ECB39630010F5D5 /* ARRootViewController+AppHub.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ARRootViewController+AppHub.m"; sourceTree = "<group>"; };
+		60E4ABF51EE7D85000E8C3B1 /* LoadingSpinner.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LoadingSpinner.h; sourceTree = "<group>"; };
+		60E4ABF61EE7D85000E8C3B1 /* LoadingSpinner.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LoadingSpinner.m; sourceTree = "<group>"; };
 		60F61A891DAF982A00A72101 /* AuthenticationManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AuthenticationManager.h; sourceTree = "<group>"; };
 		60F61A8A1DAF982B00A72101 /* AuthenticationManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AuthenticationManager.m; sourceTree = "<group>"; };
 		7F3A1FEFE0AEAB158547A0BB /* Pods-Emission.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Emission.release.xcconfig"; path = "Pods/Target Support Files/Pods-Emission/Pods-Emission.release.xcconfig"; sourceTree = "<group>"; };
@@ -288,8 +300,12 @@
 				6011C23A1DAF5DD900CE54E5 /* ARRootViewController.m */,
 				60E02A661ECB39630010F5D5 /* ARRootViewController+AppHub.h */,
 				60E02A671ECB39630010F5D5 /* ARRootViewController+AppHub.m */,
+				60DA49A61EE7CF70001FE871 /* ARRootViewController+PRs.h */,
+				60DA49A71EE7CF70001FE871 /* ARRootViewController+PRs.m */,
 				6011C24F1DAF7B6D00CE54E5 /* UnroutedViewController.h */,
 				6011C2501DAF7B6D00CE54E5 /* UnroutedViewController.m */,
+				60DA49A91EE7D219001FE871 /* EmissionPRChooseViewController.h */,
+				60DA49AA1EE7D219001FE871 /* EmissionPRChooseViewController.m */,
 			);
 			name = "View Controllers";
 			sourceTree = "<group>";
@@ -302,10 +318,14 @@
 				6011C24A1DAF63C000CE54E5 /* ARDefaults.m */,
 				510DCB131CCA69EC0075E8CB /* AppDelegate.h */,
 				510DCB141CCA69EC0075E8CB /* AppDelegate.m */,
+				60E4ABF61EE7D85000E8C3B1 /* LoadingSpinner.m */,
+				60E4ABF51EE7D85000E8C3B1 /* LoadingSpinner.h */,
 				60F61A891DAF982A00A72101 /* AuthenticationManager.h */,
 				60F61A8A1DAF982B00A72101 /* AuthenticationManager.m */,
 				605D07011ED9D44A0026B56A /* UnusedSwiftFile.swift */,
 				605D07001ED9D44A0026B56A /* Emission-Bridging-Header.h */,
+				60AE1D7E1EE7DF9C00FC800A /* PRNetworkModel.h */,
+				60AE1D7F1EE7DF9C00FC800A /* PRNetworkModel.m */,
 			);
 			name = App;
 			sourceTree = "<group>";
@@ -563,11 +583,15 @@
 				6011C2451DAF61AF00CE54E5 /* ARAdminTableViewCell.m in Sources */,
 				60B743B71D3EB12600E6B2A3 /* ARStorybookComponentViewController.m in Sources */,
 				51F3E9A41CF3B8A4004A2013 /* EigenLikeNavigationController.m in Sources */,
+				60DA49AB1EE7D219001FE871 /* EmissionPRChooseViewController.m in Sources */,
 				6011C2461DAF61AF00CE54E5 /* ARTickedTableViewCell.m in Sources */,
+				60AE1D801EE7DF9C00FC800A /* PRNetworkModel.m in Sources */,
+				60E4ABF71EE7D85000E8C3B1 /* LoadingSpinner.m in Sources */,
 				60F61A8B1DAF982B00A72101 /* AuthenticationManager.m in Sources */,
 				6011C2471DAF61AF00CE54E5 /* ARAnimatedTickView.m in Sources */,
 				60AEE7A01ECC6237008058E3 /* NSDateFormatter+TimeAgo.m in Sources */,
 				510DCB151CCA69EC0075E8CB /* AppDelegate.m in Sources */,
+				60DA49A81EE7CF70001FE871 /* ARRootViewController+PRs.m in Sources */,
 				6011C24B1DAF63C000CE54E5 /* ARDefaults.m in Sources */,
 				510DCB121CCA69EC0075E8CB /* main.m in Sources */,
 				6011C24E1DAF697B00CE54E5 /* EigenLikeAdminViewController.m in Sources */,

--- a/Example/Emission/ARDefaults.h
+++ b/Example/Emission/ARDefaults.h
@@ -1,3 +1,5 @@
 #import <Foundation/Foundation.h>
 
 extern NSString *const ARUseStagingDefault;
+extern NSString *const ARUsePREmissionDefault;
+extern NSString *const ARPREmissionIDDefault;

--- a/Example/Emission/ARDefaults.m
+++ b/Example/Emission/ARDefaults.m
@@ -2,3 +2,5 @@
 #import <Foundation/Foundation.h>
 
 NSString *const ARUseStagingDefault = @"ARUseStagingDefault";
+NSString *const ARUsePREmissionDefault = @"ARUsePREmissionDefault";
+NSString *const ARPREmissionIDDefault = @"ARPREmissionIDDefault";

--- a/Example/Emission/ARRootViewController+AppHub.m
+++ b/Example/Emission/ARRootViewController+AppHub.m
@@ -8,12 +8,12 @@
 
 - (ARSectionData *)appHubSectionData;
 {
-  ARSectionData *section = [[ARSectionData alloc] initWithCellDataArray: @[
+  ARSectionData *section = [[ARSectionData alloc] initWithCellDataArray:@[
     [self appHubBuildChooser],
     [self appHubMetadata],
     [self showPRForBuild]
   ]];
-  section.headerTitle = [@"AppHub" uppercaseString];
+  [self setupSection:section withTitle:@"AppHub"];
   return section;
 }
 

--- a/Example/Emission/ARRootViewController+PRs.h
+++ b/Example/Emission/ARRootViewController+PRs.h
@@ -1,0 +1,8 @@
+#import "ARRootViewController.h"
+
+@class ARSectionData;
+@interface ARRootViewController(PR)
+
+- (ARSectionData *)prSectionData;
+
+@end

--- a/Example/Emission/ARRootViewController+PRs.m
+++ b/Example/Emission/ARRootViewController+PRs.m
@@ -1,0 +1,57 @@
+#import "ARRootViewController+AppHub.h"
+#import "NSDateFormatter+TimeAgo.h"
+#import "ARDefaults.h"
+#import "EmissionPRChooseViewController.h"
+
+#import <ARGenericTableViewController/ARGenericTableViewController.h>
+
+@implementation ARRootViewController(PR)
+
+- (ARSectionData *)prSectionData;
+{
+  ARSectionData *section = [[ARSectionData alloc] initWithCellDataArray:@[
+    [self togglePRBuilds]
+  ]];
+
+  [self setupSection:section withTitle:@"Code Review"];
+  return section;
+}
+
+- (ARCellData *)togglePRBuilds
+{
+  ARCellData *cellData = [[ARCellData alloc] initWithIdentifier:AROptionCell];
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+
+  cellData.cellConfigurationBlock = ^(UITableViewCell *cell) {
+    BOOL usingPR = [defaults boolForKey:ARUsePREmissionDefault];
+
+    if (usingPR) {
+      cell.textLabel.text = @"Disable PR Build";
+
+    } else {
+      cell.textLabel.text = @"Use a PR build of Emission";
+    }
+  };
+
+  cellData.cellSelectionBlock = ^(UITableView *tableView, NSIndexPath *indexPath) {
+    BOOL usingPR = [defaults boolForKey:ARUsePREmissionDefault];
+
+    if (!usingPR) {
+      // Show a PR chooser
+      [self presentViewController:[EmissionPRChooseViewController new] animated:YES completion:NULL];
+    } else {
+      // Undo the changes and restart
+      [self showAlertViewWithTitle:@"Restarting to undo PR mode" message:@"This will revert back to dev, or apphub based JS" actionTitle:@"Do it" actionHandler:^{
+        [defaults setBool:NO forKey:ARUsePREmissionDefault];
+        [defaults synchronize];
+
+        exit(0);
+      }];
+    }
+  };
+
+  return cellData;
+}
+
+
+@end

--- a/Example/Emission/ARRootViewController.m
+++ b/Example/Emission/ARRootViewController.m
@@ -4,12 +4,15 @@
 #import "ARAdminTableViewCell.h"
 #import <SAMKeychain/SAMKeychain.h>
 
+#import "AppDelegate.h"
 #import "ARDefaults.h"
 
 // See https://github.com/artsy/eigen/blob/master/Artsy/View_Controllers/Admin/ARAdminSettingsViewController.m
 // for examples of how to work with this.
 
 #import "ARRootViewController+AppHub.h"
+#import "ARRootViewController+PRs.h"
+
 #import <Emission/ARArtistComponentViewController.h>
 #import <Emission/ARHomeComponentViewController.h>
 #import <Emission/ARGeneComponentViewController.h>
@@ -29,19 +32,23 @@
 
   ARSectionData *appData = [[ARSectionData alloc] init];
   [self setupSection:appData withTitle:[self titleForApp]];
+  [appData addCellData:self.emissionJSLocationDescription];
   [appData addCellData:self.generateStagingSwitch];
   [tableViewData addSectionData:appData];
+
+#if TARGET_OS_SIMULATOR && defined(DEBUG)
+  ARSectionData *developerSection = [self developersSection];
+  [tableViewData addSectionData:developerSection];
+#endif
+
+  ARSectionData *reviewSection = [self prSectionData];
+  [tableViewData addSectionData:reviewSection];
 
   ARSectionData *userSection = [self userSection];
   [tableViewData addSectionData:userSection];
 
   ARSectionData *viewControllerSection = [self jumpToViewControllersSection];
   [tableViewData addSectionData:viewControllerSection];
-
-#if TARGET_OS_SIMULATOR && defined(DEBUG)
-  ARSectionData *developerSection = [self developersSection];
-  [tableViewData addSectionData:developerSection];
-#endif
 
 #if defined(DEPLOY)
   ARSectionData *appHubSection = [self appHubSectionData];
@@ -195,6 +202,19 @@
   }];
   return crashCellData;
 }
+
+- (ARCellData *)emissionJSLocationDescription
+{
+  AppDelegate *appDelegate = (id)[UIApplication sharedApplication].delegate;
+
+  ARCellData *crashCellData = [[ARCellData alloc] initWithIdentifier:AROptionCell];
+  [crashCellData setCellConfigurationBlock:^(UITableViewCell *cell) {
+    cell.textLabel.text = [appDelegate emissionLoadedFromString];
+  }];
+
+  return crashCellData;
+}
+
 
 - (ARSectionData *)userSection
 {

--- a/Example/Emission/AppDelegate.h
+++ b/Example/Emission/AppDelegate.h
@@ -2,5 +2,6 @@
 
 @interface AppDelegate : UIResponder <UIApplicationDelegate>
 @property (strong, nonatomic) UIWindow *window;
+@property (nonatomic, strong) NSString *emissionLoadedFromString;
 @end
 

--- a/Example/Emission/AppDelegate.m
+++ b/Example/Emission/AppDelegate.m
@@ -20,10 +20,9 @@
 #import <React/RCTUtils.h>
 #import <TargetConditionals.h>
 #import "AuthenticationManager.h"
-
-#if defined(DEPLOY)
+#import "LoadingSpinner.h"
+#import "PRNetworkModel.h"
 #import <AppHub/AppHub.h>
-#endif
 
 // Disable this to force using the release JS bundle, note that you should really do so by running a Release build.
 //
@@ -42,17 +41,20 @@ randomBOOL(void)
 
 @interface AppDelegate ()
 @property (nonatomic, strong) UINavigationController *navigationController;
+@property (nonatomic, strong) LoadingSpinner *spinner;
 @end
 
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions;
 {
-
   BOOL useStaging = [[NSUserDefaults standardUserDefaults] boolForKey:ARUseStagingDefault];
   NSString *service = useStaging? @"Emission-Staging" : @"Emission-Production";
 
+  BOOL usesPRBuild = [[NSUserDefaults standardUserDefaults] boolForKey:ARUsePREmissionDefault];
+
   AuthenticationManager *auth = [[AuthenticationManager alloc] initWithService:service];
+  self.spinner = [LoadingSpinner new];
 
   ARRootViewController *rootVC = [ARRootViewController new];
   rootVC.authenticationManager = auth;
@@ -70,16 +72,21 @@ randomBOOL(void)
   [[AppHub buildManager] setDebugBuildsEnabled:YES];
 #endif
 
-
   if ([auth isAuthenticated]) {
     NSString *accessToken = [auth token];
     if (accessToken) {
-      [self setupEmissionWithUserID:[auth userID] accessToken:accessToken keychainService:service];
+      if(usesPRBuild) {
+        [self downloadPRBuildAndLoginWithAuth:auth keychainService:service];
+      } else {
+        [self setupEmissionWithUserID:[auth userID] accessToken:accessToken keychainService:service];
+      }
     }
   } else {
-    [auth presentAuthenticationPromptOnViewController:rootVC completion:^{
-      NSLog(@"Logged in successfully :)");
-      [self setupEmissionWithUserID:[auth userID] accessToken:[auth token] keychainService:service];
+    [self.spinner presentSpinnerOnViewController:rootVC completion:^{
+      [auth presentAuthenticationPromptOnViewController:rootVC.presentedViewController completion:^{
+        NSLog(@"Logged in successfully :)");
+        [self setupEmissionWithUserID:[auth userID] accessToken:[auth token] keychainService:service];
+      }];
     }];
   }
 
@@ -92,32 +99,50 @@ randomBOOL(void)
 - (void)setupEmissionWithUserID:(NSString *)userID accessToken:(NSString *)accessToken keychainService:(NSString *)service;
 {
   AREmission *emission = nil;
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
 
-  BOOL useStaging = [[NSUserDefaults standardUserDefaults] boolForKey:ARUseStagingDefault];
+  BOOL useStaging = [defaults boolForKey:ARUseStagingDefault];
+  BOOL usePRBuild = [defaults boolForKey:ARUsePREmissionDefault];
+  BOOL useRNP = NO;
+  BOOL useAppHub = NO;
 
 #ifdef ENABLE_DEV_MODE
-  NSURL *packagerURL = [NSURL URLWithString:@"http://localhost:8081/Example/Emission/index.ios.bundle?platform=ios&dev=true"];
-  emission = [[AREmission alloc] initWithUserID:userID
-                            authenticationToken:accessToken
-                                    packagerURL:packagerURL
-                          useStagingEnvironment:useStaging
-                                      sentryDSN:nil];
-#else
-#if DEPLOY
-  AHBuild *build = [[AppHub buildManager] currentBuild];
-  NSURL *jsCodeLocation = [build.bundle URLForResource:@"main" withExtension:@"jsbundle"];
-#else
-  NSURL *jsCodeLocation = nil;
+  useRNP = YES;
 #endif
+
+#if DEPLOY
+  useAppHub = YES;
+#endif
+
+  NSURL *jsCodeLocation = nil;
+  if (usePRBuild) {
+    PRNetworkModel *pr = [PRNetworkModel new];
+    jsCodeLocation = [pr fileURLForPRJavaScript];
+    NSInteger prNumber = [defaults integerForKey:ARPREmissionIDDefault];
+    self.emissionLoadedFromString = [NSString stringWithFormat:@"PR #%@", @(prNumber)];
+
+  } else if (useRNP) {
+    jsCodeLocation = [NSURL URLWithString:@"http://localhost:8081/Example/Emission/index.ios.bundle?platform=ios&dev=true"];
+    self.emissionLoadedFromString = [NSString stringWithFormat:@"Using RNP from %@", jsCodeLocation.host];
+
+  } else if (useAppHub) {
+    AHBuild *build = [[AppHub buildManager] currentBuild];
+    jsCodeLocation = [build.bundle URLForResource:@"main" withExtension:@"jsbundle"];
+    self.emissionLoadedFromString = [NSString stringWithFormat:@"Using AppHub build %@", build.name];
+  }
+
+  // Fall back to the bundled Emission JS for release
   if (!jsCodeLocation) {
     NSBundle *emissionBundle = [NSBundle bundleForClass:AREmission.class];
     jsCodeLocation = [emissionBundle URLForResource:@"Emission" withExtension:@"js"];
+    self.emissionLoadedFromString = @"Using bundled JS";
   }
+
   emission = [[AREmission alloc] initWithUserID:userID authenticationToken:accessToken packagerURL:jsCodeLocation useStagingEnvironment:useStaging];
-#endif
   [AREmission setSharedInstance:emission];
 
-
+  ARRootViewController *controller = (id)self.navigationController.topViewController;
+  [controller.tableView reloadData];
 
   emission.APIModule.artistFollowStatusProvider = ^(NSString *artistID, RCTResponseSenderBlock block) {
     NSNumber *following = @(randomBOOL());
@@ -236,6 +261,20 @@ randomBOOL(void)
 {
   UINavigationController *navigationController = (UINavigationController *)self.window.rootViewController;
   [navigationController.visibleViewController.navigationController dismissViewControllerAnimated:YES completion:nil];
+}
+
+- (void)downloadPRBuildAndLoginWithAuth:(AuthenticationManager *)auth keychainService:(NSString *)service
+{
+  PRNetworkModel *network = [PRNetworkModel new];
+  NSUInteger prNumber = [[NSUserDefaults standardUserDefaults] integerForKey:ARPREmissionIDDefault];
+
+  [self.spinner presentSpinnerOnViewController:self.navigationController completion:^{
+    [network downloadJavaScriptForPRNumber:prNumber completion:^(NSURL * _Nullable downloadedFileURL, NSError * _Nullable error) {
+      [self.navigationController dismissViewControllerAnimated:YES completion:^{
+        [self setupEmissionWithUserID:[auth userID] accessToken:[auth token] keychainService:service];
+      }];
+    }];
+  }];
 }
 
 @end

--- a/Example/Emission/AuthenticationManager.m
+++ b/Example/Emission/AuthenticationManager.m
@@ -9,7 +9,7 @@
 #import <Artsy_Authentication/ArtsyToken.h>
 
 @interface AuthenticationManager()
-@property (nonatomic, strong) UIViewController *authenticationSpinnerController;
+@property (nonatomic, strong) UIViewController *viewController;
 @end
 
 @implementation AuthenticationManager
@@ -33,15 +33,8 @@
 
 - (void)presentAuthenticationPromptOnViewController:(UIViewController *)viewController completion:(dispatch_block_t)completion
 {
-  if (self.authenticationSpinnerController == nil) {
-    ARSpinner *spinner = [ARSpinner new];
-    [spinner startAnimating];
-    self.authenticationSpinnerController = [UIViewController new];
-    self.authenticationSpinnerController.view = spinner;
-    [viewController presentViewController:self.authenticationSpinnerController animated:NO completion:^{
-      [self showAuthenticationToArtsy:nil completion:completion];
-    }];
-  }
+  self.viewController = viewController;
+  [self showAuthenticationToArtsy:nil completion:completion];
 }
 
 /// Create an alert view to type in your user credentials
@@ -70,7 +63,7 @@
                      completion:completion];
   }]];
 
-  [self.authenticationSpinnerController presentViewController:alert animated:YES completion:nil];
+  [self.viewController presentViewController:alert animated:YES completion:nil];
 }
 
 /// Attempt to log in with creds, if it fails, set up the alert view again
@@ -110,7 +103,7 @@
               NSLog(@"%@", error);
             }
 
-            [self.authenticationSpinnerController dismissViewControllerAnimated:YES completion:nil];
+            [self.viewController dismissViewControllerAnimated:YES completion:nil];
             [self updateFromStoredCredentials];
             completion();
           }

--- a/Example/Emission/EigenLikeAdminViewController.m
+++ b/Example/Emission/EigenLikeAdminViewController.m
@@ -103,7 +103,7 @@ NSString *const ARLabOptionCell = @"LabOptionCell";
   // trigger the lines between cells.
   UIView *emptyView_ = [[UIView alloc] initWithFrame:CGRectZero];
   emptyView_.backgroundColor = [UIColor clearColor];
-  [ self.tableView setTableFooterView:emptyView_];
+  [self.tableView setTableFooterView:emptyView_];
 }
 
 @end

--- a/Example/Emission/EmissionPRChooseViewController.h
+++ b/Example/Emission/EmissionPRChooseViewController.h
@@ -1,0 +1,5 @@
+#import "EigenLikeAdminViewController.h"
+
+@interface EmissionPRChooseViewController : EigenLikeAdminViewController
+
+@end

--- a/Example/Emission/EmissionPRChooseViewController.m
+++ b/Example/Emission/EmissionPRChooseViewController.m
@@ -1,0 +1,86 @@
+#import "EmissionPRChooseViewController.h"
+#import "ARDefaults.h"
+#import "ARTickedTableViewCell.h"
+#import "PRNetworkModel.h"
+
+@implementation EmissionPRChooseViewController
+
+- (void)viewDidLoad
+{
+  [super viewDidLoad];
+
+  PRNetworkModel *network = [PRNetworkModel new];
+
+  [network getPRs:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+    if(error) {
+      NSLog(@"Error: %@", error.localizedDescription);
+      return;
+    }
+
+    NSArray *prs = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
+    ARSectionData *section = [[ARSectionData alloc] init];
+    [self setupSection:section withTitle:@"Code Review"];
+
+    for (NSDictionary *pr in prs) {
+      [section addCellData:[self sectionForPR:pr]];
+    }
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+      ARTableViewData *tableViewData = [[ARTableViewData alloc] init];
+      [self registerClass:ARTickedTableViewCell.class forCellReuseIdentifier:ARLabOptionCell];
+      [tableViewData addSectionData:section];
+      [tableViewData addSectionData:self.sectionForGoingBack];
+      self.tableViewData = tableViewData;
+      [self.tableView reloadData];
+    });
+  }];
+}
+
+- (ARCellData *)sectionForPR:(NSDictionary *)pr
+{
+  ARCellData *cellData = [[ARCellData alloc] initWithIdentifier:ARLabOptionCell];
+  PRNetworkModel *network = [PRNetworkModel new];
+
+  cellData.cellConfigurationBlock = ^(ARTickedTableViewCell *cell) {
+    cell.textLabel.text = [NSString stringWithFormat:@"#%@ - %@", pr[@"number"], pr[@"title"]];
+    [cell.textLabel setAlpha:0.5];
+    
+    [network verifyJSAtPRNumber:[pr[@"number"] intValue] completion:^(BOOL exists) {
+      [cell.textLabel setAlpha:exists ? 1 : 0.5];
+      [cell setTickSelected:exists animated:YES];
+    }];
+  };
+
+  cellData.cellSelectionBlock = ^(UITableView *tableView, NSIndexPath *indexPath) {
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    [defaults setBool:YES forKey:ARUsePREmissionDefault];
+    [defaults setInteger:[pr[@"number"] intValue] forKey:ARPREmissionIDDefault];
+    [defaults synchronize];
+
+    NSString *message = [NSString stringWithFormat:@"Converting to use: %@", pr[@"number"]];
+    [self showAlertViewWithTitle:message message:@"This will show a spinner on every app load as it gets the newest JS" actionTitle:@"Restart" actionHandler:^{
+      exit(0);
+    }];
+  };
+
+  return cellData;
+}
+
+- (ARSectionData *)sectionForGoingBack
+{
+  ARSectionData *exitSection = [[ARSectionData alloc] init];
+  [self setupSection:exitSection withTitle:@"Exit"];
+
+  ARCellData *exitData = [[ARCellData alloc] initWithIdentifier:ARLabOptionCell];
+  exitData.cellConfigurationBlock = ^(UITableViewCell *cell) {
+    cell.textLabel.text = @"Go back";
+  };
+
+  exitData.cellSelectionBlock = ^(UITableView *tableView, NSIndexPath *indexPath) {
+    [self.presentingViewController dismissViewControllerAnimated:YES completion:nil];
+  };
+
+  [exitSection addCellData:exitData];
+  return exitSection;
+}
+@end

--- a/Example/Emission/LoadingSpinner.h
+++ b/Example/Emission/LoadingSpinner.h
@@ -1,0 +1,8 @@
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+@interface LoadingSpinner : NSObject
+
+- (void)presentSpinnerOnViewController:(UIViewController *)viewController completion:(dispatch_block_t)completion;
+
+@end

--- a/Example/Emission/LoadingSpinner.m
+++ b/Example/Emission/LoadingSpinner.m
@@ -1,0 +1,22 @@
+#import "LoadingSpinner.h"
+#import <Extraction/ARSpinner.h>
+
+@interface LoadingSpinner()
+@property (nonatomic, strong) UIViewController *spinnerController;
+@end
+
+
+@implementation LoadingSpinner
+
+- (void)presentSpinnerOnViewController:(UIViewController *)viewController completion:(dispatch_block_t)completion;
+{
+  if (self.spinnerController == nil) {
+    ARSpinner *spinner = [ARSpinner new];
+    [spinner startAnimating];
+    self.spinnerController = [UIViewController new];
+    self.spinnerController.view = spinner;
+    [viewController presentViewController:self.spinnerController animated:NO completion:completion];
+  }
+}
+
+@end

--- a/Example/Emission/PRNetworkModel.h
+++ b/Example/Emission/PRNetworkModel.h
@@ -1,0 +1,13 @@
+#import <Foundation/Foundation.h>
+
+@interface PRNetworkModel : NSObject
+
+- (void)getPRs:(void (^_Nonnull)(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+
+- (void)verifyJSAtPRNumber:(NSUInteger)number completion:(void (^_Nonnull)(BOOL exists))completionHandler;
+
+- (NSURL *_Nonnull)fileURLForPRJavaScript;
+
+- (void)downloadJavaScriptForPRNumber:(NSUInteger)number completion:(void (^_Nonnull)(NSURL * _Nullable downloadedFileURL, NSError * _Nullable error))completionHandler;
+
+@end

--- a/Example/Emission/PRNetworkModel.m
+++ b/Example/Emission/PRNetworkModel.m
@@ -1,0 +1,49 @@
+#import "PRNetworkModel.h"
+
+@implementation PRNetworkModel
+
+- (void)getPRs:(void (^_Nonnull)(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error))completionHandler
+{
+  NSURL *prListURL = [NSURL URLWithString:@"https://api.github.com/repos/artsy/emission/pulls"];
+  NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithURL:prListURL completionHandler:completionHandler];
+  [task resume];
+}
+
+- (void)verifyJSAtPRNumber:(NSUInteger)number completion:(void (^_Nonnull)(BOOL exists))completionHandler
+{
+  NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"https://s3.amazonaws.com/artsy-emission-js/%@.js", @(number)]];
+  NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
+  request.HTTPMethod = @"HEAD";
+
+  NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+    NSHTTPURLResponse *httpResponse = (id)response;
+    NSInteger code = httpResponse.statusCode;
+
+    completionHandler(code == 200);
+  }];
+
+  [task resume];
+}
+
+- (NSURL *_Nonnull)fileURLForPRJavaScript
+{
+  return [[[[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask] firstObject] URLByAppendingPathComponent:@"Emission-PR.js"];
+}
+
+- (void)downloadJavaScriptForPRNumber:(NSUInteger)number completion:(void (^_Nonnull)(NSURL * _Nullable downloadedFileURL, NSError * _Nullable error))completionHandler;
+{
+  NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"https://s3.amazonaws.com/artsy-emission-js/%@.js", @(number)]];
+  NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithURL:url completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+    if(error) {
+      completionHandler(nil, error);
+      return;
+    }
+
+    NSURL *fileURL = [self fileURLForPRJavaScript];
+    [data writeToURL:fileURL atomically:YES];
+    completionHandler(fileURL, nil);
+  }];
+  [task resume];
+}
+
+@end


### PR DESCRIPTION
Allows anyone using the app to pick any current PR, assuming it has passed CI enough to upload the JS from #588 

Here's the flow:

The app normally looks like this
![screen shot 2017-06-07 at 09 13 32](https://user-images.githubusercontent.com/49038/26869958-43e8b5a6-4b66-11e7-975a-0442bd512719.png)

You want to look at the JS for a PR, so you click "Use a PR of Emission":
![screen shot 2017-06-07 at 09 52 08](https://user-images.githubusercontent.com/49038/26870186-0faca3b4-4b67-11e7-9d1c-1bf3c96e25de.png)

The grey'd out ones are unavailable to use because the JS isn't there, shouldn't be many in the future - but if we ship failing typescript then it won't bundle.

You pick one:
![screen shot 2017-06-07 at 09 42 59](https://user-images.githubusercontent.com/49038/26870218-2ef5090a-4b67-11e7-9c1b-55d4d79cc07f.png)

App restarts, and it shows a spinner while it downloads the JS from S3
![screen shot 2017-06-07 at 09 43 05](https://user-images.githubusercontent.com/49038/26870239-429f871e-4b67-11e7-855d-026515c4ed3c.png)

This happens every time, so if the PR updates, you just kill the app and load it back up. Now the main menu looks like this:

![screen shot 2017-06-07 at 09 43 16](https://user-images.githubusercontent.com/49038/26870255-5586491c-4b67-11e7-8e21-83b4d66cc355.png)

And in this case, in the storybook browser, you'll get the stories for that PR, in my case that's the "Consignments - bottom aligned".

![screen shot 2017-06-07 at 09 43 24](https://user-images.githubusercontent.com/49038/26870294-6eb5e532-4b67-11e7-99c9-310ff8440e0d.png)

---

So why the S3 instead of apphub for PRs? 

Mainly, that this is really gonna mess up our AppHub builds - we'd be creating and deleting them a lot or it'd be full of builds. I know I regularly amend my commits on PRs and so we'd need to delete all apphub builds for the PR other than head on each CI run. It turns out the API is now closed-ish, so I'd have to email for details on how to seach and delete builds.

Shipping a to a single JS file per-PR seemed the simplest way to build it.