### PR TITLE
[Dev] Adds a recommended styled-components vscode extension - #trivial

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
 	// See http://go.microsoft.com/fwlink/?LinkId=827846
 	// for the documentation about the extensions.json format
 	"recommendations": [
+		"jpoissonnier.vscode-styled-components",
 		"Orta.vscode-danger",
 		"christian-kohler.npm-intellisense",
 		"eg2.tslint",

--- a/src/lib/components/consignments/components/artist-search-results.tsx
+++ b/src/lib/components/consignments/components/artist-search-results.tsx
@@ -6,52 +6,52 @@ import colors from "../../../../data/colors"
 import fonts from "../../../../data/fonts"
 
 const Input = styled.TextInput`
-  height: 40
-  backgroundColor: black
-  color: white
-  font-family: "${fonts["garamond-regular"]}"
-  font-size: 20
-  border-bottom-color: white
-  border-bottom-width: 1
-  flex: 1
+  height: 40;
+  background-color: black;
+  color: white;
+  font-family: "${fonts["garamond-regular"]}";
+  font-size: 20;
+  border-bottom-color: white;
+  border-bottom-width: 1;
+  flex: 1;
 `
 
 const Result = styled.View`
-  flex-direction: row
-  align-items: center
-  height: 40
-  margin-bottom: 10
+  flex-direction: row;
+  align-items: center;
+  height: 40;
+  margin-bottom: 10;
 `
 
 const Image = styled.Image`
-  height: 40
-  width: 40
-  border-radius: 20
+  height: 40;
+  width: 40;
+  border-radius: 20;
 `
 
 const Text = styled.Text`
-  font-family: "${fonts["garamond-regular"]}"
-  color: white
-  font-size: 20
-  padding-top: 8
-  margin-left: 13
+  font-family: "${fonts["garamond-regular"]}";
+  color: white;
+  font-size: 20;
+  padding-top: 8;
+  margin-left: 13;
 `
 
 const UnknownLabel = styled.Text`
-  font-family: "${fonts["garamond-regular"]}"
-  color: ${colors["gray-medium"]}
-  font-size: 17
+  font-family: "${fonts["garamond-regular"]}";
+  color: ${colors["gray-medium"]};
+  font-size: 17;
 `
 
 const UnknownName = styled.Text`
-  font-family: "${fonts["garamond-italic"]}"
-  color: ${colors["gray-medium"]}
-  font-size: 17
+  font-family: "${fonts["garamond-italic"]}";
+  color: ${colors["gray-medium"]};
+  font-size: 17;
 `
 
 const Separator = styled.View`
-  background-color: ${colors["gray-regular"]}
-  height: 1
+  background-color: ${colors["gray-regular"]};
+  height: 1;
 `
 
 export interface ArtistQueryData {

--- a/src/lib/components/consignments/components/artwork-consignment-todo.tsx
+++ b/src/lib/components/consignments/components/artwork-consignment-todo.tsx
@@ -8,70 +8,70 @@ import fonts from "../../../../data/fonts"
 import { ConsignmentSetup } from "../index"
 
 const Title = styled.Text`
-  color: white
-  font-family: "${fonts["avant-garde-regular"]}"
-  flex: 1
+  color: white;
+  font-family: "${fonts["avant-garde-regular"]}";
+  flex: 1;
 `
 
 const Subtitle = styled.Text`
-  color: white
-  font-family: "${fonts["garamond-regular"]}"
-  padding-top: 6
-  flex: 1
-  text-align: right
+  color: white;
+  font-family: "${fonts["garamond-regular"]}";
+  padding-top: 6;
+  flex: 1;
+  text-align: right;
 `
 
 const InlineCopy = styled.Text`
-  color: white
-  font-family: "${fonts["garamond-regular"]}"
-  background-color: transparent
+  color: white;
+  font-family: "${fonts["garamond-regular"]}";
+  background-color: transparent;
 `
 
 const Background = styled.View`
-  background-color: black
-  flex: 1
-  padding-top: 20
-  padding-bottom: 20
-  padding-left: 20
-  padding-right: 20
+  background-color: black;
+  flex: 1;
+  padding-top: 20;
+  padding-bottom: 20;
+  padding-left: 20;
+  padding-right: 20;
 `
 
 const Separator = styled.View`
   background-color: ${colors["gray-regular"]}
-  height: 1
+  height: 1;
 `
 
 const Button = styled.View`
-  flex-direction: row
-  align-items: center
-  height: 60
+  flex-direction: row;
+  align-items: center;
+  height: 60;
 `
 
 const ImageBG = styled.View`
-  border-color: white
-  border-radius: 13
-  border-width: 1
-  width: 26
-  height: 26
-  justify-content: center
-  align-items: center
-  margin-right: 20
+  border-color: white;
+  border-radius: 13;
+  border-width: 1;
+  width: 26;
+  height: 26;
+  justify-content: center;
+  align-items: center;
+  margin-right: 20;
 `
 
 const ImageStyle = styled.Image`
-  border-color: white
-  border-width: 1
-  width: 38
-  height: 38
+  border-color: white;
+  border-width: 1;
+  width: 38;
+  height: 38;
 `
 
 const ImageDarkener = styled.View`
-  background-color: rgba(0, 0, 0, 0.5)
-  flex: 1
-  width: 38
-  justify-content: center
-  align-items: center
-  padding-top: 2
+  background-color: rgba(0, 0, 0, 0.5);
+  flex: 1;
+  width: 38;
+  justify-content: center;
+  align-items: center;
+  padding-top: 2;
 `
 
 // Can't add TouchableHighlight yet, see https://github.com/styled-components/styled-components/issues/763

--- a/src/lib/components/consignments/components/bottom-aligned-button.tsx
+++ b/src/lib/components/consignments/components/bottom-aligned-button.tsx
@@ -6,22 +6,22 @@ import colors from "../../../../data/colors"
 import fonts from "../../../../data/fonts"
 
 const ButtonText = styled.Text`
-  color: white
-  font-family: "${fonts["avant-garde-regular"]}"
-  flex: 1
-  text-align: center
-  font-size: 14
+  color: white;
+  font-family: "${fonts["avant-garde-regular"]}";
+  flex: 1;
+  text-align: center;
+  font-size: 14;
 `
 
 const Body = styled.TouchableOpacity`
-  height: 56
-  margin-bottom: 20
-  padding-top: 18
+  height: 56;
+  margin-bottom: 20;
+  padding-top: 18;
 `
 
 const Separator = styled.View`
-  background-color: ${colors["gray-regular"]}
-  height: 1
+  background-color: ${colors["gray-regular"]};
+  height: 1;
 `
 
 export interface BottomAlignedProps {


### PR DESCRIPTION
I dunno what best practices are in styled-components yet, but I added an extension that will color the text correctly.

In this PR, I also changed all of the consignments components to use `x-y` instead of `xY` to be consistent with reaction-force, and added a `;` - as that fixes the syntax colouring :)

Before:
![screen shot 2017-06-08 at 13 18 19](https://user-images.githubusercontent.com/49038/26929278-f5472900-4c50-11e7-9d77-5d6e67c38993.png)

After:
![screen shot 2017-06-08 at 13 18 57](https://user-images.githubusercontent.com/49038/26929279-f64eea4a-4c50-11e7-90d9-23908e4fc498.png)