### PR TITLE
[MSG] Added ArtworkPreview to Conversation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Emission
 
+- [Messaging] Adds an ArtworkPreview to each Conversation - sarah
 - [Messaging] Adds inbox zero state - maxim
 - [Messaging] Relay support in Conversation container - sarah
 - [Messaging] Adds a FlatList for Messages in Conversations - sarah

--- a/src/lib/components/inbox/conversations/__stories__/artwork_preview.story.tsx
+++ b/src/lib/components/inbox/conversations/__stories__/artwork_preview.story.tsx
@@ -1,0 +1,17 @@
+import { storiesOf } from "@storybook/react-native"
+import * as React from "react"
+import "react-native"
+
+import ArtworkPreview from "../artwork_preview"
+
+const artwork = {
+  id: "kara-walker-canisters-1",
+  title: "Canisters",
+  date: "1997",
+  artist_names: "Kara Walker",
+  image: {
+    url: "https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/normalized.jpg",
+  },
+}
+
+storiesOf("Conversation - Artwork Preview").add("Alone", () => <ArtworkPreview artwork={artwork} />)

--- a/src/lib/components/inbox/conversations/__stories__/artwork_preview.story.tsx
+++ b/src/lib/components/inbox/conversations/__stories__/artwork_preview.story.tsx
@@ -1,6 +1,7 @@
 import { storiesOf } from "@storybook/react-native"
 import * as React from "react"
 import "react-native"
+import StubContainer from "react-storybooks-relay-container"
 
 import ArtworkPreview from "../artwork_preview"
 
@@ -10,8 +11,13 @@ const artwork = {
   date: "1997",
   artist_names: "Kara Walker",
   image: {
-    url: "https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/normalized.jpg",
+    url: "https://d32dm0rphc51dk.cloudfront.net/bUR0QklqLHJ4_mfIzeioIQ/normalized.jpg",
   },
 }
 
-storiesOf("Conversation - Artwork Preview").add("Alone", () => <ArtworkPreview artwork={artwork} />)
+storiesOf("Conversation - Artwork Preview")
+  .add("Basic", () => <StubContainer Component={ArtworkPreview} props={{ artwork }} />)
+  .add("With a long title", () => {
+    artwork.title = "Canisters Canisters Canisters Canisters Canisters Canisters"
+    return <StubContainer Component={ArtworkPreview} props={{ artwork }} />
+  })

--- a/src/lib/components/inbox/conversations/__stories__/conversation-snippet.story.tsx
+++ b/src/lib/components/inbox/conversations/__stories__/conversation-snippet.story.tsx
@@ -19,12 +19,9 @@ const conversation: Conversation = {
       href: "/artwork/bradley-theodore-karl-and-anna-face-off-diptych",
       title: "Karl and Anna Face Off (Diptych)",
       date: "2016",
-      artist: {
-        name: "Bradley Theodore",
-      },
+      artist_names: "Bradley Theodore",
       image: {
         url: "https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/normalized.jpg",
-        image_url: "https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/:version.jpg",
       },
     },
   ],

--- a/src/lib/components/inbox/conversations/__stories__/inbox.story.tsx
+++ b/src/lib/components/inbox/conversations/__stories__/inbox.story.tsx
@@ -30,9 +30,7 @@ const meProps = {
               href: "/artwork/bradley-theodore-karl-and-anna-face-off-diptych",
               title: "Karl and Anna Face Off (Diptych)",
               date: "2016",
-              artist: {
-                name: "Bradley Theodore",
-              },
+              artist_names: "Bradley Theodore",
               image: {
                 url: "https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/normalized.jpg",
                 image_url: "https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/:version.jpg",
@@ -58,9 +56,7 @@ const meProps = {
               href: "/artwork/aida-muluneh-darkness-give-way-to-light-1",
               title: "Darkness Give Way to Light",
               date: "2016",
-              artist: {
-                name: "Aida Muluneh",
-              },
+              artist_names: "Aida Muluneh",
               image: {
                 url: "https://d32dm0rphc51dk.cloudfront.net/FDIuqbZUY1kLR-1Pd-Ec8w/normalized.jpg",
                 image_url: "https://d32dm0rphc51dk.cloudfront.net/FDIuqbZUY1kLR-1Pd-Ec8w/:version.jpg",

--- a/src/lib/components/inbox/conversations/__stories__/index.ts
+++ b/src/lib/components/inbox/conversations/__stories__/index.ts
@@ -1,3 +1,4 @@
+import "./artwork_preview.story"
 import "./composer.story.tsx"
 import "./conversation-snippet.story"
 import "./inbox.story"

--- a/src/lib/components/inbox/conversations/__tests__/__snapshots__/artwork_preview-tests.tsx.snap
+++ b/src/lib/components/inbox/conversations/__tests__/__snapshots__/artwork_preview-tests.tsx.snap
@@ -1,0 +1,132 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "borderColor": "#e5e5e5",
+        "borderWidth": 1,
+        "flexDirection": "row",
+        "marginTop": 20,
+      },
+      undefined,
+    ]
+  }
+>
+  <AROpaqueImageView
+    imageURL="https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/normalized.jpg"
+    style={
+      Array [
+        Object {
+          "height": 55,
+          "marginBottom": 12,
+          "marginLeft": 12,
+          "marginTop": 12,
+          "width": 80,
+        },
+        undefined,
+      ]
+    }
+  />
+  <View
+    style={
+      Array [
+        Object {
+          "flexBasis": 0,
+          "flexDirection": "column",
+          "flexGrow": 1,
+          "flexShrink": 1,
+        },
+        Array [
+          Object {
+            "alignSelf": "center",
+            "marginLeft": 25,
+          },
+          undefined,
+        ],
+      ]
+    }
+  >
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      disabled={false}
+      ellipsizeMode="tail"
+      numberOfLines={1}
+      style={
+        Array [
+          Object {
+            "color": "black",
+            "fontSize": 16,
+            "textAlign": "left",
+          },
+          Array [
+            Object {
+              "fontSize": 14,
+            },
+            undefined,
+          ],
+          Object {
+            "fontFamily": "AGaramondPro-Regular",
+          },
+        ]
+      }
+    >
+      Bradley Theodore
+    </Text>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      disabled={false}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "black",
+            "fontSize": 14,
+          },
+          Array [
+            Object {
+              "marginTop": 3,
+            },
+            undefined,
+          ],
+          Object {
+            "fontFamily": "AGaramondPro-Italic",
+          },
+        ]
+      }
+    >
+      Karl and Anna Face Off (Diptych)
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        disabled={false}
+        ellipsizeMode="tail"
+        numberOfLines={1}
+        style={
+          Array [
+            Object {
+              "color": "black",
+              "fontSize": 16,
+              "textAlign": "left",
+            },
+            Array [
+              Object {
+                "fontSize": 14,
+              },
+              undefined,
+            ],
+            Object {
+              "fontFamily": "AGaramondPro-Regular",
+            },
+          ]
+        }
+      >
+        , 2016
+      </Text>
+    </Text>
+  </View>
+</View>
+`;

--- a/src/lib/components/inbox/conversations/__tests__/__snapshots__/artwork_preview-tests.tsx.snap
+++ b/src/lib/components/inbox/conversations/__tests__/__snapshots__/artwork_preview-tests.tsx.snap
@@ -2,103 +2,78 @@
 
 exports[`renders correctly 1`] = `
 <View
+  accessibilityComponentType={undefined}
+  accessibilityLabel={undefined}
+  accessibilityTraits={undefined}
+  accessible={true}
+  hasTVPreferredFocus={undefined}
+  hitSlop={undefined}
+  isTVSelectable={true}
+  nativeID={undefined}
+  onLayout={undefined}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
   style={
     Array [
       Object {
-        "borderColor": "#e5e5e5",
-        "borderWidth": 1,
-        "flexDirection": "row",
-        "marginTop": 20,
+        "backgroundColor": "transparent",
       },
       undefined,
     ]
   }
+  testID={undefined}
+  tvParallaxProperties={undefined}
 >
-  <AROpaqueImageView
-    imageURL="https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/normalized.jpg"
-    style={
-      Array [
-        Object {
-          "height": 55,
-          "marginBottom": 12,
-          "marginLeft": 12,
-          "marginTop": 12,
-          "width": 80,
-        },
-        undefined,
-      ]
-    }
-  />
   <View
     style={
       Array [
         Object {
-          "flexBasis": 0,
-          "flexDirection": "column",
-          "flexGrow": 1,
-          "flexShrink": 1,
+          "borderColor": "#e5e5e5",
+          "borderWidth": 1,
+          "flexDirection": "row",
         },
-        Array [
-          Object {
-            "alignSelf": "center",
-            "marginLeft": 25,
-          },
-          undefined,
-        ],
+        undefined,
       ]
     }
   >
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      disabled={false}
-      ellipsizeMode="tail"
-      numberOfLines={1}
+    <AROpaqueImageView
+      imageURL="https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/normalized.jpg"
       style={
         Array [
           Object {
-            "color": "black",
-            "fontSize": 16,
-            "textAlign": "left",
+            "height": 55,
+            "marginBottom": 12,
+            "marginLeft": 12,
+            "marginTop": 12,
+            "width": 80,
           },
-          Array [
-            Object {
-              "fontSize": 14,
-            },
-            undefined,
-          ],
-          Object {
-            "fontFamily": "AGaramondPro-Regular",
-          },
+          undefined,
         ]
       }
-    >
-      Bradley Theodore
-    </Text>
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      disabled={false}
-      ellipsizeMode="tail"
+    />
+    <View
       style={
         Array [
           Object {
-            "color": "black",
-            "fontSize": 14,
+            "flexBasis": 0,
+            "flexDirection": "column",
+            "flexGrow": 1,
+            "flexShrink": 1,
           },
           Array [
             Object {
-              "marginTop": 3,
+              "alignSelf": "center",
+              "marginLeft": 25,
             },
             undefined,
           ],
-          Object {
-            "fontFamily": "AGaramondPro-Italic",
-          },
         ]
       }
     >
-      Karl and Anna Face Off (Diptych)
       <Text
         accessible={true}
         allowFontScaling={true}
@@ -124,9 +99,61 @@ exports[`renders correctly 1`] = `
           ]
         }
       >
-        , 2016
+        Bradley Theodore
       </Text>
-    </Text>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        disabled={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": "black",
+              "fontSize": 14,
+            },
+            Array [
+              Object {
+                "marginTop": 3,
+              },
+              undefined,
+            ],
+            Object {
+              "fontFamily": "AGaramondPro-Italic",
+            },
+          ]
+        }
+      >
+        Karl and Anna Face Off (Diptych)
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          disabled={false}
+          ellipsizeMode="tail"
+          numberOfLines={1}
+          style={
+            Array [
+              Object {
+                "color": "black",
+                "fontSize": 16,
+                "textAlign": "left",
+              },
+              Array [
+                Object {
+                  "fontSize": 14,
+                },
+                undefined,
+              ],
+              Object {
+                "fontFamily": "AGaramondPro-Regular",
+              },
+            ]
+          }
+        >
+          , 2016
+        </Text>
+      </Text>
+    </View>
   </View>
 </View>
 `;

--- a/src/lib/components/inbox/conversations/__tests__/artwork_preview-tests.tsx
+++ b/src/lib/components/inbox/conversations/__tests__/artwork_preview-tests.tsx
@@ -1,0 +1,22 @@
+import * as moment from "moment"
+import * as React from "react"
+import "react-native"
+import * as renderer from "react-test-renderer"
+
+import ArtworkPreview from "../artwork_preview"
+
+it("renders correctly", () => {
+  const tree = renderer.create(<ArtworkPreview artwork={artwork} />)
+  expect(tree).toMatchSnapshot()
+})
+
+const artwork = {
+  id: "bradley-theodore-karl-and-anna-face-off-diptych",
+  href: "/artwork/bradley-theodore-karl-and-anna-face-off-diptych",
+  title: "Karl and Anna Face Off (Diptych)",
+  date: "2016",
+  artist_names: "Bradley Theodore",
+  image: {
+    url: "https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/normalized.jpg",
+  },
+}

--- a/src/lib/components/inbox/conversations/__tests__/conversation_snippet-tests.tsx
+++ b/src/lib/components/inbox/conversations/__tests__/conversation_snippet-tests.tsx
@@ -6,7 +6,7 @@ import * as renderer from "react-test-renderer"
 import ConversationSnippet from "../conversation_snippet"
 
 it("renders correctly", () => {
-  const tree = renderer.create(<ConversationSnippet conversation={conversation} />)
+  const tree = renderer.create(<ConversationSnippet conversation={conversation} onSelected={null} />)
   expect(tree).toMatchSnapshot()
 })
 
@@ -25,9 +25,7 @@ const conversation = {
       href: "/artwork/bradley-theodore-karl-and-anna-face-off-diptych",
       title: "Karl and Anna Face Off (Diptych)",
       date: "2016",
-      artist: {
-        name: "Bradley Theodore",
-      },
+      artist_names: "Bradley Theodore",
       image: {
         url: "https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/normalized.jpg",
         image_url: "https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/:version.jpg",

--- a/src/lib/components/inbox/conversations/__tests__/conversations-tests.tsx
+++ b/src/lib/components/inbox/conversations/__tests__/conversations-tests.tsx
@@ -29,9 +29,7 @@ const meProps = {
               href: "/artwork/bradley-theodore-karl-and-anna-face-off-diptych",
               title: "Karl and Anna Face Off (Diptych)",
               date: "2016",
-              artist: {
-                name: "Bradley Theodore",
-              },
+              artist_names: "Bradley Theodore",
               image: {
                 url: "https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/normalized.jpg",
                 image_url: "https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/:version.jpg",
@@ -58,9 +56,7 @@ const meProps = {
               href: "/artwork/aida-muluneh-darkness-give-way-to-light-1",
               title: "Darkness Give Way to Light",
               date: "2016",
-              artist: {
-                name: "Aida Muluneh",
-              },
+              artist_names: "Aida Muluneh",
               image: {
                 url: "https://d32dm0rphc51dk.cloudfront.net/FDIuqbZUY1kLR-1Pd-Ec8w/normalized.jpg",
                 image_url: "https://d32dm0rphc51dk.cloudfront.net/FDIuqbZUY1kLR-1Pd-Ec8w/:version.jpg",

--- a/src/lib/components/inbox/conversations/artwork_preview.tsx
+++ b/src/lib/components/inbox/conversations/artwork_preview.tsx
@@ -1,0 +1,87 @@
+import * as React from "react"
+import * as Relay from "react-relay"
+
+import { PreviewText as P, Subtitle } from "../typography"
+
+import styled from "styled-components/native"
+import colors from "../../../../data/colors"
+import fonts from "../../../../data/fonts"
+import OpaqueImageView from "../../opaque_image_view"
+
+const Container = styled.View`
+  borderWidth: 1
+  borderColor: ${colors["gray-regular"]}
+  marginTop: 20
+  flexDirection: row
+`
+
+const VerticalLayout = styled.View`
+  flex: 1
+  flex-direction: column
+`
+
+const Image = styled(OpaqueImageView)`
+  marginTop: 12
+  marginLeft: 12
+  marginBottom: 12
+  width: 80
+  height: 55
+`
+
+const TextContainer = styled(VerticalLayout)`
+  marginLeft: 25
+  alignSelf: center
+`
+
+const SerifText = styled(P)`
+  fontSize: 14
+`
+
+const TitleAndDate = styled(Subtitle)`
+  marginTop: 3
+`
+
+export class ArtworkPreview extends React.Component<RelayProps, any> {
+  render() {
+    const artwork = this.props.artwork
+
+    return (
+      <Container>
+        <Image imageURL={artwork.image.url} />
+        <TextContainer>
+          <SerifText>{artwork.artist_names}</SerifText>
+          <TitleAndDate>
+            {artwork.title}
+            {artwork.date && <SerifText>{`, ${artwork.date}`}</SerifText>}
+          </TitleAndDate>
+        </TextContainer>
+      </Container>
+    )
+  }
+}
+
+export default Relay.createContainer(ArtworkPreview, {
+  fragments: {
+    artwork: () => Relay.QL`
+      fragment on Artwork {
+        title
+        artist_names
+        date
+        image {
+          url
+        }
+      }
+    `,
+  },
+})
+
+interface RelayProps {
+  artwork: {
+    title: string
+    artist_names: string
+    date: string | null
+    image: {
+      url: string
+    }
+  }
+}

--- a/src/lib/components/inbox/conversations/artwork_preview.tsx
+++ b/src/lib/components/inbox/conversations/artwork_preview.tsx
@@ -1,6 +1,8 @@
 import * as React from "react"
 import * as Relay from "react-relay"
 
+import { TouchableHighlight } from "react-native"
+
 import { PreviewText as P, Subtitle } from "../typography"
 
 import styled from "styled-components/native"
@@ -11,7 +13,6 @@ import OpaqueImageView from "../../opaque_image_view"
 const Container = styled.View`
   borderWidth: 1
   borderColor: ${colors["gray-regular"]}
-  marginTop: 20
   flexDirection: row
 `
 
@@ -41,21 +42,27 @@ const TitleAndDate = styled(Subtitle)`
   marginTop: 3
 `
 
-export class ArtworkPreview extends React.Component<RelayProps, any> {
+interface Props extends RelayProps {
+  onSelected?: () => void
+}
+
+export class ArtworkPreview extends React.Component<Props, any> {
   render() {
     const artwork = this.props.artwork
 
     return (
-      <Container>
-        <Image imageURL={artwork.image.url} />
-        <TextContainer>
-          <SerifText>{artwork.artist_names}</SerifText>
-          <TitleAndDate>
-            {artwork.title}
-            {artwork.date && <SerifText>{`, ${artwork.date}`}</SerifText>}
-          </TitleAndDate>
-        </TextContainer>
-      </Container>
+      <TouchableHighlight underlayColor={colors["gray-light"]} onPress={this.props.onSelected}>
+        <Container>
+          <Image imageURL={artwork.image.url} />
+          <TextContainer>
+            <SerifText>{artwork.artist_names}</SerifText>
+            <TitleAndDate>
+              {artwork.title}
+              {artwork.date && <SerifText>{`, ${artwork.date}`}</SerifText>}
+            </TitleAndDate>
+          </TextContainer>
+        </Container>
+      </TouchableHighlight>
     )
   }
 }

--- a/src/lib/components/inbox/conversations/conversation_snippet.tsx
+++ b/src/lib/components/inbox/conversations/conversation_snippet.tsx
@@ -9,7 +9,6 @@ import { StyleSheet, TouchableWithoutFeedback, ViewStyle } from "react-native"
 import styled from "styled-components/native"
 import colors from "../../../../data/colors"
 import fonts from "../../../../data/fonts"
-import SwitchBoard from "../../../native_modules/switch_board"
 import OpaqueImageView from "../../opaque_image_view"
 
 const Card = styled.View`
@@ -82,12 +81,9 @@ export interface Conversation {
       href: string | null
       title: string | null
       date: string | null
-      artist: {
-        name: string | null
-      }
+      artist_names: string | null
       image: {
         url: string | null
-        image_url: string | null
       }
     }
   >
@@ -95,6 +91,7 @@ export interface Conversation {
 
 interface Props {
   conversation: Conversation
+  onSelected?: () => void
 }
 
 export class ConversationSnippet extends React.Component<Props, any> {
@@ -105,13 +102,13 @@ export class ConversationSnippet extends React.Component<Props, any> {
     const partnerName = conversation.to_name
     const artworkTitle = `${artwork.title.trim()}, `
     const artworkDate = `${artwork.date}`
-    const artworkArtist = `${artwork.artist.name} · `
+    const artworkArtist = `${artwork.artist_names} · `
     const conversationText = conversation.last_message.replace(/\n/g, " ")
     const date = moment(conversation.last_message_at).fromNow(true)
     const imageURL = artwork.image.url
 
     return (
-      <TouchableWithoutFeedback onPress={this.handleTap.bind(this)}>
+      <TouchableWithoutFeedback onPress={this.props.onSelected}>
         <Card>
           <CardContent>
             <OpaqueImageView imageURL={imageURL} style={styles.image} />
@@ -137,10 +134,6 @@ export class ConversationSnippet extends React.Component<Props, any> {
         </Card>
       </TouchableWithoutFeedback>
     )
-  }
-
-  handleTap() {
-    SwitchBoard.presentNavigationViewController(this, `/conversation/${this.props.conversation.id}`)
   }
 }
 
@@ -173,12 +166,9 @@ export default Relay.createContainer(ConversationSnippet, {
           href
           title
           date
-          artist {
-            name
-          }
+          artist_names
           image {
             url
-            image_url
           }
         }
       }

--- a/src/lib/components/inbox/conversations/index.tsx
+++ b/src/lib/components/inbox/conversations/index.tsx
@@ -4,6 +4,7 @@ import * as Relay from "react-relay"
 import { ListView, ListViewDataSource, ScrollView, Text, View } from "react-native"
 import { LargeHeadline } from "../typography"
 
+import SwitchBoard from "../../../native_modules/switch_board"
 import ConversationSnippet from "./conversation_snippet"
 import ZeroStateInbox from "./zerostate_inbox"
 
@@ -72,7 +73,11 @@ export class Conversations extends React.Component<Props, State> {
     return (
       <ListView
         dataSource={this.state.dataSource}
-        renderRow={data => <ConversationSnippet conversation={data} />}
+        renderRow={data =>
+          <ConversationSnippet
+            conversation={data}
+            onSelected={() => SwitchBoard.presentNavigationViewController(this, `conversation/${data.id}`)}
+          />}
         onEndReached={() => this.fetchNextPage()}
         scrollEnabled={false}
       />
@@ -118,6 +123,7 @@ export default Relay.createContainer(Conversations, {
           }
           edges {
             node {
+              id
               ${ConversationSnippet.getFragment("conversation")}
             }
           }

--- a/src/lib/components/inbox/typography/index.tsx
+++ b/src/lib/components/inbox/typography/index.tsx
@@ -79,7 +79,7 @@ const styles = StyleSheet.create<Styles>({
   },
 
   subtitleDefault: {
-    fontSize: 16,
+    fontSize: 14,
     color: "black",
   },
 

--- a/src/lib/containers/__tests__/__snapshots__/conversation-tests.tsx.snap
+++ b/src/lib/containers/__tests__/__snapshots__/conversation-tests.tsx.snap
@@ -100,6 +100,134 @@ exports[`looks correct when rendered 1`] = `
       </Text>
     </View>
   </View>
+  <View
+    style={
+      Array [
+        Object {
+          "borderColor": "#e5e5e5",
+          "borderWidth": 1,
+          "flexDirection": "row",
+          "marginTop": 20,
+        },
+        undefined,
+      ]
+    }
+  >
+    <AROpaqueImageView
+      imageURL="https://d32dm0rphc51dk.cloudfront.net/W1FkNoM9IjrND_xv_DTkeg/normalized.jpg"
+      style={
+        Array [
+          Object {
+            "height": 55,
+            "marginBottom": 12,
+            "marginLeft": 12,
+            "marginTop": 12,
+            "width": 80,
+          },
+          undefined,
+        ]
+      }
+    />
+    <View
+      style={
+        Array [
+          Object {
+            "flexBasis": 0,
+            "flexDirection": "column",
+            "flexGrow": 1,
+            "flexShrink": 1,
+          },
+          Array [
+            Object {
+              "alignSelf": "center",
+              "marginLeft": 25,
+            },
+            undefined,
+          ],
+        ]
+      }
+    >
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        disabled={false}
+        ellipsizeMode="tail"
+        numberOfLines={1}
+        style={
+          Array [
+            Object {
+              "color": "black",
+              "fontSize": 16,
+              "textAlign": "left",
+            },
+            Array [
+              Object {
+                "fontSize": 14,
+              },
+              undefined,
+            ],
+            Object {
+              "fontFamily": "AGaramondPro-Regular",
+            },
+          ]
+        }
+      >
+        Adrian Piper
+      </Text>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        disabled={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": "black",
+              "fontSize": 14,
+            },
+            Array [
+              Object {
+                "marginTop": 3,
+              },
+              undefined,
+            ],
+            Object {
+              "fontFamily": "AGaramondPro-Italic",
+            },
+          ]
+        }
+      >
+        The Mythic Being: Sol’s Drawing #1–5
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          disabled={false}
+          ellipsizeMode="tail"
+          numberOfLines={1}
+          style={
+            Array [
+              Object {
+                "color": "black",
+                "fontSize": 16,
+                "textAlign": "left",
+              },
+              Array [
+                Object {
+                  "fontSize": 14,
+                },
+                undefined,
+              ],
+              Object {
+                "fontFamily": "AGaramondPro-Regular",
+              },
+            ]
+          }
+        >
+          , 1974
+        </Text>
+      </Text>
+    </View>
+  </View>
   <RCTScrollView
     ItemSeparatorComponent={[Function]}
     data={
@@ -111,7 +239,7 @@ exports[`looks correct when rendered 1`] = `
           "time": "11:00AM",
         },
         Object {
-          "body": "Hi Sarah, thanks for reaching out with your interest in this great piece by Ana Mendieta. Threestool is currently available at $3,600, please let me know if you have any other questions ",
+          "body": "Hi Sarah, thanks for reaching out with your interest in this great piece by Adrian Piper. The Mythic Being: Sol’s Drawing #1–5 is currently available at $3,600; please let me know if you have any other questions.",
           "key": 1,
           "senderName": "Kimberly Klark",
           "time": "11:00AM",
@@ -141,7 +269,7 @@ exports[`looks correct when rendered 1`] = `
     style={
       Array [
         Object {
-          "marginTop": 30,
+          "marginTop": 10,
         },
         undefined,
       ]
@@ -451,7 +579,7 @@ exports[`looks correct when rendered 1`] = `
                 ]
               }
             >
-              Hi Sarah, thanks for reaching out with your interest in this great piece by Ana Mendieta. Threestool is currently available at $3,600, please let me know if you have any other questions 
+              Hi Sarah, thanks for reaching out with your interest in this great piece by Adrian Piper. The Mythic Being: Sol’s Drawing #1–5 is currently available at $3,600; please let me know if you have any other questions.
             </Text>
           </View>
         </View>

--- a/src/lib/containers/__tests__/__snapshots__/conversation-tests.tsx.snap
+++ b/src/lib/containers/__tests__/__snapshots__/conversation-tests.tsx.snap
@@ -22,6 +22,7 @@ exports[`looks correct when rendered 1`] = `
         Object {
           "alignSelf": "stretch",
           "flexDirection": "column",
+          "marginBottom": 20,
           "marginTop": 10,
         },
         undefined,
@@ -101,103 +102,78 @@ exports[`looks correct when rendered 1`] = `
     </View>
   </View>
   <View
+    accessibilityComponentType={undefined}
+    accessibilityLabel={undefined}
+    accessibilityTraits={undefined}
+    accessible={true}
+    hasTVPreferredFocus={undefined}
+    hitSlop={undefined}
+    isTVSelectable={true}
+    nativeID={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
     style={
       Array [
         Object {
-          "borderColor": "#e5e5e5",
-          "borderWidth": 1,
-          "flexDirection": "row",
-          "marginTop": 20,
+          "backgroundColor": "transparent",
         },
         undefined,
       ]
     }
+    testID={undefined}
+    tvParallaxProperties={undefined}
   >
-    <AROpaqueImageView
-      imageURL="https://d32dm0rphc51dk.cloudfront.net/W1FkNoM9IjrND_xv_DTkeg/normalized.jpg"
-      style={
-        Array [
-          Object {
-            "height": 55,
-            "marginBottom": 12,
-            "marginLeft": 12,
-            "marginTop": 12,
-            "width": 80,
-          },
-          undefined,
-        ]
-      }
-    />
     <View
       style={
         Array [
           Object {
-            "flexBasis": 0,
-            "flexDirection": "column",
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "borderColor": "#e5e5e5",
+            "borderWidth": 1,
+            "flexDirection": "row",
           },
-          Array [
-            Object {
-              "alignSelf": "center",
-              "marginLeft": 25,
-            },
-            undefined,
-          ],
+          undefined,
         ]
       }
     >
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        disabled={false}
-        ellipsizeMode="tail"
-        numberOfLines={1}
+      <AROpaqueImageView
+        imageURL="https://d32dm0rphc51dk.cloudfront.net/W1FkNoM9IjrND_xv_DTkeg/normalized.jpg"
         style={
           Array [
             Object {
-              "color": "black",
-              "fontSize": 16,
-              "textAlign": "left",
+              "height": 55,
+              "marginBottom": 12,
+              "marginLeft": 12,
+              "marginTop": 12,
+              "width": 80,
             },
-            Array [
-              Object {
-                "fontSize": 14,
-              },
-              undefined,
-            ],
-            Object {
-              "fontFamily": "AGaramondPro-Regular",
-            },
+            undefined,
           ]
         }
-      >
-        Adrian Piper
-      </Text>
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        disabled={false}
-        ellipsizeMode="tail"
+      />
+      <View
         style={
           Array [
             Object {
-              "color": "black",
-              "fontSize": 14,
+              "flexBasis": 0,
+              "flexDirection": "column",
+              "flexGrow": 1,
+              "flexShrink": 1,
             },
             Array [
               Object {
-                "marginTop": 3,
+                "alignSelf": "center",
+                "marginLeft": 25,
               },
               undefined,
             ],
-            Object {
-              "fontFamily": "AGaramondPro-Italic",
-            },
           ]
         }
       >
-        The Mythic Being: Sol’s Drawing #1–5
         <Text
           accessible={true}
           allowFontScaling={true}
@@ -223,9 +199,61 @@ exports[`looks correct when rendered 1`] = `
             ]
           }
         >
-          , 1974
+          Adrian Piper
         </Text>
-      </Text>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          disabled={false}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "black",
+                "fontSize": 14,
+              },
+              Array [
+                Object {
+                  "marginTop": 3,
+                },
+                undefined,
+              ],
+              Object {
+                "fontFamily": "AGaramondPro-Italic",
+              },
+            ]
+          }
+        >
+          The Mythic Being: Sol’s Drawing #1–5
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            disabled={false}
+            ellipsizeMode="tail"
+            numberOfLines={1}
+            style={
+              Array [
+                Object {
+                  "color": "black",
+                  "fontSize": 16,
+                  "textAlign": "left",
+                },
+                Array [
+                  Object {
+                    "fontSize": 14,
+                  },
+                  undefined,
+                ],
+                Object {
+                  "fontFamily": "AGaramondPro-Regular",
+                },
+              ]
+            }
+          >
+            , 1974
+          </Text>
+        </Text>
+      </View>
     </View>
   </View>
   <RCTScrollView

--- a/src/lib/containers/__tests__/conversation-tests.tsx
+++ b/src/lib/containers/__tests__/conversation-tests.tsx
@@ -21,9 +21,7 @@ const props = {
         href: "/artwork/adrian-piper-the-mythic-being-sols-drawing-number-1-5",
         title: "The Mythic Being: Sol’s Drawing #1–5",
         date: "1974",
-        artist: {
-          name: "Adrian Piper",
-        },
+        artist_names: "Adrian Piper",
         image: {
           url: "https://d32dm0rphc51dk.cloudfront.net/W1FkNoM9IjrND_xv_DTkeg/normalized.jpg",
           image_url: "https://d32dm0rphc51dk.cloudfront.net/J0uofgV9e8cIxGiZwn12mg/:version.jpg",

--- a/src/lib/containers/__tests__/inbox-tests.tsx
+++ b/src/lib/containers/__tests__/inbox-tests.tsx
@@ -27,9 +27,7 @@ const meProps = {
               href: "/artwork/bradley-theodore-karl-and-anna-face-off-diptych",
               title: "Karl and Anna Face Off (Diptych)",
               date: "2016",
-              artist: {
-                name: "Bradley Theodore",
-              },
+              artist_names: "Bradley Theodore",
               image: {
                 url: "https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/normalized.jpg",
                 image_url: "https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/:version.jpg",
@@ -55,9 +53,7 @@ const meProps = {
               href: "/artwork/aida-muluneh-darkness-give-way-to-light-1",
               title: "Darkness Give Way to Light",
               date: "2016",
-              artist: {
-                name: "Aida Muluneh",
-              },
+              artist_names: "Aida Muluneh",
               image: {
                 url: "https://d32dm0rphc51dk.cloudfront.net/FDIuqbZUY1kLR-1Pd-Ec8w/normalized.jpg",
                 image_url: "https://d32dm0rphc51dk.cloudfront.net/FDIuqbZUY1kLR-1Pd-Ec8w/:version.jpg",

--- a/src/lib/containers/conversation.tsx
+++ b/src/lib/containers/conversation.tsx
@@ -10,6 +10,7 @@ import colors from "../../data/colors"
 import ArtworkPreview from "../components/inbox/conversations/artwork_preview"
 import Composer from "../components/inbox/conversations/composer"
 import Message from "../components/inbox/conversations/message"
+import ARSwitchBoard from "../native_modules/switch_board"
 
 // tslint:disable-next-line:no-var-requires
 const chevron: ImageURISource = require("../../../images/horizontal_chevron.png")
@@ -24,6 +25,7 @@ const Header = styled.View`
   alignSelf: stretch
   marginTop: 10
   flexDirection: column
+  marginBottom: 20
 `
 
 const HeaderTextContainer = styled.View`
@@ -78,7 +80,10 @@ export class Conversation extends React.Component<RelayProps, any> {
             <MetadataText>Info</MetadataText>
           </HeaderTextContainer>
         </Header>
-        <ArtworkPreview artwork={artwork} />
+        <ArtworkPreview
+          artwork={artwork}
+          onSelected={() => ARSwitchBoard.presentNavigationViewController(this, artwork.href)}
+        />
         <MessagesList
           data={data}
           renderItem={messageProps => <Message message={messageProps.item} />}
@@ -105,6 +110,7 @@ export default Relay.createContainer(Conversation, {
           artworks @relay (plural: true) {
             title
             artist_names
+            href
             ${ArtworkPreview.getFragment("artwork")}
           }
         }

--- a/src/lib/containers/conversation.tsx
+++ b/src/lib/containers/conversation.tsx
@@ -7,6 +7,7 @@ import { FlatList, ImageURISource, ViewProperties } from "react-native"
 
 import styled from "styled-components/native"
 import colors from "../../data/colors"
+import ArtworkPreview from "../components/inbox/conversations/artwork_preview"
 import Composer from "../components/inbox/conversations/composer"
 import Message from "../components/inbox/conversations/message"
 
@@ -44,21 +45,23 @@ const DottedBorder = styled.View`
 `
 
 const MessagesList = styled(FlatList)`
-  marginTop: 30
+  marginTop: 10
 `
 
 export class Conversation extends React.Component<RelayProps, any> {
   render() {
     const conversation = this.props.me.conversation
     const partnerName = conversation.to_name
+    const artwork = conversation.artworks[0]
 
     /** These are the only messages we can access at the moment; eventually we will get an array of all messages in the
      *  conversation to use as `data`
      */
     const initialMessage = conversation.initial_message
     // tslint:disable-next-line:max-line-length
-    const partnerResponse =
-      "Hi Sarah, thanks for reaching out with your interest in this great piece by Ana Mendieta. Threestool is currently available at $3,600, please let me know if you have any other questions "
+    const partnerResponse = `Hi Sarah, thanks for reaching out with your interest in this great piece by ${artwork.artist_names +
+      ". " +
+      artwork.title} is currently available at $3,600; please let me know if you have any other questions.`
     const temporaryTimestamp = "11:00AM"
 
     const data = [
@@ -75,6 +78,7 @@ export class Conversation extends React.Component<RelayProps, any> {
             <MetadataText>Info</MetadataText>
           </HeaderTextContainer>
         </Header>
+        <ArtworkPreview artwork={artwork} />
         <MessagesList
           data={data}
           renderItem={messageProps => <Message message={messageProps.item} />}
@@ -98,6 +102,11 @@ export default Relay.createContainer(Conversation, {
           from_name
           to_name
           initial_message
+          artworks @relay (plural: true) {
+            title
+            artist_names
+            ${ArtworkPreview.getFragment("artwork")}
+          }
         }
       }
     `,
@@ -111,6 +120,7 @@ interface RelayProps {
       from_name: string
       to_name: string
       initial_message: string
+      artworks: any[]
     }
   }
 }


### PR DESCRIPTION
- [x] New component 💅🏼
- [x] Changed `artists[0].name` usage throughout messaging components to `artist_names` string (oftentimes an artwork has more than one artist; this formatted string will make sure both names are properly displayed)
- [x] Add routing to Artwork container after tap
- [x] Broken story
- [x] Tests

![simulator screen shot jun 12 2017 6 30 03 pm](https://user-images.githubusercontent.com/2712962/27044475-f70118b4-4f9d-11e7-870d-a80126befb5d.png) 

