### PR TITLE
Improve SVG renderings

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "danger-plugin-yarn": "^0.2.10",
     "jest": "^20.0.4",
     "jest-react-native": "18.0.0",
-    "jest-snapshots-svg": "^0.0.11",
+    "jest-snapshots-svg": "^0.0.13",
     "lint-staged": "^3.4.1",
     "prettier": "^1.4.2",
     "react-dom": "16.0.0-alpha.12",

--- a/src/lib/components/consignments/components/__tests__/__snapshots__/toggle-tests.tsx.svg
+++ b/src/lib/components/consignments/components/__tests__/__snapshots__/toggle-tests.tsx.svg
@@ -1,33 +1,23 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <svg width="64" height="40" xmlns="http://www.w3.org/2000/svg" version="1.1">
 
- <rect x="0" y="0" width="64" height="40" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+ <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="64" height="34"/>
 
  <g transform='translate(0, 0)'>
-   <rect x="0" y="0" width="64" height="55" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+   <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="64" height="55"/>
 
    <g transform='translate(0, 0)'>
-     <rect x="8" y="9" width="48" height="22" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+     <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="8" y="9" width="48" height="22"/>
 
      <g transform='translate(8, 9)'>
-       <rect x="0" y="0" width="24" height="22" fill-opacity="0.1" stroke-width="1" stroke="black"/>
-
-       <g transform='translate(0, 0)'>
-         <rect x="0" y="0" width="24" height="0" fill-opacity="0.1" stroke-width="1" stroke="black"/>
-       </g>
-
-       <rect x="24" y="0" width="24" height="22" fill-opacity="0.1" stroke-width="1" stroke="black"/>
-
-       <g transform='translate(24, 0)'>
-         <rect x="0" y="0" width="24" height="0" fill-opacity="0.1" stroke-width="1" stroke="black"/>
-       </g>
-
+       <rect type="Text" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="24" height="22"/>
+       <rect type="Text" fill-opacity="0.1" stroke-width="1" stroke="black" x="24" y="0" width="24" height="22"/>
      </g>
 
-     <rect x="0" y="31" width="64" height="24" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+     <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="31" width="64" height="24"/>
 
      <g transform='translate(0, 31)'>
-       <rect x="40" y="0" width="24" height="24" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+       <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="40" y="0" width="24" height="24"/>
      </g>
 
    </g>

--- a/src/lib/components/inbox/conversations/__tests__/__snapshots__/zerostate_inbox-tests.tsx.svg
+++ b/src/lib/components/inbox/conversations/__tests__/__snapshots__/zerostate_inbox-tests.tsx.svg
@@ -1,67 +1,42 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<svg width="320" height="520" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg width="480" height="1024" xmlns="http://www.w3.org/2000/svg" version="1.1">
 
- <rect x="0" y="0" width="320" height="520" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+ <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="480" height="1024"/>
 
  <g transform='translate(0, 0)'>
-   <rect x="0" y="0" width="320" height="520" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+   <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="480" height="1024"/>
 
    <g transform='translate(0, 0)'>
-     <rect x="110" y="0" width="100" height="700" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+     <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="100" y="0" width="280" height="735"/>
 
-     <g transform='translate(110, 0)'>
-       <rect x="0" y="0" width="100" height="60" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+     <g transform='translate(100, 0)'>
+       <rect type="Text" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="35" width="280" height="60"/>
+       <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="20" y="145" width="260" height="60"/>
 
-       <g transform='translate(0, 0)'>
-         <rect x="20" y="0" width="60" height="0" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+       <g transform='translate(20, 145)'>
+         <rect type="Image" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="40" height="60"/>
+         <rect type="Text" fill-opacity="0.1" stroke-width="1" stroke="black" x="40" y="0" width="40" height="60"/>
        </g>
 
-       <rect x="20" y="110" width="80" height="60" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+       <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="20" y="305" width="260" height="60"/>
 
-       <g transform='translate(20, 110)'>
-         <rect x="0" y="0" width="40" height="60" fill-opacity="0.1" stroke-width="1" stroke="black"/>
-         <rect x="40" y="0" width="40" height="60" fill-opacity="0.1" stroke-width="1" stroke="black"/>
-
-         <g transform='translate(40, 0)'>
-           <rect x="20" y="0" width="0" height="0" fill-opacity="0.1" stroke-width="1" stroke="black"/>
-         </g>
-
+       <g transform='translate(20, 305)'>
+         <rect type="Image" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="40" height="60"/>
+         <rect type="Text" fill-opacity="0.1" stroke-width="1" stroke="black" x="40" y="0" width="40" height="60"/>
        </g>
 
-       <rect x="20" y="270" width="80" height="60" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+       <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="20" y="465" width="260" height="60"/>
 
-       <g transform='translate(20, 270)'>
-         <rect x="0" y="0" width="40" height="60" fill-opacity="0.1" stroke-width="1" stroke="black"/>
-         <rect x="40" y="0" width="40" height="60" fill-opacity="0.1" stroke-width="1" stroke="black"/>
-
-         <g transform='translate(40, 0)'>
-           <rect x="20" y="0" width="0" height="0" fill-opacity="0.1" stroke-width="1" stroke="black"/>
-         </g>
-
+       <g transform='translate(20, 465)'>
+         <rect type="Image" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="40" height="60"/>
+         <rect type="Text" fill-opacity="0.1" stroke-width="1" stroke="black" x="40" y="0" width="40" height="60"/>
        </g>
 
-       <rect x="20" y="430" width="80" height="60" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+       <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="20" y="625" width="260" height="60"/>
 
-       <g transform='translate(20, 430)'>
-         <rect x="0" y="0" width="40" height="60" fill-opacity="0.1" stroke-width="1" stroke="black"/>
-         <rect x="40" y="0" width="40" height="60" fill-opacity="0.1" stroke-width="1" stroke="black"/>
-
-         <g transform='translate(40, 0)'>
-           <rect x="20" y="0" width="0" height="0" fill-opacity="0.1" stroke-width="1" stroke="black"/>
-         </g>
-
-       </g>
-
-       <rect x="20" y="590" width="80" height="60" fill-opacity="0.1" stroke-width="1" stroke="black"/>
-
-       <g transform='translate(20, 590)'>
-         <rect x="0" y="0" width="40" height="60" fill-opacity="0.1" stroke-width="1" stroke="black"/>
-         <rect x="40" y="0" width="40" height="60" fill-opacity="0.1" stroke-width="1" stroke="black"/>
-
-         <g transform='translate(40, 0)'>
-           <rect x="20" y="0" width="0" height="0" fill-opacity="0.1" stroke-width="1" stroke="black"/>
-         </g>
-
+       <g transform='translate(20, 625)'>
+         <rect type="Image" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="40" height="60"/>
+         <rect type="Text" fill-opacity="0.1" stroke-width="1" stroke="black" x="40" y="0" width="40" height="60"/>
        </g>
 
      </g>

--- a/src/lib/components/inbox/conversations/__tests__/zerostate_inbox-tests.tsx
+++ b/src/lib/components/inbox/conversations/__tests__/zerostate_inbox-tests.tsx
@@ -12,5 +12,5 @@ it("looks correct when the user has no conversations", () => {
 
 it("renders correct when the user has no conversations", () => {
   const tree = renderer.create(<Inbox me={{ conversations: { edges: [] } }} />).toJSON()
-  expect(tree).toMatchSVGSnapshot(320, 520)
+  expect(tree).toMatchSVGSnapshot(480, 1024)
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3849,7 +3849,7 @@ istanbul-lib-hook@^1.0.6:
   dependencies:
     append-transform "^0.4.0"
 
-istanbul-lib-instrument@^1.4.2:
+istanbul-lib-instrument@^1.4.2, istanbul-lib-instrument@^1.6.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.6.2.tgz#dac644f358f51efd6113536d7070959a0111f73b"
   dependencies:
@@ -3861,7 +3861,7 @@ istanbul-lib-instrument@^1.4.2:
     istanbul-lib-coverage "^1.0.0"
     semver "^5.3.0"
 
-istanbul-lib-instrument@^1.6.2, istanbul-lib-instrument@^1.7.1:
+istanbul-lib-instrument@^1.7.1:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.1.tgz#169e31bc62c778851a99439dd99c3cc12184d360"
   dependencies:
@@ -4126,9 +4126,9 @@ jest-snapshot@^20.0.3:
     natural-compare "^1.4.0"
     pretty-format "^20.0.3"
 
-jest-snapshots-svg@^0.0.11:
-  version "0.0.11"
-  resolved "https://registry.yarnpkg.com/jest-snapshots-svg/-/jest-snapshots-svg-0.0.11.tgz#6a0b40740078fa6c746b89b7e1812d0f53022d45"
+jest-snapshots-svg@^0.0.13:
+  version "0.0.13"
+  resolved "https://registry.yarnpkg.com/jest-snapshots-svg/-/jest-snapshots-svg-0.0.13.tgz#9c7e7edb080c3d4b5f28bfeb60f3930c72a60230"
   dependencies:
     nbind "^0.3.12"
     yoga-layout "^1.5.0"
@@ -4974,14 +4974,14 @@ netrc@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/netrc/-/netrc-0.1.4.tgz#6be94fcaca8d77ade0a9670dc460914c94472444"
 
-node-fetch@^1.0.1, node-fetch@^1.6.3, node-fetch@^1.7.1:
+node-fetch@^1.0.1, node-fetch@^1.7.1:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.1.tgz#899cb3d0a3c92f952c47f1b876f4c8aeabd400d5"
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
-node-fetch@^1.3.3:
+node-fetch@^1.3.3, node-fetch@^1.6.3:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.6.3.tgz#dc234edd6489982d58e8f0db4f695029abcd8c04"
   dependencies:
@@ -5124,15 +5124,7 @@ npm-which@^3.0.1:
     npm-path "^2.0.2"
     which "^1.2.10"
 
-"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-2.0.4.tgz#98b52530f2514ca90d09ec5b22c8846722375692"
-  dependencies:
-    ansi "~0.3.1"
-    are-we-there-yet "~1.1.2"
-    gauge "~1.2.5"
-
-npmlog@^4.0.2:
+"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.2:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.0.tgz#dc59bee85f64f00ed424efb2af0783df25d1c0b5"
   dependencies:
@@ -5140,6 +5132,14 @@ npmlog@^4.0.2:
     console-control-strings "~1.1.0"
     gauge "~2.7.3"
     set-blocking "~2.0.0"
+
+npmlog@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-2.0.4.tgz#98b52530f2514ca90d09ec5b22c8846722375692"
+  dependencies:
+    ansi "~0.3.1"
+    are-we-there-yet "~1.1.2"
+    gauge "~1.2.5"
 
 nth-check@~1.0.1:
   version "1.0.1"


### PR DESCRIPTION
![screen shot 2017-06-13 at 10 53 17](https://user-images.githubusercontent.com/49038/27076959-87985b98-5026-11e7-9155-e7cca79a89e5.png)

looks a lot more like 

<img width="387" alt="screen shot 2017-06-07 at 11 01 17" src="https://user-images.githubusercontent.com/373860/26981249-6f7c7aaa-4d2c-11e7-9409-8e31c9947592.png">

#trivial

---

You can see all the changes in https://github.com/orta/jest-snapshots-svg/pull/16