### PR TITLE
@sarahscott => [Messaging] WIP on updating messages connection/fragment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ playground.xcworkspace
 
 .DS_Store
 node_modules
+npm-debug.log
 Example/Pods
 Example/compile_commands.json
 Example/Emission/Configuration.h

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ###### Messaging
 
+-   Adds an `ImagePreview` to each Conversation, Relay-ified messages - matt
 -   Adds an `ArtworkPreview` to each Conversation - sarah
 -   Adds Inbox zero state - maxim
 -   Relay support in Conversation container - sarah

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -173,13 +173,13 @@ EXTERNAL SOURCES:
     :branch: fetch-user-details
     :git: https://github.com/artsy/Artsy-Authentication.git
   Emission:
-    :path: "../"
+    :path: ../
   React:
-    :path: "../node_modules/react-native"
+    :path: ../node_modules/react-native
   SentryReactNative:
-    :path: "../node_modules/react-native-sentry"
+    :path: ../node_modules/react-native-sentry
   Yoga:
-    :path: "../node_modules/react-native/ReactCommon/yoga"
+    :path: ../node_modules/react-native/ReactCommon/yoga
 
 CHECKOUT OPTIONS:
   AppHub:

--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -2807,7 +2807,10 @@ type MessagePayloadType {
 }
 
 # A message in a conversation.
-type MessageType {
+type MessageType implements Node {
+  # A globally unique ID.
+  __id: ID!
+
   # Impulse message id.
   id: String!
 
@@ -2818,6 +2821,13 @@ type MessageType {
   # Full unsanitized text.
   raw_text: String!
   attachments: [AttachmentType]
+  created_at(
+    convert_to_utc: Boolean
+    format: String
+
+    # Specify a tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
 }
 
 # A connection to a list of items.

--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -1,8 +1,3 @@
-schema {
-  query: RootQueryType
-  mutation: RootMutationType
-}
-
 # One item in an aggregation
 type AggregationCount {
   # A globally unique ID.
@@ -21,10 +16,7 @@ input AppendConversationThreadInput {
 
   # The email address of the message sender
   from: String!
-
-  # An array of email addresses that the message should be sent to
-  to: [String]
-  message_body: String!
+  body_text: String!
   clientMutationId: String
 }
 
@@ -792,6 +784,9 @@ type ArtworkContextFair {
   shows_connection(
     # Number of artworks to return
     section: String
+
+    # Sorts for shows in a fair
+    sort: ShowSort = FEATURED_DESC
     after: String
     first: Int
     before: String
@@ -1326,6 +1321,18 @@ enum ArtworkSorts {
   TITLE_DESC
 }
 
+type AttachmentType {
+  # Attachment id.
+  id: String!
+
+  # Content type of file.
+  content_type: String!
+
+  # File name.
+  file_name: String!
+  download_url: String!
+}
+
 type Author {
   # A globally unique ID.
   __id: ID!
@@ -1725,6 +1732,9 @@ type Fair {
   shows_connection(
     # Number of artworks to return
     section: String
+
+    # Sorts for shows in a fair
+    sort: ShowSort = FEATURED_DESC
     after: String
     first: Int
     before: String
@@ -2376,6 +2386,9 @@ type HomePageModuleContextFair {
   shows_connection(
     # Number of artworks to return
     section: String
+
+    # Sorts for shows in a fair
+    sort: ShowSort = FEATURED_DESC
     after: String
     first: Int
     before: String
@@ -2795,15 +2808,16 @@ type MessagePayloadType {
 
 # A message in a conversation.
 type MessageType {
-  # Impulse id.
+  # Impulse message id.
   id: String!
 
-  # Email address of sender.
-  from_email_address: String!
+  # True if message is from the user to the partner.
+  is_from_user: Boolean
+  from_email_address: String
 
-  # A snippet of the full message
-  snippet: String!
-  radiation_message_id: String!
+  # Full unsanitized text.
+  raw_text: String!
+  attachments: [AttachmentType]
 }
 
 # A connection to a list of items.
@@ -2822,6 +2836,16 @@ type MessageTypeEdge {
 
   # A cursor for use in pagination
   cursor: String!
+}
+
+type Mutation {
+  followArtist(input: FollowArtistInput!): FollowArtistPayload
+  updateCollectorProfile(input: UpdateCollectorProfileInput!): UpdateCollectorProfilePayload
+  updateConversation(input: UpdateConversationInput!): UpdateConversationPayload
+
+  # Appending a message to a conversation thread
+  appendConversationThread(input: AppendConversationThreadInput!): AppendConversationThreadPayload
+  saveArtwork(input: SaveArtworkInput!): SaveArtworkPayload
 }
 
 input Near {
@@ -3381,29 +3405,7 @@ type ProfileSearchEntity {
   is_publically_visible: Boolean
 }
 
-type ResizedImageUrl {
-  factor: Float
-  width: Int
-  height: Int
-  url: String
-}
-
-enum Role {
-  PARTICIPANT
-  OPERATOR
-}
-
-type RootMutationType {
-  followArtist(input: FollowArtistInput!): FollowArtistPayload
-  updateCollectorProfile(input: UpdateCollectorProfileInput!): UpdateCollectorProfilePayload
-  updateBuyerOutcome(input: UpdateBuyerOutcomeInput!): UpdateBuyerOutcomePayload
-
-  # Appending a message to a conversation thread
-  appendConversationThread(input: AppendConversationThreadInput!): AppendConversationThreadPayload
-  saveArtwork(input: SaveArtworkInput!): SaveArtworkPayload
-}
-
-type RootQueryType {
+type Query {
   # An Article
   article(
     # The ID of the Article
@@ -3700,6 +3702,18 @@ type RootQueryType {
 
   # A wildcard used to support complex root queries in Relay
   viewer: Viewer
+}
+
+type ResizedImageUrl {
+  factor: Float
+  width: Int
+  height: Int
+  url: String
+}
+
+enum Role {
+  PARTICIPANT
+  OPERATOR
 }
 
 type Sale {
@@ -4180,6 +4194,21 @@ type ShowEdge {
   cursor: String!
 }
 
+enum ShowSort {
+  START_AT_ASC
+  START_AT_DESC
+  END_AT_ASC
+  END_AT_DESC
+  UPDATED_AT_ASC
+  UPDATED_AT_DESC
+  NAME_ASC
+  NAME_DESC
+  FEATURED_ASC
+  FEATURED_DESC
+  SORTABLE_NAME_ASC
+  SORTABLE_NAME_DESC
+}
+
 type Status {
   gravity: StatusGravity
 
@@ -4233,17 +4262,6 @@ enum TrendingMetrics {
   ARTIST_SEARCH
 }
 
-input UpdateBuyerOutcomeInput {
-  buyer_outcome: BuyerOutcomeTypes!
-  ids: [String]
-  clientMutationId: String
-}
-
-type UpdateBuyerOutcomePayload {
-  conversations: [ConversationType]
-  clientMutationId: String
-}
-
 input UpdateCollectorProfileInput {
   loyalty_applicant: Boolean
   professional_buyer: Boolean
@@ -4289,6 +4307,17 @@ type UpdateCollectorProfilePayload {
     # Specify a tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
   ): String
+  clientMutationId: String
+}
+
+input UpdateConversationInput {
+  buyer_outcome: BuyerOutcomeTypes!
+  ids: [String]
+  clientMutationId: String
+}
+
+type UpdateConversationPayload {
+  conversations: [ConversationType]
   clientMutationId: String
 }
 

--- a/data/schema.json
+++ b/data/schema.json
@@ -2373,6 +2373,11 @@
             },
             {
               "kind": "OBJECT",
+              "name": "MessageType",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
               "name": "NotificationsFeedItem",
               "ofType": null
             },
@@ -24659,6 +24664,22 @@
           "description": "A message in a conversation.",
           "fields": [
             {
+              "name": "__id",
+              "description": "A globally unique ID.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": "Impulse message id.",
               "args": [],
@@ -24729,10 +24750,59 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "created_at",
+              "description": null,
+              "args": [
+                {
+                  "name": "convert_to_utc",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "format",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "timezone",
+                  "description": "Specify a tz database time zone, otherwise falls back to `X-TIMEZONE` header",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
-          "interfaces": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
           "enumValues": null,
           "possibleTypes": null
         },

--- a/data/schema.json
+++ b/data/schema.json
@@ -2,16 +2,16 @@
   "data": {
     "__schema": {
       "queryType": {
-        "name": "RootQueryType"
+        "name": "Query"
       },
       "mutationType": {
-        "name": "RootMutationType"
+        "name": "Mutation"
       },
       "subscriptionType": null,
       "types": [
         {
           "kind": "OBJECT",
-          "name": "RootQueryType",
+          "name": "Query",
           "description": null,
           "fields": [
             {
@@ -7378,6 +7378,16 @@
                   "defaultValue": null
                 },
                 {
+                  "name": "sort",
+                  "description": "Sorts for shows in a fair",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "ShowSort",
+                    "ofType": null
+                  },
+                  "defaultValue": "FEATURED_DESC"
+                },
+                {
                   "name": "after",
                   "description": null,
                   "type": {
@@ -8059,6 +8069,89 @@
           "inputFields": null,
           "interfaces": [],
           "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "ShowSort",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "START_AT_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "START_AT_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "END_AT_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "END_AT_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UPDATED_AT_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UPDATED_AT_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "NAME_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "NAME_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FEATURED_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FEATURED_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SORTABLE_NAME_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SORTABLE_NAME_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {
@@ -13618,6 +13711,16 @@
                     "ofType": null
                   },
                   "defaultValue": null
+                },
+                {
+                  "name": "sort",
+                  "description": "Sorts for shows in a fair",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "ShowSort",
+                    "ofType": null
+                  },
+                  "defaultValue": "FEATURED_DESC"
                 },
                 {
                   "name": "after",
@@ -19442,6 +19545,16 @@
                   "defaultValue": null
                 },
                 {
+                  "name": "sort",
+                  "description": "Sorts for shows in a fair",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "ShowSort",
+                    "ofType": null
+                  },
+                  "defaultValue": "FEATURED_DESC"
+                },
+                {
                   "name": "after",
                   "description": null,
                   "type": {
@@ -24547,7 +24660,7 @@
           "fields": [
             {
               "name": "id",
-              "description": "Impulse id.",
+              "description": "Impulse message id.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -24557,13 +24670,37 @@
                   "name": "String",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "is_from_user",
+              "description": "True if message is from the user to the partner.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "from_email_address",
-              "description": "Email address of sender.",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "raw_text",
+              "description": "Full unsanitized text.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -24578,8 +24715,35 @@
               "deprecationReason": null
             },
             {
-              "name": "snippet",
-              "description": "A snippet of the full message",
+              "name": "attachments",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "AttachmentType",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "AttachmentType",
+          "description": null,
+          "fields": [
+            {
+              "name": "id",
+              "description": "Attachment id.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -24594,7 +24758,39 @@
               "deprecationReason": null
             },
             {
-              "name": "radiation_message_id",
+              "name": "content_type",
+              "description": "Content type of file.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "file_name",
+              "description": "File name.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "download_url",
               "description": null,
               "args": [],
               "type": {
@@ -34497,7 +34693,7 @@
         },
         {
           "kind": "OBJECT",
-          "name": "RootMutationType",
+          "name": "Mutation",
           "description": null,
           "fields": [
             {
@@ -34555,7 +34751,7 @@
               "deprecationReason": null
             },
             {
-              "name": "updateBuyerOutcome",
+              "name": "updateConversation",
               "description": null,
               "args": [
                 {
@@ -34566,7 +34762,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "INPUT_OBJECT",
-                      "name": "UpdateBuyerOutcomeInput",
+                      "name": "UpdateConversationInput",
                       "ofType": null
                     }
                   },
@@ -34575,7 +34771,7 @@
               ],
               "type": {
                 "kind": "OBJECT",
-                "name": "UpdateBuyerOutcomePayload",
+                "name": "UpdateConversationPayload",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -35045,7 +35241,7 @@
         },
         {
           "kind": "INPUT_OBJECT",
-          "name": "UpdateBuyerOutcomeInput",
+          "name": "UpdateConversationInput",
           "description": null,
           "fields": null,
           "inputFields": [
@@ -35147,7 +35343,7 @@
         },
         {
           "kind": "OBJECT",
-          "name": "UpdateBuyerOutcomePayload",
+          "name": "UpdateConversationPayload",
           "description": null,
           "fields": [
             {
@@ -35219,21 +35415,7 @@
               "defaultValue": null
             },
             {
-              "name": "to",
-              "description": "An array of email addresses that the message should be sent to",
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "message_body",
+              "name": "body_text",
               "description": null,
               "type": {
                 "kind": "NON_NULL",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "tslint": "tslint",
     "sync-colors": "cd externals/elan && git fetch && git checkout origin/master && cp components/lib/variables/colors.json ../../data",
     "sync-externals": "npm run-script sync-schema && npm run-script sync-colors",
-    "sync-schema": "cd externals/metaphysics && git fetch && git checkout origin/message_details_from_impulse && yarn install && npm run dump-schema -- ../../data && rm -rf node_modules",
+    "sync-schema": "cd externals/metaphysics && git fetch && git checkout origin/master && yarn install && npm run dump-schema -- ../../data && rm -rf node_modules",
     "version": "yarn install && yarn bundle && pushd Example && pod install && popd && git add Pod/Assets Example/Podfile.lock",
     "postversion": "git push --follow-tags && env EMISSION_ROOT=\"$(pwd)\" pod repo push artsy --allow-warnings --use-json --skip-import-validation",
     "postinstall": "sed -i '' 's/#import <RCTAnimation\\/RCTValueAnimatedNode.h>/#import \"RCTValueAnimatedNode.h\"/' ./node_modules/react-native/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.h || true"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "tslint": "tslint",
     "sync-colors": "cd externals/elan && git fetch && git checkout origin/master && cp components/lib/variables/colors.json ../../data",
     "sync-externals": "npm run-script sync-schema && npm run-script sync-colors",
-    "sync-schema": "cd externals/metaphysics && git fetch && git checkout origin/master && yarn install && npm run dump-schema -- ../../data && rm -rf node_modules",
+    "sync-schema": "cd externals/metaphysics && git fetch && git checkout origin/message_details_from_impulse && yarn install && npm run dump-schema -- ../../data && rm -rf node_modules",
     "version": "yarn install && yarn bundle && pushd Example && pod install && popd && git add Pod/Assets Example/Podfile.lock",
     "postversion": "git push --follow-tags && env EMISSION_ROOT=\"$(pwd)\" pod repo push artsy --allow-warnings --use-json --skip-import-validation",
     "postinstall": "sed -i '' 's/#import <RCTAnimation\\/RCTValueAnimatedNode.h>/#import \"RCTValueAnimatedNode.h\"/' ./node_modules/react-native/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.h || true"

--- a/src/lib/Components/Inbox/Conversations/Message.tsx
+++ b/src/lib/Components/Inbox/Conversations/Message.tsx
@@ -72,7 +72,6 @@ export class Message extends React.Component<Props, any> {
 }
 
 export default Relay.createContainer(Message, {
-  initialVariables: {},
   fragments: {
     message: () => Relay.QL`
       fragment on MessageType {

--- a/src/lib/Components/Inbox/Conversations/Message.tsx
+++ b/src/lib/Components/Inbox/Conversations/Message.tsx
@@ -1,3 +1,4 @@
+import * as moment from "moment"
 import * as React from "react"
 import * as Relay from "react-relay"
 
@@ -55,13 +56,14 @@ interface Props extends RelayProps {
 
 export class Message extends React.Component<Props, any> {
   render() {
+    const date = moment(this.props.message.created_at).fromNow(true)
     return (
       <Container>
         <Avatar />
         <TextContainer>
           <Header>
             <SenderName>{this.props.senderName}</SenderName>
-            <MetadataText>{this.props.message.created_at}</MetadataText>
+            <MetadataText>{date}</MetadataText>
           </Header>
           {this.props.artworkPreview && <ArtworkPreviewContainer>{this.props.artworkPreview}</ArtworkPreviewContainer>}
           <BodyText>{this.props.message.raw_text.split("\n\nAbout")[0]}</BodyText>
@@ -77,6 +79,7 @@ export default Relay.createContainer(Message, {
       fragment on MessageType {
         raw_text
         created_at
+        is_from_user
       }
     `,
   },
@@ -84,7 +87,8 @@ export default Relay.createContainer(Message, {
 
 interface RelayProps {
   message: {
-    raw_text: string
-    created_at: string
+    raw_text: string | null
+    created_at: string | null
+    is_from_user: boolean
   }
 }

--- a/src/lib/Components/Inbox/Conversations/Message.tsx
+++ b/src/lib/Components/Inbox/Conversations/Message.tsx
@@ -49,9 +49,14 @@ const ArtworkPreviewContainer = styled.View`
   marginBottom: 10
 `
 
+const ImagePreviewContainer = styled.View`
+  marginBottom: 10
+`
+
 interface Props extends RelayProps {
   senderName: string
   artworkPreview?: JSX.Element
+  imagePreview?: JSX.Element
 }
 
 export class Message extends React.Component<Props, any> {
@@ -66,6 +71,7 @@ export class Message extends React.Component<Props, any> {
             <MetadataText>{date}</MetadataText>
           </Header>
           {this.props.artworkPreview && <ArtworkPreviewContainer>{this.props.artworkPreview}</ArtworkPreviewContainer>}
+          {this.props.imagePreview && <ImagePreviewContainer>{this.props.imagePreview}</ImagePreviewContainer>}
           <BodyText>{this.props.message.raw_text.split("\n\nAbout")[0]}</BodyText>
         </TextContainer>
       </Container>

--- a/src/lib/Components/Inbox/Conversations/Message.tsx
+++ b/src/lib/Components/Inbox/Conversations/Message.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import * as Relay from "react-relay"
 
 import { BodyText, MetadataText, SmallHeadline } from "../Typography"
 
@@ -47,29 +48,44 @@ const ArtworkPreviewContainer = styled.View`
   marginBottom: 10
 `
 
-interface Props {
-  message: {
-    senderName: string
-    time: string
-    body: string
-  }
+interface Props extends RelayProps {
+  senderName: string
   artworkPreview?: JSX.Element
 }
 
-export default class Message extends React.Component<Props, any> {
+export class Message extends React.Component<Props, any> {
   render() {
     return (
       <Container>
         <Avatar />
         <TextContainer>
           <Header>
-            <SenderName>{this.props.message.senderName}</SenderName>
-            <MetadataText>{this.props.message.time}</MetadataText>
+            <SenderName>{this.props.senderName}</SenderName>
+            <MetadataText>{this.props.message.created_at}</MetadataText>
           </Header>
           {this.props.artworkPreview && <ArtworkPreviewContainer>{this.props.artworkPreview}</ArtworkPreviewContainer>}
-          <BodyText>{this.props.message.body.split("\n\nAbout")[0]}</BodyText>
+          <BodyText>{this.props.message.raw_text.split("\n\nAbout")[0]}</BodyText>
         </TextContainer>
       </Container>
     )
+  }
+}
+
+export default Relay.createContainer(Message, {
+  initialVariables: {},
+  fragments: {
+    message: () => Relay.QL`
+      fragment on MessageType {
+        raw_text
+        created_at
+      }
+    `,
+  },
+})
+
+interface RelayProps {
+  message: {
+    raw_text: string
+    created_at: string
   }
 }

--- a/src/lib/Components/Inbox/Conversations/Previews/ArtworkPreview.tsx
+++ b/src/lib/Components/Inbox/Conversations/Previews/ArtworkPreview.tsx
@@ -3,12 +3,12 @@ import * as Relay from "react-relay"
 
 import { TouchableHighlight } from "react-native"
 
-import { PreviewText as P, Subtitle } from "../Typography"
+import { PreviewText as P, Subtitle } from "../../Typography"
 
 import styled from "styled-components/native"
-import colors from "../../../../data/colors"
-import fonts from "../../../../data/fonts"
-import OpaqueImageView from "../../OpaqueImageView"
+import colors from "../../../../../data/colors"
+import fonts from "../../../../../data/fonts"
+import OpaqueImageView from "../../../OpaqueImageView"
 
 const Container = styled.View`
   borderWidth: 1

--- a/src/lib/Components/Inbox/Conversations/Previews/ImagePreview.tsx
+++ b/src/lib/Components/Inbox/Conversations/Previews/ImagePreview.tsx
@@ -1,0 +1,45 @@
+import * as React from "react"
+import * as Relay from "react-relay"
+
+import { TouchableHighlight } from "react-native"
+
+import styled from "styled-components/native"
+import colors from "../../../../../data/colors"
+import fonts from "../../../../../data/fonts"
+import OpaqueImageView from "../../../OpaqueImageView"
+
+const Container = styled.View`
+  borderWidth: 1
+  borderColor: ${colors["gray-regular"]}
+  flexDirection: row
+`
+
+const VerticalLayout = styled.View`
+  flex: 1
+  flex-direction: column
+`
+
+const Image = styled(OpaqueImageView)`
+  marginTop: 12
+  marginLeft: 12
+  marginBottom: 12
+  width: 80
+  height: 55
+`
+
+interface Props {
+  url: string
+  onSelected?: () => void
+}
+
+export default class ImagePreview extends React.Component<Props, any> {
+  render() {
+    return (
+      <TouchableHighlight underlayColor={colors["gray-light"]} onPress={this.props.onSelected}>
+        <Container>
+          <Image skipGemini={true} imageURL={this.props.url} />
+        </Container>
+      </TouchableHighlight>
+    )
+  }
+}

--- a/src/lib/Components/Inbox/Conversations/Previews/ImagePreview.tsx
+++ b/src/lib/Components/Inbox/Conversations/Previews/ImagePreview.tsx
@@ -27,19 +27,31 @@ const Image = styled(OpaqueImageView)`
   height: 55
 `
 
-interface Props {
-  url: string
-  onSelected?: () => void
-}
-
-export default class ImagePreview extends React.Component<Props, any> {
+export class ImagePreview extends React.Component<RelayProps, any> {
   render() {
     return (
       <TouchableHighlight underlayColor={colors["gray-light"]} onPress={this.props.onSelected}>
         <Container>
-          <Image skipGemini={true} imageURL={this.props.url} />
+          <Image skipGemini={true} imageURL={this.props.imageAttachment.download_url} />
         </Container>
       </TouchableHighlight>
     )
   }
+}
+
+export default Relay.createContainer(ImagePreview, {
+  fragments: {
+    imageAttachment: () => Relay.QL`
+      fragment on AttachmentType {
+        download_url
+      }
+    `,
+  },
+})
+
+interface RelayProps {
+  imageAttachment: {
+    download_url?: string
+  }
+  onSelected?: () => void
 }

--- a/src/lib/Components/Inbox/Conversations/__stories__/ArtworkPreview.story.tsx
+++ b/src/lib/Components/Inbox/Conversations/__stories__/ArtworkPreview.story.tsx
@@ -3,7 +3,7 @@ import * as React from "react"
 import "react-native"
 import StubContainer from "react-storybooks-relay-container"
 
-import ArtworkPreview from "../ArtworkPreview"
+import ArtworkPreview from "../Previews/ArtworkPreview"
 
 const artwork = {
   id: "kara-walker-canisters-1",

--- a/src/lib/Components/Inbox/Conversations/__tests__/ArtworkPreview-tests.tsx
+++ b/src/lib/Components/Inbox/Conversations/__tests__/ArtworkPreview-tests.tsx
@@ -3,7 +3,7 @@ import * as React from "react"
 import "react-native"
 import * as renderer from "react-test-renderer"
 
-import ArtworkPreview from "../ArtworkPreview"
+import ArtworkPreview from "../Previews/ArtworkPreview"
 
 it("renders correctly", () => {
   const tree = renderer.create(<ArtworkPreview artwork={artwork} />)

--- a/src/lib/Components/Inbox/Conversations/__tests__/Message-tests.tsx
+++ b/src/lib/Components/Inbox/Conversations/__tests__/Message-tests.tsx
@@ -1,3 +1,4 @@
+import * as moment from "moment"
 import * as React from "react"
 import "react-native"
 import * as renderer from "react-test-renderer"
@@ -8,7 +9,13 @@ it("looks correct when rendered", () => {
   // tslint:disable-next-line:max-line-length
   const messageBody =
     "Hi, I'm interested in purchasing this work. Could you please provide more information about the piece, including price?"
-  const props = { senderName: "Sarah Scott", key: 0, time: "11:00AM", body: messageBody }
-  const tree = renderer.create(<Message message={props} />).toJSON()
+  const senderName = "Sarah"
+  const props = {
+    key: 0,
+    created_at: moment().subtract(30, "minutes").toISOString(),
+    raw_text: messageBody,
+    is_from_user: true,
+  }
+  const tree = renderer.create(<Message senderName={senderName} message={props} />).toJSON()
   expect(tree).toMatchSnapshot()
 })

--- a/src/lib/Components/Inbox/Conversations/__tests__/__snapshots__/Message-tests.tsx.snap
+++ b/src/lib/Components/Inbox/Conversations/__tests__/__snapshots__/Message-tests.tsx.snap
@@ -91,7 +91,7 @@ exports[`looks correct when rendered 1`] = `
           ]
         }
       >
-        SARAH SCOTT
+        SARAH
       </Text>
       <Text
         accessible={true}
@@ -112,7 +112,7 @@ exports[`looks correct when rendered 1`] = `
           ]
         }
       >
-        11:00AM
+        30 MINUTES
       </Text>
     </View>
     <Text

--- a/src/lib/Components/OpaqueImageView.tsx
+++ b/src/lib/Components/OpaqueImageView.tsx
@@ -25,6 +25,8 @@ interface Props {
   /** Any additional styling for the imageview */
   style?: any
 
+  skipGemini?: boolean
+
   /**
    * An aspect ratio created with: width / height.
    *
@@ -81,6 +83,9 @@ export default class OpaqueImageView extends React.Component<Props, State> {
 
   imageURL() {
     const imageURL = this.props.imageURL
+    if (this.props.skipGemini) {
+      return imageURL
+    }
     if (imageURL) {
       // Either scale or crop, based on if an aspect ratio is available.
       const type = this.state.aspectRatio ? "fit" : "fill"
@@ -113,6 +118,8 @@ export default class OpaqueImageView extends React.Component<Props, State> {
       imageURL: isLaidOut ? this.imageURL() : null,
       onLayout: this.onLayout,
     })
+
+    console.log(this.imageURL())
 
     // If no imageURL is given at all, simply set the placeholder background color as a view backgroundColor style so
     // that it shows immediately.

--- a/src/lib/Components/OpaqueImageView.tsx
+++ b/src/lib/Components/OpaqueImageView.tsx
@@ -119,8 +119,6 @@ export default class OpaqueImageView extends React.Component<Props, State> {
       onLayout: this.onLayout,
     })
 
-    console.log(this.imageURL())
-
     // If no imageURL is given at all, simply set the placeholder background color as a view backgroundColor style so
     // that it shows immediately.
     let backgroundColorStyle = null

--- a/src/lib/Containers/Conversation.tsx
+++ b/src/lib/Containers/Conversation.tsx
@@ -67,18 +67,13 @@ export class Conversation extends React.Component<RelayProps, any> {
     const conversation = this.props.viewer.me.conversation
     const partnerName = conversation.to.name
     const senderName = item.is_from_user ? conversation.from.name : partnerName
-    let imageAttachmentUrl
-    if (item.attachments.length > 0) {
-      if (item.attachments[0].content_type === "image/jpeg") {
-        imageAttachmentUrl = item.attachments[0].download_url
-      }
-    }
+    const hasImageAttachment = item.attachments.length > 0 && item.attachments[0].content_type === "image/jpeg"
 
     return (
       <Message
         message={item}
         senderName={senderName}
-        imagePreview={imageAttachmentUrl && <ImagePreview url={imageAttachmentUrl} />}
+        imagePreview={hasImageAttachment && <ImagePreview imageAttachment={item.attachments[0]} />}
         artworkPreview={
           item.first_message &&
           <ArtworkPreview
@@ -95,6 +90,7 @@ export class Conversation extends React.Component<RelayProps, any> {
     const partnerName = conversation.to.name
     const messages = this.props.viewer.me.conversation.messages.edges.map(({ node }, index) => {
       node.first_message = index === 0
+      node.key = node.id
       return node
     })
     return (
@@ -140,9 +136,8 @@ export default Relay.createContainer(Conversation, {
               }
               edges {
                 node {
-                  is_from_user
-                  raw_text
-                  created_at
+                  id
+                  ${Message.getFragment("message")}
                   attachments {
                     content_type
                     download_url
@@ -151,8 +146,6 @@ export default Relay.createContainer(Conversation, {
               }
             }
             artworks @relay (plural: true) {
-              title
-              artist_names
               href
               ${ArtworkPreview.getFragment("artwork")}
             }

--- a/src/lib/Containers/Conversation.tsx
+++ b/src/lib/Containers/Conversation.tsx
@@ -63,8 +63,8 @@ const ComposerContainer = styled.View`
 
 export class Conversation extends React.Component<RelayProps, any> {
   renderMessage({ item }) {
-    const artwork = this.props.viewer.me.conversation.artworks[0]
-    const conversation = this.props.viewer.me.conversation
+    const artwork = this.props.me.conversation.artworks[0]
+    const conversation = this.props.me.conversation
     const partnerName = conversation.to.name
     const senderName = item.is_from_user ? conversation.from.name : partnerName
     const hasImageAttachment = item.attachments.length > 0 && item.attachments[0].content_type === "image/jpeg"
@@ -86,9 +86,9 @@ export class Conversation extends React.Component<RelayProps, any> {
   }
 
   render() {
-    const conversation = this.props.viewer.me.conversation
+    const conversation = this.props.me.conversation
     const partnerName = conversation.to.name
-    const messages = this.props.viewer.me.conversation.messages.edges.map(({ node }, index) => {
+    const messages = this.props.me.conversation.messages.edges.map(({ node }, index) => {
       node.first_message = index === 0
       node.key = node.id
       return node
@@ -118,37 +118,35 @@ export default Relay.createContainer(Conversation, {
     conversationID: null,
   },
   fragments: {
-    viewer: () => Relay.QL`
-      fragment on Viewer {
-        me {
-          conversation(id: $conversationID) {
-            id
-            from {
-              name
-              email
+    me: () => Relay.QL`
+      fragment on Me {
+        conversation(id: $conversationID) {
+          id
+          from {
+            name
+            email
+          }
+          to {
+            name
+          }
+          messages(first: 10) {
+            pageInfo {
+              hasNextPage
             }
-            to {
-              name
-            }
-            messages(first: 10) {
-              pageInfo {
-                hasNextPage
-              }
-              edges {
-                node {
-                  id
-                  ${Message.getFragment("message")}
-                  attachments {
-                    content_type
-                    download_url
-                  }
+            edges {
+              node {
+                id
+                ${Message.getFragment("message")}
+                attachments {
+                  content_type
+                  download_url
                 }
               }
             }
-            artworks @relay (plural: true) {
-              href
-              ${ArtworkPreview.getFragment("artwork")}
-            }
+          }
+          artworks @relay (plural: true) {
+            href
+            ${ArtworkPreview.getFragment("artwork")}
           }
         }
       }
@@ -157,28 +155,26 @@ export default Relay.createContainer(Conversation, {
 })
 
 interface RelayProps {
-  viewer: {
-    me: {
-      conversation: {
-        id: string
-        from: {
-          name: string
-          email: string
+  me: {
+    conversation: {
+      id: string
+      from: {
+        name: string
+        email: string
+      }
+      to: {
+        name: string
+      }
+      artworks: any[]
+      messages: {
+        pageInfo?: {
+          hasNextPage: boolean
         }
-        to: {
-          name: string
-        }
-        artworks: any[]
-        messages: {
-          pageInfo?: {
-            hasNextPage: boolean
+        edges: Array<
+          {
+            node: any | null
           }
-          edges: Array<
-            {
-              node: any | null
-            }
-          >
-        }
+        >
       }
     }
   }

--- a/src/lib/Containers/Conversation.tsx
+++ b/src/lib/Containers/Conversation.tsx
@@ -61,18 +61,17 @@ const ComposerContainer = styled.View`
 `
 
 export class Conversation extends React.Component<RelayProps, any> {
-  renderMessage(message) {
+  renderMessage({ item }) {
     const artwork = this.props.viewer.me.conversation.artworks[0]
-    console.log(this.props.viewer.me.conversation.messages.edges[0])
     const conversation = this.props.viewer.me.conversation
     const partnerName = conversation.to.name
-    const senderName = message.is_from_user ? conversation.from.name : partnerName
+    const senderName = item.is_from_user ? conversation.from.name : partnerName
     return (
       <Message
-        message={message}
+        message={item}
         senderName={senderName}
         artworkPreview={
-          !message.index &&
+          item.first_message &&
           <ArtworkPreview
             artwork={artwork}
             onSelected={() => ARSwitchBoard.presentNavigationViewController(this, artwork.href)}
@@ -85,7 +84,10 @@ export class Conversation extends React.Component<RelayProps, any> {
   render() {
     const conversation = this.props.viewer.me.conversation
     const partnerName = conversation.to.name
-    const messages = this.props.viewer.me.conversation.messages.edges.map(edge => edge.node)
+    const messages = this.props.viewer.me.conversation.messages.edges.map(({ node }, index) => {
+      node.first_message = index === 0
+      return node
+    })
     return (
       <Container>
         <Header>
@@ -129,7 +131,9 @@ export default Relay.createContainer(Conversation, {
               }
               edges {
                 node {
-                  ${Message.getFragment("message")}
+                  is_from_user
+                  raw_text
+                  created_at
                 }
               }
             }

--- a/src/lib/Containers/Conversation.tsx
+++ b/src/lib/Containers/Conversation.tsx
@@ -7,9 +7,10 @@ import { FlatList, ImageURISource, ViewProperties } from "react-native"
 
 import styled from "styled-components/native"
 import colors from "../../data/colors"
-import ArtworkPreview from "../Components/Inbox/Conversations/ArtworkPreview"
 import Composer from "../Components/Inbox/Conversations/Composer"
 import Message from "../Components/Inbox/Conversations/Message"
+import ArtworkPreview from "../Components/Inbox/Conversations/Previews/ArtworkPreview"
+import ImagePreview from "../Components/Inbox/Conversations/Previews/ImagePreview"
 import ARSwitchBoard from "../NativeModules/SwitchBoard"
 
 // tslint:disable-next-line:no-var-requires
@@ -66,10 +67,18 @@ export class Conversation extends React.Component<RelayProps, any> {
     const conversation = this.props.viewer.me.conversation
     const partnerName = conversation.to.name
     const senderName = item.is_from_user ? conversation.from.name : partnerName
+    let imageAttachmentUrl
+    if (item.attachments.length > 0) {
+      if (item.attachments[0].content_type === "image/jpeg") {
+        imageAttachmentUrl = item.attachments[0].download_url
+      }
+    }
+
     return (
       <Message
         message={item}
         senderName={senderName}
+        imagePreview={imageAttachmentUrl && <ImagePreview url={imageAttachmentUrl} />}
         artworkPreview={
           item.first_message &&
           <ArtworkPreview
@@ -134,6 +143,10 @@ export default Relay.createContainer(Conversation, {
                   is_from_user
                   raw_text
                   created_at
+                  attachments {
+                    content_type
+                    download_url
+                  }
                 }
               }
             }

--- a/src/lib/Containers/Conversation.tsx
+++ b/src/lib/Containers/Conversation.tsx
@@ -62,9 +62,9 @@ const ComposerContainer = styled.View`
 
 export class Conversation extends React.Component<RelayProps, any> {
   renderMessage(message) {
-    const artwork = this.props.me.conversation.artworks[0]
-    console.log(this.props.me.conversation.artworks[0])
-    const conversation = this.props.me.conversation
+    const artwork = this.props.viewer.me.conversation.artworks[0]
+    console.log(this.props.viewer.me.conversation.messages.edges[0])
+    const conversation = this.props.viewer.me.conversation
     const partnerName = conversation.to.name
     const senderName = message.is_from_user ? conversation.from.name : partnerName
     return (
@@ -83,10 +83,9 @@ export class Conversation extends React.Component<RelayProps, any> {
   }
 
   render() {
-    const temporaryTimestamp = "11:00AM"
-    const conversation = this.props.me.conversation
+    const conversation = this.props.viewer.me.conversation
     const partnerName = conversation.to.name
-    const messages = this.props.me.conversation.messages.edges.map(edge => edge.node)
+    const messages = this.props.viewer.me.conversation.messages.edges.map(edge => edge.node)
     return (
       <Container>
         <Header>
@@ -112,32 +111,34 @@ export default Relay.createContainer(Conversation, {
     conversationID: null,
   },
   fragments: {
-    me: () => Relay.QL`
-      fragment on Me {
-        conversation(id: $conversationID) {
-          id
-          from {
-            name
-            email
-          }
-          to {
-            name
-          }
-          messages(first: 10) {
-            pageInfo {
-              hasNextPage
+    viewer: () => Relay.QL`
+      fragment on Viewer {
+        me {
+          conversation(id: $conversationID) {
+            id
+            from {
+              name
+              email
             }
-            edges {
-              node {
-                ${Message.getFragment("message")}
+            to {
+              name
+            }
+            messages(first: 10) {
+              pageInfo {
+                hasNextPage
+              }
+              edges {
+                node {
+                  ${Message.getFragment("message")}
+                }
               }
             }
-          }
-          artworks @relay (plural: true) {
-            title
-            artist_names
-            href
-            ${ArtworkPreview.getFragment("artwork")}
+            artworks @relay (plural: true) {
+              title
+              artist_names
+              href
+              ${ArtworkPreview.getFragment("artwork")}
+            }
           }
         }
       }
@@ -146,26 +147,28 @@ export default Relay.createContainer(Conversation, {
 })
 
 interface RelayProps {
-  me: {
-    conversation: {
-      id: string
-      from: {
-        name: string
-        email: string
-      }
-      to: {
-        name: string
-      }
-      artworks: any[]
-      messages: {
-        pageInfo?: {
-          hasNextPage: boolean
+  viewer: {
+    me: {
+      conversation: {
+        id: string
+        from: {
+          name: string
+          email: string
         }
-        edges: Array<
-          {
-            node: any | null
+        to: {
+          name: string
+        }
+        artworks: any[]
+        messages: {
+          pageInfo?: {
+            hasNextPage: boolean
           }
-        >
+          edges: Array<
+            {
+              node: any | null
+            }
+          >
+        }
       }
     }
   }

--- a/src/lib/Containers/Conversation.tsx
+++ b/src/lib/Containers/Conversation.tsx
@@ -61,14 +61,6 @@ const ComposerContainer = styled.View`
 `
 
 export class Conversation extends React.Component<RelayProps, any> {
-  isFromUser(message) {
-    /**
-     * this is a quick hacky way to alternate between user/partner messages; will be changed once we have actual email
-     * data
-     */
-    return message.from_email_address === this.props.me.conversation.from.email
-  }
-
   renderMessage(message) {
     const artwork = this.props.me.conversation.artworks[0]
     return (
@@ -92,12 +84,12 @@ export class Conversation extends React.Component<RelayProps, any> {
     const temporaryTimestamp = "11:00AM"
 
     // Ideally we will use a Relay fragment in the Message component, but for now this is good enough
-    const messageData = conversation.messages.edges.reverse().map(({ node }, index) => {
+    const messageData = conversation.messages.edges.map(({ node }, index) => {
       return {
-        senderName: this.isFromUser(node) ? conversation.from.name : partnerName,
+        senderName: node.is_from_user ? conversation.from.name : partnerName,
         key: index,
         time: temporaryTimestamp,
-        body: node.snippet,
+        body: node.raw_text,
       }
     })
 
@@ -140,8 +132,9 @@ export default Relay.createContainer(Conversation, {
           messages(first: 10) {
             edges {
               node {
-                snippet
-                from_email_address
+                raw_text
+                is_from_user
+
               }
             }
           }

--- a/src/lib/Containers/__tests__/Conversation-tests.tsx
+++ b/src/lib/Containers/__tests__/Conversation-tests.tsx
@@ -26,7 +26,7 @@ const props = {
             raw_text: "Adoro! Por favor envie-me mais informações",
             from_email_address: "anita@garibaldi.br",
             attachments: [],
-            created_at: moment().subtract(30, "minutes").toISOString(),
+            created_at: "2017-06-26T14:14:35.538Z",
           },
         },
       ],

--- a/src/lib/Containers/__tests__/Conversation-tests.tsx
+++ b/src/lib/Containers/__tests__/Conversation-tests.tsx
@@ -1,3 +1,4 @@
+import * as moment from "moment"
 import * as React from "react"
 import "react-native"
 import * as renderer from "react-test-renderer"
@@ -21,8 +22,11 @@ const props = {
       edges: [
         {
           node: {
-            snippet: "Adoro! Por favor envie-me mais informações",
+            id: 222,
+            raw_text: "Adoro! Por favor envie-me mais informações",
             from_email_address: "anita@garibaldi.br",
+            attachments: [],
+            created_at: moment().subtract(30, "minutes").toISOString(),
           },
         },
       ],

--- a/src/lib/Containers/__tests__/__snapshots__/Conversation-tests.tsx.snap
+++ b/src/lib/Containers/__tests__/__snapshots__/Conversation-tests.tsx.snap
@@ -91,10 +91,13 @@ exports[`looks correct when rendered 1`] = `
     data={
       Array [
         Object {
-          "body": "Adoro! Por favor envie-me mais informações",
-          "key": 0,
-          "senderName": "Anita Garibaldi",
-          "time": "11:00AM",
+          "attachments": Array [],
+          "created_at": "2017-06-27T08:09:32.183Z",
+          "first_message": true,
+          "from_email_address": "anita@garibaldi.br",
+          "id": 222,
+          "key": 222,
+          "raw_text": "Adoro! Por favor envie-me mais informações",
         },
       ]
     }
@@ -223,7 +226,7 @@ exports[`looks correct when rendered 1`] = `
                   ]
                 }
               >
-                ANITA GARIBALDI
+                KIMBERLY KLARK
               </Text>
               <Text
                 accessible={true}
@@ -244,7 +247,7 @@ exports[`looks correct when rendered 1`] = `
                   ]
                 }
               >
-                11:00AM
+                30 MINUTES
               </Text>
             </View>
             <View

--- a/src/lib/Containers/__tests__/__snapshots__/Conversation-tests.tsx.snap
+++ b/src/lib/Containers/__tests__/__snapshots__/Conversation-tests.tsx.snap
@@ -92,7 +92,7 @@ exports[`looks correct when rendered 1`] = `
       Array [
         Object {
           "attachments": Array [],
-          "created_at": "2017-06-27T08:09:32.183Z",
+          "created_at": "2017-06-26T14:14:35.538Z",
           "first_message": true,
           "from_email_address": "anita@garibaldi.br",
           "id": 222,
@@ -247,7 +247,7 @@ exports[`looks correct when rendered 1`] = `
                   ]
                 }
               >
-                30 MINUTES
+                A DAY
               </Text>
             </View>
             <View

--- a/src/lib/relay/config.tsx
+++ b/src/lib/relay/config.tsx
@@ -9,6 +9,8 @@ if (Emission && Emission.useStagingEnvironment) {
   metaphysicsURL = "https://metaphysics-production.artsy.net"
 }
 
+metaphysicsURL = "http://localhost:5001"
+
 export { metaphysicsURL }
 
 if (Emission) {

--- a/src/lib/relay/config.tsx
+++ b/src/lib/relay/config.tsx
@@ -9,8 +9,6 @@ if (Emission && Emission.useStagingEnvironment) {
   metaphysicsURL = "https://metaphysics-production.artsy.net"
 }
 
-metaphysicsURL = "http://localhost:5001"
-
 export { metaphysicsURL }
 
 if (Emission) {

--- a/src/lib/relay/routes.tsx
+++ b/src/lib/relay/routes.tsx
@@ -20,11 +20,11 @@ class Artist extends Relay.Route {
 
 class Conversation extends Relay.Route {
   static queries = {
-    me: (component, params) => Relay.QL`
+    viewer: (component, params) => Relay.QL`
       query {
-          me {
-            ${component.getFragment("me", params)}
-          }
+        viewer {
+          ${component.getFragment("viewer", params)}
+        }
       }
     `,
   }

--- a/src/lib/relay/routes.tsx
+++ b/src/lib/relay/routes.tsx
@@ -20,10 +20,10 @@ class Artist extends Relay.Route {
 
 class Conversation extends Relay.Route {
   static queries = {
-    viewer: (component, params) => Relay.QL`
+    me: (component, params) => Relay.QL`
       query {
-        viewer {
-          ${component.getFragment("viewer", params)}
+        me {
+          ${component.getFragment("me", params)}
         }
       }
     `,


### PR DESCRIPTION
This uses the updated schema from https://github.com/artsy/metaphysics/pull/680

It doesn't have the real Relay fragment yet...but the existing stuff does work (`raw_text` instead of `snippet`), and we now have `is_from_user` coming back from Metaphysics. I need to go back and do that in a more 'proper' way, but that should be transparent to Emission anyway.

<img width="354" alt="screen shot 2017-06-23 at 4 32 11 pm" src="https://user-images.githubusercontent.com/1457859/27499436-d4807b08-5831-11e7-8b9e-ca491b73409c.png">
