### PR TITLE
Updates Prettier to 1.5.0

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -62,5 +62,9 @@
         "iPhone",
         "ListView",
         "ARTemporaryAPIModule"
+    ],
+    "stylelint.additionalDocumentSelectors": [
+        "typescript",
+        "typescriptreact"
     ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 -   [dev] Renamed files to reflect case in component/function names - alloy
 
 ###### Emission
+
 -   Users/Devs can run any PR from inside beta/sim - orta
 -   Users now can access stories from inside the app - orta
--   [dev] Applies prettier, and adds it to the webhooks + extension settings - orta
+-   [dev] Applies prettier 1.5.0, and adds it to the webhooks + extension settings - orta
 -   [dev] Adds stories for new messaging components - maxim
 -   [dev] Upgrades Sentry to 3.0, note Eigen integrator, this may require changes to Eigen - orta
 -   [dev] Upgrades React Native to v0.45 - sarah
@@ -35,32 +36,6 @@
 -   Adds component for consignments todo  - orta
 -   Adds storybooks for consignments  - orta
 -   Adds some form elements for consignments - orta
-#### Emission
-
-- [Messaging] Implements pagination for messages - sarah
-- [Messaging] Adds an ArtworkPreview to each Conversation - sarah
-- [Messaging] Adds inbox zero state - maxim
-- [Messaging] Relay support in Conversation container - sarah
-- [Messaging] Adds a FlatList for Messages in Conversations - sarah
-- [dev] Applies prettier, and adds it to the webhooks + extension settings - orta
-- [dev] Adds stories for new messaging components - maxim
-- [Messaging] Adds Conversation, Composer, and Message components - sarah
-- [dev] Upgrades Sentry to 3.0, note Eigen integrator, this may require changes to Eigen - orta
-- [Messaging] Adds Inbox view with real data - luc
-- [dev] Upgrades React Native to v0.45 - sarah
-- [dev] Allows toggling the back button by pressing space - orta
-- Users/Devs can run any PR from inside beta/sim - orta
-- Users now can access stories from inside the app - orta
-
-#### Consignments
-
-- [dev] Adds component for attaching buttons to the keyboard  - orta
-- [dev] Adds component for artist search  - orta
-- [dev] Adds component for consignments todo  - orta
-- [dev] Adds a root component for the Consignments flow  - orta
-- [dev] Adds storybooks for consignments  - orta
-- [dev] Adds some form elements for consignments - orta
-- Added the Welcome/Overview screen for consignments - orta
 
 ### 1.3.8 & 1.3.9
 

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "styled-components": "^2.0.0"
   },
   "devDependencies": {
-    "@storybook/react-native": "^3.0.0",
+    "@storybook/react-native": "^3.1.6",
     "@types/jest": "^19.2.2",
     "@types/lodash": "^4.14.64",
     "@types/react-native": "^0.44.0",
@@ -112,6 +112,7 @@
     "jest-snapshots-svg": "^0.0.14",
     "lint-staged": "^3.4.1",
     "prettier": "^1.4.2",
+    "react-dom": "16.0.0-alpha.12",
     "react-storybooks-relay-container": "^1.0.0",
     "react-test-renderer": "16.0.0-alpha.12",
     "recursive-readdir-sync": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "jest-react-native": "18.0.0",
     "jest-snapshots-svg": "^0.0.14",
     "lint-staged": "^3.4.1",
-    "prettier": "^1.4.2",
+    "prettier": "^1.5.0",
     "react-dom": "16.0.0-alpha.12",
     "react-storybooks-relay-container": "^1.0.0",
     "react-test-renderer": "16.0.0-alpha.12",

--- a/src/lib/Components/Artist/Articles/Article.tsx
+++ b/src/lib/Components/Artist/Articles/Article.tsx
@@ -26,14 +26,20 @@ class Article extends React.Component<Props, {}> {
 
   render() {
     const article = this.props.article
-    const author = article.author && <Text style={styles.sansSerifText}>{article.author.name.toUpperCase()}</Text>
+    const author =
+      article.author &&
+      <Text style={styles.sansSerifText}>
+        {article.author.name.toUpperCase()}
+      </Text>
 
     return (
       <View style={styles.container}>
         <TouchableWithoutFeedback onPress={this.handleTap.bind(this)}>
           <View style={styles.touchableContent}>
             <ImageView style={styles.image} imageURL={article.thumbnail_image.url} />
-            <Text style={styles.serifText} numberOfLines={5}>{article.thumbnail_title}</Text>
+            <Text style={styles.serifText} numberOfLines={5}>
+              {article.thumbnail_title}
+            </Text>
             {author}
           </View>
         </TouchableWithoutFeedback>

--- a/src/lib/Components/Artist/Biography.tsx
+++ b/src/lib/Components/Artist/Biography.tsx
@@ -24,14 +24,20 @@ class Biography extends React.Component<Props, any> {
       <View style={{ marginLeft: sideMargin, marginRight: sideMargin }}>
         <Headline style={{ marginBottom: 20 }}>Biography</Headline>
         {this.blurb(artist)}
-        <SerifText style={styles.bio} numberOfLines={0}>{this.bioText()}</SerifText>
+        <SerifText style={styles.bio} numberOfLines={0}>
+          {this.bioText()}
+        </SerifText>
       </View>
     )
   }
 
   blurb(artist) {
     if (artist.blurb) {
-      return <SerifText style={styles.blurb} numberOfLines={0}>{removeMarkdown(artist.blurb)}</SerifText>
+      return (
+        <SerifText style={styles.blurb} numberOfLines={0}>
+          {removeMarkdown(artist.blurb)}
+        </SerifText>
+      )
     }
   }
 

--- a/src/lib/Components/Artist/Shows/Metadata.tsx
+++ b/src/lib/Components/Artist/Shows/Metadata.tsx
@@ -27,9 +27,16 @@ class Metadata extends React.Component<Props, any> {
     const partnerName = this.props.show.partner && this.props.show.partner.name
     return (
       <View style={styles.container}>
-        {partnerName && <Text style={styles.sansSerifText}>{partnerName.toUpperCase()}</Text>}
-        <Text style={styles.sansSerifText}>{this.showTypeString()}</Text>
-        <SerifText style={styles.serifText}>{this.props.show.name}</SerifText>
+        {partnerName &&
+          <Text style={styles.sansSerifText}>
+            {partnerName.toUpperCase()}
+          </Text>}
+        <Text style={styles.sansSerifText}>
+          {this.showTypeString()}
+        </Text>
+        <SerifText style={styles.serifText}>
+          {this.props.show.name}
+        </SerifText>
         {this.dateAndLocationString()}
         {this.statusText()}
       </View>
@@ -47,7 +54,11 @@ class Metadata extends React.Component<Props, any> {
 
     if (city || exhibition_period) {
       const text = city ? city.trim() + ", " + exhibition_period : exhibition_period
-      return <SerifText style={[styles.serifText, { color: "grey" }]}>{text}</SerifText>
+      return (
+        <SerifText style={[styles.serifText, { color: "grey" }]}>
+          {text}
+        </SerifText>
+      )
     }
     return null
   }
@@ -55,7 +66,11 @@ class Metadata extends React.Component<Props, any> {
   statusText() {
     if (this.props.show.status_update) {
       const textColor = this.props.show.status === "upcoming" ? "green-regular" : "red-regular"
-      return <SerifText style={{ color: colors[textColor] }}>{this.props.show.status_update}</SerifText>
+      return (
+        <SerifText style={{ color: colors[textColor] }}>
+          {this.props.show.status_update}
+        </SerifText>
+      )
     }
     return null
   }

--- a/src/lib/Components/Artist/Shows/index.tsx
+++ b/src/lib/Components/Artist/Shows/index.tsx
@@ -79,9 +79,8 @@ const styles = StyleSheet.create<Styles>({
   },
 })
 
-const pastShowsFragment = windowDimensions.width > 700
-  ? VariableSizeShowsList.getFragment("shows")
-  : SmallShowsList.getFragment("shows")
+const pastShowsFragment =
+  windowDimensions.width > 700 ? VariableSizeShowsList.getFragment("shows") : SmallShowsList.getFragment("shows")
 
 export default Relay.createContainer(Shows, {
   fragments: {

--- a/src/lib/Components/Artist/__stories__/ArtistArticles.story.tsx
+++ b/src/lib/Components/Artist/__stories__/ArtistArticles.story.tsx
@@ -6,7 +6,11 @@ import StubContainer from "react-storybooks-relay-container"
 import ArtistArticles from "../Articles"
 
 storiesOf("Artist Articles")
-  .addDecorator(story => <View style={{ marginTop: 20, marginLeft: 20, marginRight: 20 }}>{story()}</View>)
+  .addDecorator(story =>
+    <View style={{ marginTop: 20, marginLeft: 20, marginRight: 20 }}>
+      {story()}
+    </View>
+  )
   .add("Single Item", () => {
     const props = {
       articles: [

--- a/src/lib/Components/Artist/__stories__/ArtistHeader.story.tsx
+++ b/src/lib/Components/Artist/__stories__/ArtistHeader.story.tsx
@@ -8,7 +8,11 @@ import Routes from "../../../relay/routes"
 import ArtistHeader from "../Header"
 
 storiesOf("Artist Header")
-  .addDecorator(story => <View style={{ marginLeft: 20, marginRight: 20 }}>{story()}</View>)
+  .addDecorator(story =>
+    <View style={{ marginLeft: 20, marginRight: 20 }}>
+      {story()}
+    </View>
+  )
   .add("Real Artist - Glenn Brown", () => {
     const artistRoute = new Routes.Artist({ artistID: "glenn-brown" })
     return <RootContainer Component={ArtistHeader} route={artistRoute} />

--- a/src/lib/Components/ArtworkGrids/Artwork.tsx
+++ b/src/lib/Components/ArtworkGrids/Artwork.tsx
@@ -22,7 +22,10 @@ class Artwork extends React.Component<RelayProps, any> {
           <ImageView style={styles.image} aspectRatio={artwork.image.aspect_ratio} imageURL={artwork.image.url} />
           {this.artists()}
           {this.artworkTitle()}
-          {partnerName && <SerifText style={styles.text}>{partnerName}</SerifText>}
+          {partnerName &&
+            <SerifText style={styles.text}>
+              {partnerName}
+            </SerifText>}
           {this.saleMessage()}
         </View>
       </TouchableWithoutFeedback>
@@ -47,7 +50,9 @@ class Artwork extends React.Component<RelayProps, any> {
     if (artwork.title) {
       return (
         <SerifText style={styles.text}>
-          <SerifText style={[styles.text, styles.title]}>{artwork.title}</SerifText>
+          <SerifText style={[styles.text, styles.title]}>
+            {artwork.title}
+          </SerifText>
           {artwork.date ? ", " + artwork.date : ""}
         </SerifText>
       )
@@ -67,11 +72,18 @@ class Artwork extends React.Component<RelayProps, any> {
       return (
         <View style={{ flexDirection: "row" }}>
           <Image style={{ marginRight: 4 }} source={require("../../../../images/paddle.png")} />
-          <SerifText style={styles.text}>{text}</SerifText>
+          <SerifText style={styles.text}>
+            {text}
+          </SerifText>
         </View>
       )
     } else {
-      return artwork.sale_message && <SerifText style={styles.text}>{artwork.sale_message}</SerifText>
+      return (
+        artwork.sale_message &&
+        <SerifText style={styles.text}>
+          {artwork.sale_message}
+        </SerifText>
+      )
     }
   }
 }

--- a/src/lib/Components/ArtworkGrids/InfiniteScrollGrid.tsx
+++ b/src/lib/Components/ArtworkGrids/InfiniteScrollGrid.tsx
@@ -28,14 +28,12 @@ export const PageEndThreshold = 1000
  *   - the calculation currently only takes into account the size of the image, not if e.g. the sale message is present
  */
 
-type Artworks = Array<
-  {
-    __id: string
-    image: {
-      aspect_ratio: number | null
-    } | null
-  }
->
+type Artworks = Array<{
+  __id: string
+  image: {
+    aspect_ratio: number | null
+  } | null
+}>
 
 interface Props extends ArtistRelayProps, GeneRelayProps {
   /** The direction for the grid, currently only 'column' is supported . */

--- a/src/lib/Components/ArtworkGrids/RelayConnections/ArtistArtworksGrid.tsx
+++ b/src/lib/Components/ArtworkGrids/RelayConnections/ArtistArtworksGrid.tsx
@@ -37,16 +37,14 @@ export interface ArtistRelayProps {
       pageInfo: {
         hasNextPage: boolean
       }
-      edges: Array<
-        {
-          node: {
-            __id: string
-            image: {
-              aspect_ratio: number | null
-            } | null
+      edges: Array<{
+        node: {
+          __id: string
+          image: {
+            aspect_ratio: number | null
           } | null
-        }
-      >
+        } | null
+      }>
     } | null
   }
 }

--- a/src/lib/Components/ArtworkGrids/RelayConnections/GeneArtworksGrid.tsx
+++ b/src/lib/Components/ArtworkGrids/RelayConnections/GeneArtworksGrid.tsx
@@ -41,16 +41,14 @@ export interface GeneRelayProps {
       pageInfo: {
         hasNextPage: boolean
       }
-      edges: Array<
-        {
-          node: {
-            __id: string
-            image: {
-              aspect_ratio: number | null
-            } | null
+      edges: Array<{
+        node: {
+          __id: string
+          image: {
+            aspect_ratio: number | null
           } | null
-        }
-      >
+        } | null
+      }>
     } | null
   }
 }

--- a/src/lib/Components/Buttons/FlatWhite.tsx
+++ b/src/lib/Components/Buttons/FlatWhite.tsx
@@ -64,7 +64,9 @@ export default class WhiteButton extends React.Component<Props, State> {
     return (
       <AnimatedTouchable onPress={this.props.onPress} activeOpacity={1} {...styling}>
         <View>
-          <AnimatedHeadline style={headlineStyles}>{this.props.text}</AnimatedHeadline>
+          <AnimatedHeadline style={headlineStyles}>
+            {this.props.text}
+          </AnimatedHeadline>
         </View>
       </AnimatedTouchable>
     )

--- a/src/lib/Components/Buttons/InvertedButton.tsx
+++ b/src/lib/Components/Buttons/InvertedButton.tsx
@@ -61,11 +61,17 @@ export default class InvertedButton extends React.Component<InvertedButtonProps,
       content = <Spinner spinnerColor="white" style={{ backgroundColor: "transparent" }} />
     } else {
       const headlineStyles = [styles.text, { opacity: this.state.textOpacity }]
-      content = <AnimatedHeadline style={headlineStyles}>{this.props.text}</AnimatedHeadline>
+      content = (
+        <AnimatedHeadline style={headlineStyles}>
+          {this.props.text}
+        </AnimatedHeadline>
+      )
     }
     return (
       <AnimatedTouchable onPress={this.props.onPress} activeOpacity={1} disabled={this.props.inProgress} {...styling}>
-        <View>{content}</View>
+        <View>
+          {content}
+        </View>
       </AnimatedTouchable>
     )
   }

--- a/src/lib/Components/Buttons/__stories__/Buttons.story.tsx
+++ b/src/lib/Components/Buttons/__stories__/Buttons.story.tsx
@@ -10,7 +10,11 @@ const smallButton = { height: 26, width: 320, marginBottom: 20 }
 const largeButton = { height: 26, width: 320, marginBottom: 20 }
 
 storiesOf("Artsy Buttons")
-  .addDecorator(story => <View style={{ marginTop: 60, marginLeft: 20, marginRight: 20 }}>{story()}</View>)
+  .addDecorator(story =>
+    <View style={{ marginTop: 60, marginLeft: 20, marginRight: 20 }}>
+      {story()}
+    </View>
+  )
   .add("Flat White", () => {
     return [
       <FlatWhite text="Default" style={smallButton} />,

--- a/src/lib/Components/Consignments/Components/ArtistSearchResults.tsx
+++ b/src/lib/Components/Consignments/Components/ArtistSearchResults.tsx
@@ -49,7 +49,9 @@ export interface ArtistQueryData extends TextInputProps {
 const rowForResult = result =>
   <Result key={result.id}>
     <Image source={{ uri: result.image.url }} />
-    <Text>{result.name}</Text>
+    <Text>
+      {result.name}
+    </Text>
   </Result>
 
 const noResults = props => {

--- a/src/lib/Components/Consignments/Components/ArtworkConsignmentTodo.tsx
+++ b/src/lib/Components/Consignments/Components/ArtworkConsignmentTodo.tsx
@@ -88,13 +88,17 @@ const DoneButton = () =>
 
 const Button = (props: TouchableHighlightProperties) =>
   <TouchableHighlight {...props}>
-    <ButtonView>{(props as any).children}</ButtonView>
+    <ButtonView>
+      {(props as any).children}
+    </ButtonView>
   </TouchableHighlight>
 
 const ImagePreview = images =>
   <ImageStyle source={{ uri: images[0] }}>
     <ImageDarkener>
-      <InlineCopy>{images.length}</InlineCopy>
+      <InlineCopy>
+        {images.length}
+      </InlineCopy>
     </ImageDarkener>
   </ImageStyle>
 
@@ -112,7 +116,9 @@ const render = (props: TODOProps) =>
     <Button onPress={props.goToArtist}>
       {props.artist ? DoneButton() : ToDoButton()}
       <Title>ARTIST/DESIGNER</Title>
-      <Subtitle>{props.artist ? props.artist.name : ""}</Subtitle>
+      <Subtitle>
+        {props.artist ? props.artist.name : ""}
+      </Subtitle>
     </Button>
 
     <Separator />
@@ -126,21 +132,27 @@ const render = (props: TODOProps) =>
     <Button onPress={props.goToMetadata}>
       {props.metadata ? DoneButton() : ToDoButton()}
       <Title>METADATA</Title>
-      <Subtitle>{props.metadata ? props.metadata.displayString : ""}</Subtitle>
+      <Subtitle>
+        {props.metadata ? props.metadata.displayString : ""}
+      </Subtitle>
     </Button>
 
     <Separator />
     <Button onPress={props.goToLocation}>
       {props.location ? DoneButton() : ToDoButton()}
       <Title>LOCATION</Title>
-      <Subtitle>{props.location ? props.location : ""}</Subtitle>
+      <Subtitle>
+        {props.location ? props.location : ""}
+      </Subtitle>
     </Button>
 
     <Separator />
     <Button onPress={props.goToProvenance}>
       {props.provenance ? DoneButton() : ToDoButton()}
       <Title>PROVENANCE</Title>
-      <Subtitle numberOfLines={1}>{props.provenance ? props.provenance : ""}</Subtitle>
+      <Subtitle numberOfLines={1}>
+        {props.provenance ? props.provenance : ""}
+      </Subtitle>
     </Button>
 
     <Separator />

--- a/src/lib/Components/Consignments/Components/BottomAlignedButton.tsx
+++ b/src/lib/Components/Consignments/Components/BottomAlignedButton.tsx
@@ -31,7 +31,6 @@ export interface BottomAlignedProps {
 
 const render = (props: BottomAlignedProps) =>
   <KeyboardAvoidingView behavior="padding" keyboardVerticalOffset={60} style={{ flex: 1 }}>
-
     <View key="space-eater" style={{ flexGrow: 1 }}>
       {props.children}
     </View>

--- a/src/lib/Components/Consignments/Components/CircleImage.tsx
+++ b/src/lib/Components/Consignments/Components/CircleImage.tsx
@@ -12,4 +12,7 @@ const imageStyle: ViewStyle = {
   alignItems: "center",
 }
 
-export default props => <View style={imageStyle}><Image source={props.source} /></View>
+export default props =>
+  <View style={imageStyle}>
+    <Image source={props.source} />
+  </View>

--- a/src/lib/Components/Consignments/Components/NavButton.tsx
+++ b/src/lib/Components/Consignments/Components/NavButton.tsx
@@ -12,4 +12,7 @@ const imageStyle: ViewStyle = {
   alignItems: "center",
 }
 
-export default props => <View style={imageStyle}><Image source={props.source} /></View>
+export default props =>
+  <View style={imageStyle}>
+    <Image source={props.source} />
+  </View>

--- a/src/lib/Components/Consignments/Components/Toggle.tsx
+++ b/src/lib/Components/Consignments/Components/Toggle.tsx
@@ -75,8 +75,12 @@ const render = (props: ToggleProps) => {
     <Background style={{ backgroundColor: mainBGColor }} onPress={props.onPress}>
       <View>
         <TextBackground>
-          <Title style={{ color: leftTextColor }}>{props.left}</Title>
-          <Title style={{ color: rightTextColor }}>{props.right}</Title>
+          <Title style={{ color: leftTextColor }}>
+            {props.left}
+          </Title>
+          <Title style={{ color: rightTextColor }}>
+            {props.right}
+          </Title>
         </TextBackground>
         <CircleSpacer style={{ flexDirection: dotDirection }}>
           <Circle style={{ borderColor: dotBorder }} />

--- a/src/lib/Components/Consignments/Screens/Overview.tsx
+++ b/src/lib/Components/Consignments/Screens/Overview.tsx
@@ -24,8 +24,12 @@ export default class Info extends React.Component<Props, any> {
 
     return (
       <View style={{ backgroundColor: "black", flex: 1 }}>
-        <LargeHeadline>{title}</LargeHeadline>
-        <Subtitle>{subtitle}</Subtitle>
+        <LargeHeadline>
+          {title}
+        </LargeHeadline>
+        <Subtitle>
+          {subtitle}
+        </Subtitle>
 
         <TODO
           goToArtist={this.goToArtistTapped}

--- a/src/lib/Components/Consignments/Typography/index.tsx
+++ b/src/lib/Components/Consignments/Typography/index.tsx
@@ -7,25 +7,41 @@ import fonts from "../../../../data/fonts"
 const LargeHeadline = (props: TextProperties) => {
   const children: string = (props as any).children
   const style = [styles.largeDefault, props.style || {}, styles.largeRequired]
-  return <Text key={children} style={style}>{children}</Text>
+  return (
+    <Text key={children} style={style}>
+      {children}
+    </Text>
+  )
 }
 
 const SmallHeadline = (props: TextProperties) => {
   const children: string = (props as any).children
   const style = [styles.smallDefault, props.style || {}, styles.smallRequired]
-  return <Text key={children} style={style}>{children}</Text>
+  return (
+    <Text key={children} style={style}>
+      {children}
+    </Text>
+  )
 }
 
 const Subtitle = (props: TextProperties) => {
   const children: string = (props as any).children
   const style = [styles.subtitleDefault, props.style || {}, styles.subtitleRequired]
-  return <Text key={children} style={style}>{children}</Text>
+  return (
+    <Text key={children} style={style}>
+      {children}
+    </Text>
+  )
 }
 
 const BodyText = (props: TextProperties) => {
   const children: string = (props as any).children
   const style = [styles.bodyDefault, props.style || {}, styles.bodyRequired]
-  return <Text key={children} style={style}>{children}</Text>
+  return (
+    <Text key={children} style={style}>
+      {children}
+    </Text>
+  )
 }
 
 export { LargeHeadline, SmallHeadline, Subtitle, BodyText }

--- a/src/lib/Components/Consignments/__stories__/Style.story.tsx
+++ b/src/lib/Components/Consignments/__stories__/Style.story.tsx
@@ -41,9 +41,7 @@ storiesOf("Consignments - Styling")
         </View>
 
         <View style={{ flexDirection: "row", paddingVertical: 6, alignItems: "center" }}>
-          <T.BodyText style={{ paddingLeft: 10, flex: 1, textAlign: "left" }}>
-            Is this a toggle?
-          </T.BodyText>
+          <T.BodyText style={{ paddingLeft: 10, flex: 1, textAlign: "left" }}>Is this a toggle?</T.BodyText>
           <Toggle selected={false} left="NO" right="AYE" />
         </View>
       </View>

--- a/src/lib/Components/Gene/Biography.tsx
+++ b/src/lib/Components/Gene/Biography.tsx
@@ -26,7 +26,11 @@ class Biography extends React.Component<Props, any> {
 
   blurb(gene) {
     if (gene.description) {
-      return <SerifText style={styles.blurb} numberOfLines={0}>{removeMarkdown(gene.description)}</SerifText>
+      return (
+        <SerifText style={styles.blurb} numberOfLines={0}>
+          {removeMarkdown(gene.description)}
+        </SerifText>
+      )
     }
   }
 }

--- a/src/lib/Components/Home/ArtistRails/ArtistRail.tsx
+++ b/src/lib/Components/Home/ArtistRails/ArtistRail.tsx
@@ -173,7 +173,11 @@ class ArtistRail extends React.Component<Props, State> {
 
     return (
       <View>
-        <View style={styles.title}><SectionTitle>{this.title()}</SectionTitle></View>
+        <View style={styles.title}>
+          <SectionTitle>
+            {this.title()}
+          </SectionTitle>
+        </View>
         {this.renderModuleResults()}
         <Separator />
       </View>

--- a/src/lib/Components/Home/ArtworkRails/ArtworkRailHeader.tsx
+++ b/src/lib/Components/Home/ArtworkRails/ArtworkRailHeader.tsx
@@ -64,7 +64,11 @@ class ArtworkRailHeader extends React.Component<Props & RelayPropsWorkaround, St
   followAnnotation() {
     if (this.props.rail.key === "related_artists") {
       const name = this.props.rail.context.based_on.name
-      return <SerifText style={styles.followAnnotation}>{"Based on " + name}</SerifText>
+      return (
+        <SerifText style={styles.followAnnotation}>
+          {"Based on " + name}
+        </SerifText>
+      )
     }
   }
 
@@ -75,7 +79,11 @@ class ArtworkRailHeader extends React.Component<Props & RelayPropsWorkaround, St
 
   actionButton() {
     if (this.hasAdditionalContent()) {
-      return <Text style={styles.viewAllButton}> {"View All".toUpperCase()} </Text>
+      return (
+        <Text style={styles.viewAllButton}>
+          {" "}{"View All".toUpperCase()}{" "}
+        </Text>
+      )
     } else if (this.props.rail.key === "related_artists" || this.props.rail.key === "followed_artist") {
       return (
         <View style={styles.followButton}>

--- a/src/lib/Components/Home/HeroUnits.tsx
+++ b/src/lib/Components/Home/HeroUnits.tsx
@@ -54,8 +54,12 @@ class HeroUnits extends React.Component<Props, State> {
           />
           <View style={{ position: "absolute", top: 0, width, height, backgroundColor: "black", opacity: 0.3 }} />
           <View style={{ marginLeft: margin, backgroundColor: "transparent" }}>
-            <Headline style={{ color: "white", fontSize: 12 }}>{heroUnit.heading}</Headline>
-            <Headline style={{ color: "white", fontSize: this.state.fontSize }}>{heroUnit.title}</Headline>
+            <Headline style={{ color: "white", fontSize: 12 }}>
+              {heroUnit.heading}
+            </Headline>
+            <Headline style={{ color: "white", fontSize: this.state.fontSize }}>
+              {heroUnit.title}
+            </Headline>
           </View>
         </View>
       </TouchableHighlight>
@@ -80,7 +84,11 @@ class HeroUnits extends React.Component<Props, State> {
   }
 
   render() {
-    return <View onLayout={this.handleLayout}>{this.renderHeroUnits()}</View>
+    return (
+      <View onLayout={this.handleLayout}>
+        {this.renderHeroUnits()}
+      </View>
+    )
   }
 }
 

--- a/src/lib/Components/Inbox/Bids/ActiveBid.tsx
+++ b/src/lib/Components/Inbox/Bids/ActiveBid.tsx
@@ -8,14 +8,13 @@ import { BodyText, MetadataText } from "../Typography"
 import colors from "../../../../data/colors"
 import OpaqueImageView from "../../OpaqueImageView"
 
-const Container = styled.View`
-  margin: 17px 20px 0px;
-`
+const Container = styled.View`margin: 17px 20px 0px;`
 
 const Content = styled.View`
   flex: 1;
   flex-direction: row;
-  align-items: center;
+
+  \: center;
 `
 
 const ImageView = styled(OpaqueImageView)`
@@ -108,10 +107,16 @@ class ActiveBid extends React.Component<any, State> {
           <Content>
             <ImageView imageURL={imageURL} />
             <MetadataContainer>
-              <BodyText>{headline}</BodyText>
-              <BodyText>{subtitle}</BodyText>
+              <BodyText>
+                {headline}
+              </BodyText>
+              <BodyText>
+                {subtitle}
+              </BodyText>
             </MetadataContainer>
-            <StatusLabel status={this.state.status}>{this.statusLabel}</StatusLabel>
+            <StatusLabel status={this.state.status}>
+              {this.statusLabel}
+            </StatusLabel>
           </Content>
           <Separator />
         </Container>

--- a/src/lib/Components/Inbox/Bids/ActiveBid.tsx
+++ b/src/lib/Components/Inbox/Bids/ActiveBid.tsx
@@ -14,7 +14,7 @@ const Content = styled.View`
   flex: 1;
   flex-direction: row;
 
-  \: center;
+  align-items: center;
 `
 
 const ImageView = styled(OpaqueImageView)`

--- a/src/lib/Components/Inbox/Bids/index.tsx
+++ b/src/lib/Components/Inbox/Bids/index.tsx
@@ -6,9 +6,7 @@ import { View } from "react-native"
 import { LargeHeadline } from "../Typography"
 import ActiveBid from "./ActiveBid"
 
-const Container = styled.View`
-  margin: 20px 0 40px;
-`
+const Container = styled.View`margin: 20px 0 40px;`
 
 class ActiveBids extends React.Component<any, any> {
   hasContent() {

--- a/src/lib/Components/Inbox/Conversations/ConversationSnippet.tsx
+++ b/src/lib/Components/Inbox/Conversations/ConversationSnippet.tsx
@@ -85,18 +85,16 @@ export interface Conversation {
   }
   last_message: string | null
   last_message_at: string | null
-  artworks: Array<
-    {
-      id: string | null
-      href: string | null
-      title: string | null
-      date: string | null
-      artist_names: string | null
-      image: {
-        url: string | null
-      }
+  artworks: Array<{
+    id: string | null
+    href: string | null
+    title: string | null
+    date: string | null
+    artist_names: string | null
+    image: {
+      url: string | null
     }
-  >
+  }>
 }
 
 interface Props {
@@ -124,20 +122,32 @@ export class ConversationSnippet extends React.Component<Props, any> {
             <ImageView imageURL={imageURL} />
             <TextPreview>
               <HorizontalLayout>
-                <SmallHeadline>{partnerName}</SmallHeadline>
+                <SmallHeadline>
+                  {partnerName}
+                </SmallHeadline>
                 <DateHeading>
-                  <MetadataText>{date}</MetadataText>
+                  <MetadataText>
+                    {date}
+                  </MetadataText>
                   <UnreadIndicator />
                 </DateHeading>
               </HorizontalLayout>
               <HorizontalLayout>
                 <P>
-                  <ArtworkSubtitle>{artworkArtist}</ArtworkSubtitle>
-                  <ArtworkTitle>{artworkTitle}</ArtworkTitle>
-                  <ArtworkSubtitle>{artworkDate}</ArtworkSubtitle>
+                  <ArtworkSubtitle>
+                    {artworkArtist}
+                  </ArtworkSubtitle>
+                  <ArtworkTitle>
+                    {artworkTitle}
+                  </ArtworkTitle>
+                  <ArtworkSubtitle>
+                    {artworkDate}
+                  </ArtworkSubtitle>
                 </P>
               </HorizontalLayout>
-              <P>{conversationText}</P>
+              <P>
+                {conversationText}
+              </P>
             </TextPreview>
           </CardContent>
           <Separator />

--- a/src/lib/Components/Inbox/Conversations/Message.tsx
+++ b/src/lib/Components/Inbox/Conversations/Message.tsx
@@ -12,9 +12,7 @@ const VerticalLayout = styled.View`
   flex: 1
 `
 
-const HorizontalLayout = styled.View`
-  flex-direction: row
-`
+const HorizontalLayout = styled.View`flex-direction: row;`
 
 const Container = styled(HorizontalLayout)`
   alignSelf: stretch
@@ -45,13 +43,9 @@ const SenderName = styled(SmallHeadline)`
   marginRight: 10
 `
 
-const ArtworkPreviewContainer = styled.View`
-  marginBottom: 10
-`
+const ArtworkPreviewContainer = styled.View`marginBottom: 10;`
 
-const ImagePreviewContainer = styled.View`
-  marginBottom: 10
-`
+const ImagePreviewContainer = styled.View`marginBottom: 10;`
 
 interface Props extends RelayProps {
   senderName: string
@@ -67,12 +61,24 @@ export class Message extends React.Component<Props, any> {
         <Avatar />
         <TextContainer>
           <Header>
-            <SenderName>{this.props.senderName}</SenderName>
-            <MetadataText>{date}</MetadataText>
+            <SenderName>
+              {this.props.senderName}
+            </SenderName>
+            <MetadataText>
+              {date}
+            </MetadataText>
           </Header>
-          {this.props.artworkPreview && <ArtworkPreviewContainer>{this.props.artworkPreview}</ArtworkPreviewContainer>}
-          {this.props.imagePreview && <ImagePreviewContainer>{this.props.imagePreview}</ImagePreviewContainer>}
-          <BodyText>{this.props.message.raw_text.split("\n\nAbout")[0]}</BodyText>
+          {this.props.artworkPreview &&
+            <ArtworkPreviewContainer>
+              {this.props.artworkPreview}
+            </ArtworkPreviewContainer>}
+          {this.props.imagePreview &&
+            <ImagePreviewContainer>
+              {this.props.imagePreview}
+            </ImagePreviewContainer>}
+          <BodyText>
+            {this.props.message.raw_text.split("\n\nAbout")[0]}
+          </BodyText>
         </TextContainer>
       </Container>
     )

--- a/src/lib/Components/Inbox/Conversations/Previews/ArtworkPreview.tsx
+++ b/src/lib/Components/Inbox/Conversations/Previews/ArtworkPreview.tsx
@@ -55,7 +55,9 @@ export class ArtworkPreview extends React.Component<Props, any> {
         <Container>
           <Image imageURL={artwork.image.url} />
           <TextContainer>
-            <SerifText>{artwork.artist_names}</SerifText>
+            <SerifText>
+              {artwork.artist_names}
+            </SerifText>
             <TitleAndDate>
               {artwork.title}
               {artwork.date && <SerifText>{`, ${artwork.date}`}</SerifText>}

--- a/src/lib/Components/Inbox/Conversations/ZerostateInbox.tsx
+++ b/src/lib/Components/Inbox/Conversations/ZerostateInbox.tsx
@@ -23,8 +23,8 @@ const VerticalLayout = styled.View`
 const HorizontalLayout = styled.View`
   flex: 1;
   flex-direction: row;
-  margin-left:20;
-  margin-top:50;
+  margin-left: 20;
+  margin-top: 50;
   margin-bottom: 50;
 `
 

--- a/src/lib/Components/Inbox/Typography/index.tsx
+++ b/src/lib/Components/Inbox/Typography/index.tsx
@@ -7,37 +7,61 @@ import fonts from "../../../../data/fonts"
 const LargeHeadline = (props: TextProperties) => {
   const children: string = (props as any).children
   const style = [styles.largeDefault, props.style || {}, styles.largeRequired]
-  return <Text key={children} style={style}>{children}</Text>
+  return (
+    <Text key={children} style={style}>
+      {children}
+    </Text>
+  )
 }
 
 const SmallHeadline = (props: TextProperties) => {
   const children: string = (props as any).children
   const style = [styles.smallDefault, props.style || {}, styles.smallRequired]
-  return <Text key={children} style={style}>{(children || "").toUpperCase()}</Text>
+  return (
+    <Text key={children} style={style}>
+      {(children || "").toUpperCase()}
+    </Text>
+  )
 }
 
 const Subtitle = (props: TextProperties) => {
   const children: string = (props as any).children
   const style = [styles.subtitleDefault, props.style || {}, styles.subtitleRequired]
-  return <Text key={children} style={style}>{children}</Text>
+  return (
+    <Text key={children} style={style}>
+      {children}
+    </Text>
+  )
 }
 
 const MetadataText = (props: TextProperties) => {
   const children: string = (props as any).children
   const style = [styles.metadataDefault, props.style || {}, styles.metadataRequired]
-  return <Text key={children} style={style}>{children.toUpperCase()}</Text>
+  return (
+    <Text key={children} style={style}>
+      {children.toUpperCase()}
+    </Text>
+  )
 }
 
 const PreviewText = (props: TextProperties) => {
   const children: string = (props as any).children
   const style = [styles.bodyDefault, props.style || {}, styles.bodyRequired]
-  return <Text key={children} style={style} numberOfLines={1} ellipsizeMode={"tail"}>{children}</Text>
+  return (
+    <Text key={children} style={style} numberOfLines={1} ellipsizeMode={"tail"}>
+      {children}
+    </Text>
+  )
 }
 
 const BodyText = (props: TextProperties) => {
   const children: string = (props as any).children
   const style = [styles.bodyDefault, props.style || {}, styles.bodyRequired]
-  return <Text key={children} style={style}>{children}</Text>
+  return (
+    <Text key={children} style={style}>
+      {children}
+    </Text>
+  )
 }
 
 export { LargeHeadline, SmallHeadline, Subtitle, MetadataText, PreviewText, BodyText }

--- a/src/lib/Components/RelatedArtists/RelatedArtist.tsx
+++ b/src/lib/Components/RelatedArtists/RelatedArtist.tsx
@@ -20,8 +20,12 @@ class RelatedArtist extends React.Component<any, any> {
       <TouchableWithoutFeedback onPress={this.handleTap.bind(this)}>
         <View style={{ margin: 5, paddingBottom: 20, width: this.props.imageSize.width }}>
           <ImageView style={this.props.imageSize} imageURL={imageURL} />
-          <Text style={styles.sansSerifText}>{artist.name.toUpperCase()}</Text>
-          <Text style={styles.serifText}>{this.artworksString(artist.counts)}</Text>
+          <Text style={styles.sansSerifText}>
+            {artist.name.toUpperCase()}
+          </Text>
+          <Text style={styles.serifText}>
+            {this.artworksString(artist.counts)}
+          </Text>
         </View>
       </TouchableWithoutFeedback>
     )

--- a/src/lib/Components/Storybooks/SectionBrowser.tsx
+++ b/src/lib/Components/Storybooks/SectionBrowser.tsx
@@ -22,7 +22,9 @@ const render = (props: Props) => {
     return (
       <View key={item.kind}>
         <TouchableHighlight onPress={showStoriesForSection}>
-          <BodyText>{item.kind}</BodyText>
+          <BodyText>
+            {item.kind}
+          </BodyText>
         </TouchableHighlight>
         <Separator />
       </View>

--- a/src/lib/Components/Storybooks/StoryBrowser.tsx
+++ b/src/lib/Components/Storybooks/StoryBrowser.tsx
@@ -21,7 +21,9 @@ const render = (props: Props) => {
     return (
       <View key={item.name}>
         <TouchableHighlight onPress={showStory}>
-          <BodyText>{item.name}</BodyText>
+          <BodyText>
+            {item.name}
+          </BodyText>
         </TouchableHighlight>
         <Separator />
       </View>

--- a/src/lib/Components/WorksForYou/Notification.tsx
+++ b/src/lib/Components/WorksForYou/Notification.tsx
@@ -35,10 +35,14 @@ export class Notification extends React.Component<RelayProps, any> {
               <Image source={{ uri: notification.image.resized.url }} style={styles.artistAvatar} />}
             <View style={styles.metadataContainer}>
               <View style={styles.nameAndStatusContainer}>
-                <Headline style={styles.artistName}>{notification.artists}</Headline>
+                <Headline style={styles.artistName}>
+                  {notification.artists}
+                </Headline>
                 {notification.status === "UNREAD" && <View style={styles.readStatus} />}
               </View>
-              <SerifText style={styles.metadata}>{notification.message + " · " + notification.date}</SerifText>
+              <SerifText style={styles.metadata}>
+                {notification.message + " · " + notification.date}
+              </SerifText>
             </View>
           </View>
         </TouchableWithoutFeedback>

--- a/src/lib/Containers/Artist.tsx
+++ b/src/lib/Containers/Artist.tsx
@@ -100,7 +100,11 @@ export class Artist extends React.Component<Props, {}> {
   }
 
   renderSingleTab() {
-    return <View style={{ paddingTop: 30 }}>{this.renderSelectedTab()}</View>
+    return (
+      <View style={{ paddingTop: 30 }}>
+        {this.renderSelectedTab()}
+      </View>
+    )
   }
 
   render() {

--- a/src/lib/Containers/Conversation.tsx
+++ b/src/lib/Containers/Conversation.tsx
@@ -98,7 +98,9 @@ export class Conversation extends React.Component<RelayProps, any> {
         <Header>
           <HeaderTextContainer>
             <BackButtonPlaceholder source={chevron} />
-            <SmallHeadline>{partnerName}</SmallHeadline>
+            <SmallHeadline>
+              {partnerName}
+            </SmallHeadline>
             <PlaceholderView />
           </HeaderTextContainer>
         </Header>
@@ -107,7 +109,9 @@ export class Conversation extends React.Component<RelayProps, any> {
           renderItem={this.renderMessage.bind(this)}
           ItemSeparatorComponent={DottedBorder}
         />
-        <ComposerContainer><Composer /></ComposerContainer>
+        <ComposerContainer>
+          <Composer />
+        </ComposerContainer>
       </Container>
     )
   }
@@ -170,11 +174,9 @@ interface RelayProps {
         pageInfo?: {
           hasNextPage: boolean
         }
-        edges: Array<
-          {
-            node: any | null
-          }
-        >
+        edges: Array<{
+          node: any | null
+        }>
       }
     }
   }

--- a/src/lib/Containers/Gene.tsx
+++ b/src/lib/Containers/Gene.tsx
@@ -258,11 +258,9 @@ export class Gene extends React.Component<Props, State> {
         parallaxHeaderHeight={this.foregroundHeight}
         parallaxHeaderContainerStyles={{ marginBottom: stickyTopMargin }}
       >
-
         <View style={{ marginTop: 20, paddingLeft: this.commonPadding, paddingRight: this.commonPadding }}>
           {this.renderSectionForTab()}
         </View>
-
       </ParallaxScrollView>
     )
   }

--- a/src/lib/Containers/MyAccount.tsx
+++ b/src/lib/Containers/MyAccount.tsx
@@ -19,7 +19,9 @@ export class MyAccount extends React.Component<Props, {}> {
     return (
       <ScrollView scrollsToTop={true} automaticallyAdjustContentInsets={false}>
         <View style={{ paddingLeft: commonPadding, paddingRight: commonPadding }}>
-          <Headline>{this.props.me.name}</Headline>
+          <Headline>
+            {this.props.me.name}
+          </Headline>
         </View>
       </ScrollView>
     )

--- a/src/lib/Containers/WorksForYou.tsx
+++ b/src/lib/Containers/WorksForYou.tsx
@@ -186,7 +186,9 @@ export class WorksForYou extends React.Component<Props, State> {
           {border}
           <View style={styles.emptyStateText}>
             <SerifText style={styles.emptyStateMainLabel}>You’re not following any artists yet</SerifText>
-            <SerifText style={styles.emptyStateSubLabel} numberOfLines={2}>{text}</SerifText>
+            <SerifText style={styles.emptyStateSubLabel} numberOfLines={2}>
+              {text}
+            </SerifText>
           </View>
           {border}
         </View>
@@ -291,11 +293,9 @@ interface RelayProps {
         pageInfo: {
           hasNextPage: boolean
         }
-        edges: Array<
-          {
-            node: any | null
-          }
-        >
+        edges: Array<{
+          node: any | null
+        }>
       }
     }
     selectedArtist?: {

--- a/src/lib/Containers/__tests__/Conversation-tests.tsx
+++ b/src/lib/Containers/__tests__/Conversation-tests.tsx
@@ -26,7 +26,6 @@ const props = {
             raw_text: "Adoro! Por favor envie-me mais informações",
             from_email_address: "anita@garibaldi.br",
             attachments: [],
-            created_at: "2017-06-26T14:14:35.538Z",
           },
         },
       ],

--- a/src/lib/Containers/__tests__/WorksForYou-tests.tsx
+++ b/src/lib/Containers/__tests__/WorksForYou-tests.tsx
@@ -86,21 +86,19 @@ interface NotificationsResponse {
         pageInfo: {
           hasNextPage: boolean
         }
-        edges: Array<
-          {
-            node: {
-              artists: string
-              date: string
-              message: string
-              artworks: [{ title: string }]
-              image: {
-                resized: {
-                  url: string
-                }
+        edges: Array<{
+          node: {
+            artists: string
+            date: string
+            message: string
+            artworks: [{ title: string }]
+            image: {
+              resized: {
+                url: string
               }
             }
           }
-        >
+        }>
       }
     }
 

--- a/src/lib/Containers/__tests__/__snapshots__/Conversation-tests.tsx.snap
+++ b/src/lib/Containers/__tests__/__snapshots__/Conversation-tests.tsx.snap
@@ -92,7 +92,6 @@ exports[`looks correct when rendered 1`] = `
       Array [
         Object {
           "attachments": Array [],
-          "created_at": "2017-06-26T14:14:35.538Z",
           "first_message": true,
           "from_email_address": "anita@garibaldi.br",
           "id": 222,
@@ -247,7 +246,7 @@ exports[`looks correct when rendered 1`] = `
                   ]
                 }
               >
-                A DAY
+                A FEW SECONDS
               </Text>
             </View>
             <View

--- a/yarn.lock
+++ b/yarn.lock
@@ -5763,9 +5763,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.4.2:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.4.2.tgz#bcdd95ed1eca434ac7f98ca26ea4d25a2af6a2ac"
+prettier@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.5.0.tgz#f3476164f9a532a218a1337b1032638275d82614"
 
 pretty-format@^20.0.3:
   version "20.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,35 +2,37 @@
 # yarn lockfile v1
 
 
-"@storybook/addon-actions@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-3.0.0.tgz#e141378eeff36cbc61d27ba4330eaadfb6cd5c8b"
+"@storybook/addon-actions@^3.1.6":
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-3.1.6.tgz#0cbf00ede57ff00d1dfe02e554043d6963940064"
   dependencies:
-    "@storybook/addons" "^3.0.0"
+    "@storybook/addons" "^3.1.6"
     deep-equal "^1.0.1"
     json-stringify-safe "^5.0.1"
     prop-types "^15.5.8"
     react-inspector "^2.0.0"
+    uuid "^3.1.0"
 
-"@storybook/addon-links@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-links/-/addon-links-3.0.0.tgz#497ae071b9f36f150a47a5c61d0688d615faec0c"
+"@storybook/addon-links@^3.1.6":
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-links/-/addon-links-3.1.6.tgz#62c8a839e54ff0adb04c6023dae467b336ced5d9"
   dependencies:
-    "@storybook/addons" "^3.0.0"
+    "@storybook/addons" "^3.1.6"
 
-"@storybook/addons@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-3.0.0.tgz#0a59b73bbea15f927ec439d7bd9e67ef3719a819"
+"@storybook/addons@^3.1.6":
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-3.1.6.tgz#29ef2348550f5a74d5e83dd75d04714cac751c39"
 
-"@storybook/channel-websocket@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@storybook/channel-websocket/-/channel-websocket-3.0.0.tgz#06965485622202599cf7d66c116fcbd7d60a0391"
+"@storybook/channel-websocket@^3.1.6":
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/@storybook/channel-websocket/-/channel-websocket-3.1.6.tgz#3ea53d7989f1bb3dc24175cc87ebf6082c1142f5"
   dependencies:
-    "@storybook/channels" "^3.0.0"
+    "@storybook/channels" "^3.1.6"
+    global "^4.3.2"
 
-"@storybook/channels@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-3.0.0.tgz#603a1ea4779ee3d0b86d854f0ae6f899958ba73d"
+"@storybook/channels@^3.1.6":
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-3.1.6.tgz#81d61591bf7613dd2bcd81d26da40aeaa2899034"
 
 "@storybook/react-fuzzy@^0.4.0":
   version "0.4.0"
@@ -41,15 +43,15 @@
     fuse.js "^3.0.1"
     prop-types "^15.5.9"
 
-"@storybook/react-native@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@storybook/react-native/-/react-native-3.0.0.tgz#69f8046af5984e2ce9d6fab4b29bea587ab80f6e"
+"@storybook/react-native@^3.1.6":
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/@storybook/react-native/-/react-native-3.1.6.tgz#bac7deb6d8598476e1888c778ce2a2f2c7b99485"
   dependencies:
-    "@storybook/addon-actions" "^3.0.0"
-    "@storybook/addon-links" "^3.0.0"
-    "@storybook/addons" "^3.0.0"
-    "@storybook/channel-websocket" "^3.0.0"
-    "@storybook/ui" "^3.0.0"
+    "@storybook/addon-actions" "^3.1.6"
+    "@storybook/addon-links" "^3.1.6"
+    "@storybook/addons" "^3.1.6"
+    "@storybook/channel-websocket" "^3.1.6"
+    "@storybook/ui" "^3.1.6"
     autoprefixer "^7.0.1"
     babel-core "^6.24.1"
     babel-loader "^7.0.0"
@@ -72,6 +74,8 @@
     events "^1.1.1"
     express "^4.15.2"
     file-loader "^0.11.1"
+    find-cache-dir "^1.0.0"
+    global "^4.3.2"
     json-loader "^0.5.4"
     json5 "^0.5.1"
     postcss-loader "^2.0.3"
@@ -83,16 +87,18 @@
     webpack "^2.4.1"
     webpack-dev-middleware "^1.10.1"
     webpack-hot-middleware "^2.18.0"
+    ws "^3.0.0"
 
-"@storybook/ui@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@storybook/ui/-/ui-3.0.0.tgz#64d83dd7529ebe0ffe7622d90e08bf00cd362508"
+"@storybook/ui@^3.1.6":
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/@storybook/ui/-/ui-3.1.6.tgz#5d47c6003a2d78c06ede43861089747d986d918e"
   dependencies:
     "@storybook/react-fuzzy" "^0.4.0"
     babel-runtime "^6.23.0"
     deep-equal "^1.0.1"
     events "^1.1.1"
     fuzzysearch "^1.0.3"
+    global "^4.3.2"
     json-stringify-safe "^5.0.1"
     keycode "^2.1.8"
     lodash.pick "^4.4.0"
@@ -3038,6 +3044,14 @@ find-cache-dir@^0.1.1:
     mkdirp "^0.5.1"
     pkg-dir "^1.0.0"
 
+find-cache-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-1.0.0.tgz#9288e3e9e3cc3748717d39eade17cf71fc30ee6f"
+  dependencies:
+    commondir "^1.0.1"
+    make-dir "^1.0.0"
+    pkg-dir "^2.0.0"
+
 find-up@^1.0.0, find-up@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
@@ -3256,9 +3270,9 @@ glob@7.1.1, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-global@^4.3.0:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/global/-/global-4.3.1.tgz#5f757908c7cbabce54f386ae440e11e26b7916df"
+global@^4.3.0, global@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/global/-/global-4.3.2.tgz#e76989268a6c74c38908b1305b10fc0e394e9d0f"
   dependencies:
     min-document "^2.19.0"
     process "~0.5.1"
@@ -4705,6 +4719,12 @@ macaddress@^0.2.8:
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/macaddress/-/macaddress-0.2.8.tgz#5904dc537c39ec6dbefeae902327135fa8511f12"
 
+make-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.0.0.tgz#97a011751e91dd87cfadef58832ebb04936de978"
+  dependencies:
+    pify "^2.3.0"
+
 makeerror@1.0.x:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
@@ -5909,6 +5929,15 @@ react-devtools-core@^2.1.8:
   dependencies:
     shell-quote "^1.6.1"
     ws "^2.0.3"
+
+react-dom@16.0.0-alpha.12:
+  version "16.0.0-alpha.12"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.0.0-alpha.12.tgz#c9894ccfd9600ef87952e05340903180b013171e"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.0"
+    prop-types "^15.5.6"
 
 react-inspector@^2.0.0:
   version "2.0.0"
@@ -7278,6 +7307,10 @@ uuid@3.0.1, uuid@^3.0.0, uuid@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
 
+uuid@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
+
 valid-url@^1.0.9:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/valid-url/-/valid-url-1.0.9.tgz#1c14479b40f1397a75782f115e4086447433a200"
@@ -7517,6 +7550,13 @@ ws@^1.1.0:
 ws@^2.0.3:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/ws/-/ws-2.3.1.tgz#6b94b3e447cb6a363f785eaf94af6359e8e81c80"
+  dependencies:
+    safe-buffer "~5.0.1"
+    ultron "~1.1.0"
+
+ws@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-3.0.0.tgz#98ddb00056c8390cb751e7788788497f99103b6c"
   dependencies:
     safe-buffer "~5.0.1"
     ultron "~1.1.0"


### PR DESCRIPTION
https://github.com/prettier/prettier/releases/tag/1.5.0

* Adds JS in CSS
* Adds GraphQL support (but not for us, only on Relay Modern - ah well)

I experimented with adding style lint + [stylelint-processor-styled-components](https://github.com/styled-components/stylelint-processor-styled-components/) but there is no support for it in VS Code, so I've sent off a PR adding it https://github.com/shinnn/vscode-stylelint/pull/82

Once that's shipped then stylelint can be added /cc @l2succes 

Skip New Tests