### PR TITLE
[Messaging] Force fetch messages when loading the conversation view.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ###### Messaging
 
 -   Show progress indicator during downloading of attachment - alloy
+-   Force fetch conversation on each load - alloy
+-   Make pull to refresh in the Inbox work - luc
+-   Don’t show pull to refresh control when loading the Inbox view - luc
 
 ### 1.4.0-beta.1
 

--- a/src/lib/Containers/Conversation.tsx
+++ b/src/lib/Containers/Conversation.tsx
@@ -102,7 +102,9 @@ export class Conversation extends React.Component<Props, State> {
   //       messages. However, with a cold Relay cache this leads to an initial double fetch, because Relay will also
   //       fetch the data before rendering the initial load.
   componentDidMount() {
-    this.props.relay.forceFetch({})
+    if (this.props.relay) {
+      this.props.relay.forceFetch({})
+    }
   }
 
   render() {

--- a/src/lib/Containers/Conversation.tsx
+++ b/src/lib/Containers/Conversation.tsx
@@ -50,7 +50,6 @@ const DottedBorder = styled.View`
   borderColor: ${colors["gray-regular"]}
   marginLeft: 20
   marginRight: 20
-
 `
 
 const MessagesList = styled(FlatList)`
@@ -97,6 +96,13 @@ export class Conversation extends React.Component<Props, State> {
         }
       />
     )
+  }
+
+  // FIXME This will perform a network request after initially rendering the component and thus always fetch the latest
+  //       messages. However, with a cold Relay cache this leads to an initial double fetch, because Relay will also
+  //       fetch the data before rendering the initial load.
+  componentDidMount() {
+    this.props.relay.forceFetch({})
   }
 
   render() {


### PR DESCRIPTION
Related to #645.

It’s not the final solution yet, but good enough for first beta.