### PR TITLE
[MSG] Take out statusbar from inquiry modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ###### Messaging
 
+- Remove statusbar in inquiry modal view - maxim
+
+### 1.4.0-beta.2
+
+###### Messaging
+
 -   Show progress indicator during downloading of attachment - alloy
 -   Force fetch conversation on each load - alloy
 -   Make pull to refresh in the Inbox work - luc

--- a/Example/Emission/Info.plist
+++ b/Example/Emission/Info.plist
@@ -42,7 +42,5 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
-	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<false/>
 </dict>
 </plist>

--- a/Pod/Classes/ViewControllers/ARInquiryComponentViewController.m
+++ b/Pod/Classes/ViewControllers/ARInquiryComponentViewController.m
@@ -17,9 +17,4 @@
     return self;
 }
 
-- (UIStatusBarStyle)preferredStatusBarStyle
-{
-    return UIStatusBarStyleLightContent;
-}
-
 @end

--- a/src/lib/Containers/Inquiry.tsx
+++ b/src/lib/Containers/Inquiry.tsx
@@ -8,7 +8,6 @@ import {
   ImageURISource,
   KeyboardAvoidingView,
   NativeModules,
-  StatusBar,
   Text,
   TextInput,
   TouchableOpacity,
@@ -141,7 +140,6 @@ export class Inquiry extends React.Component<RelayProps, any> {
 
     return (
       <Container>
-        <StatusBar />
         <BottomAlignedButton
           onPress={this.sendInquiry.bind(this)}
           bodyStyle={doneButtonStyles}


### PR DESCRIPTION
Fix for #667 

It works well on the Emission app on phone, I can't test it within Eigen. I think it will keep the black statusbar at top, but that would be fine I think :). 