### PR TITLE
Fixes display of auction price info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Master
 
+### 1.3.10
+
+- No longer display bid/price info for artworks in sales that are closed.
 
 ### 1.3.8
 

--- a/src/lib/components/artwork_grids/__tests__/__snapshots__/artwork-tests.tsx.snap
+++ b/src/lib/components/artwork_grids/__tests__/__snapshots__/artwork-tests.tsx.snap
@@ -1,6 +1,155 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`in a sale renders with current bid 1`] = `
+exports[`in a closed sale renders without any price information 1`] = `
+<View
+  accessibilityComponentType={undefined}
+  accessibilityLabel={undefined}
+  accessibilityTraits={undefined}
+  accessible={true}
+  hitSlop={undefined}
+  onLayout={undefined}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={undefined}
+  testID={undefined}
+>
+  <AROpaqueImageView
+    aspectRatio={0.74}
+    imageURL="artsy.net/image-url"
+    style={
+      Object {
+        "marginBottom": 10,
+      }
+    }
+  />
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    numberOfLines={1}
+    style={
+      Array [
+        Object {
+          "fontSize": 17,
+        },
+        Array [
+          Object {
+            "color": "#666666",
+            "fontSize": 12,
+          },
+          Object {
+            "fontWeight": "bold",
+          },
+        ],
+        Object {
+          "fontFamily": "AGaramondPro-Regular",
+        },
+      ]
+    }
+  >
+    Mikael Olson
+  </Text>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    numberOfLines={1}
+    style={
+      Array [
+        Object {
+          "fontSize": 17,
+        },
+        Object {
+          "color": "#666666",
+          "fontSize": 12,
+        },
+        Object {
+          "fontFamily": "AGaramondPro-Regular",
+        },
+      ]
+    }
+  >
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      numberOfLines={1}
+      style={
+        Array [
+          Object {
+            "fontSize": 17,
+          },
+          Array [
+            Object {
+              "color": "#666666",
+              "fontSize": 12,
+            },
+            Object {
+              "fontStyle": "italic",
+            },
+          ],
+          Object {
+            "fontFamily": "AGaramondPro-Regular",
+          },
+        ]
+      }
+    >
+      Some Kind of Dinosaur
+    </Text>
+    , 2015
+  </Text>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    numberOfLines={1}
+    style={
+      Array [
+        Object {
+          "fontSize": 17,
+        },
+        Object {
+          "color": "#666666",
+          "fontSize": 12,
+        },
+        Object {
+          "fontFamily": "AGaramondPro-Regular",
+        },
+      ]
+    }
+  >
+    Gallery 1261
+  </Text>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    numberOfLines={1}
+    style={
+      Array [
+        Object {
+          "fontSize": 17,
+        },
+        Object {
+          "color": "#666666",
+          "fontSize": 12,
+        },
+        Object {
+          "fontFamily": "AGaramondPro-Regular",
+        },
+      ]
+    }
+  >
+    Contact Gallery
+  </Text>
+</View>
+`;
+
+exports[`in an open sale renders with current bid 1`] = `
 <View
   accessibilityComponentType={undefined}
   accessibilityLabel={undefined}
@@ -165,7 +314,7 @@ exports[`in a sale renders with current bid 1`] = `
 </View>
 `;
 
-exports[`in a sale renders with starting bid 1`] = `
+exports[`in an open sale renders with starting bid 1`] = `
 <View
   accessibilityComponentType={undefined}
   accessibilityLabel={undefined}
@@ -474,7 +623,7 @@ exports[`renders properly 1`] = `
       ]
     }
   >
-    $875
+    Contact Gallery
   </Text>
 </View>
 `;

--- a/src/lib/components/artwork_grids/__tests__/artwork-tests.tsx
+++ b/src/lib/components/artwork_grids/__tests__/artwork-tests.tsx
@@ -10,12 +10,15 @@ it("renders properly", () => {
   expect(artwork).toMatchSnapshot()
 })
 
-describe("in a sale", () => {
+describe("in an open sale", () => {
   it("renders with starting bid", () => {
     const saleArtwork = {
       opening_bid: { display: "$100" },
       current_bid: null,
       bidder_positions_count: 0,
+      sale: {
+        is_open: true,
+      },
     }
     const artwork = renderer.create(<Artwork artwork={artworkProps(saleArtwork)} />).toJSON()
     expect(artwork).toMatchSnapshot()
@@ -26,6 +29,24 @@ describe("in a sale", () => {
       opening_bid: { display: "$100" },
       current_bid: { display: "$200" },
       bidder_positions_count: 1,
+      sale: {
+        is_open: true,
+      },
+    }
+    const artwork = renderer.create(<Artwork artwork={artworkProps(saleArtwork)} />).toJSON()
+    expect(artwork).toMatchSnapshot()
+  })
+})
+
+describe("in a closed sale", () => {
+  it ("renders without any price information", () => {
+    const saleArtwork = {
+      opening_bid: { display: "$100" },
+      current_bid: { display: "$200" },
+      bidder_positions_count: 1,
+      sale: {
+        is_open: false,
+      },
     }
     const artwork = renderer.create(<Artwork artwork={artworkProps(saleArtwork)} />).toJSON()
     expect(artwork).toMatchSnapshot()
@@ -36,7 +57,7 @@ let artworkProps = (saleArtwork = null) => {
   return {
     title: "Some Kind of Dinosaur",
     date: "2015",
-    sale_message: "$875",
+    sale_message: "Contact Gallery",
     is_in_auction: (saleArtwork !== null),
     sale_artwork: saleArtwork,
     image: {

--- a/src/lib/components/artwork_grids/artwork.tsx
+++ b/src/lib/components/artwork_grids/artwork.tsx
@@ -58,7 +58,7 @@ class Artwork extends React.Component<RelayProps, any> {
 
   saleMessage() {
     const artwork = this.props.artwork
-    if (artwork.is_in_auction) {
+    if (artwork.is_in_auction && artwork.sale_artwork.sale.is_open) {
       const numberOfBids = artwork.sale_artwork.bidder_positions_count
       let text = artwork.sale_artwork.opening_bid.display
       if (numberOfBids > 0 ) {
@@ -104,6 +104,9 @@ export default Relay.createContainer(Artwork, {
           opening_bid { display }
           current_bid { display }
           bidder_positions_count
+          sale {
+            is_open
+          }
         }
         image {
           url(version: "large")
@@ -135,6 +138,9 @@ interface RelayProps {
         display: string | null,
       } | null,
       bidder_positions_count: number | null,
+      sale: {
+        is_open: boolean | null,
+      } | null,
     } | null,
     image: {
       url: string | null,


### PR DESCRIPTION
This PR changes Emission to no longer show opening/current bid price when the sale associated with the artwork has closed. This also modifies existing test coverage to explicitly state the existing tests were for open sales, and changes the stub `sale_message` to "Contact Gallery", to help avoid confusion around snapshot data and test names (i.e.: avoid the test named "doesn't show price info" having "$875" located _anywhere_ in the snapshot).

Initially this fix was done in [metaphysics](https://github.com/artsy/metaphysics/pull/689) but that proved problematic, as both force and parts of Emission rely on the `is_in_auction` flag remaining `true` even if the auction has closed. So we need to be a little more clever.

This fix is high priority for the auctions team; this PR is into a new branch made from the v1.3.9 release of Emission. If accepted, I would like to submit a patch of Eigen that includes this update as soon as possible, also branched from 3.2.2 of that project.