### PR TITLE
[MSG] Fix for silly bug in ArtworkPreview #trivial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ###### Messaging
 
+-   Fix for bug in ArtworkPreview related to the falsiness of an empty string - sarah
 -   Reload active bids on pull-to-refresh - alloy
 -   Make active bids link to their artworks - alloy
 -   Make zero inbox state hide on load if bids or conversations exist - alloy

--- a/Example/Emission.xcodeproj/project.pbxproj
+++ b/Example/Emission.xcodeproj/project.pbxproj
@@ -558,7 +558,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		BD012BCCAEAB7DB916DE7D2D /* [CP] Embed Pods Frameworks */ = {

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -124,13 +124,13 @@ EXTERNAL SOURCES:
     :branch: fetch-user-details
     :git: https://github.com/artsy/Artsy-Authentication.git
   Emission:
-    :path: ../
+    :path: "../"
   React:
-    :path: ../node_modules/react-native
+    :path: "../node_modules/react-native"
   SentryReactNative:
-    :path: ../node_modules/react-native-sentry
+    :path: "../node_modules/react-native-sentry"
   Yoga:
-    :path: ../node_modules/react-native/ReactCommon/yoga
+    :path: "../node_modules/react-native/ReactCommon/yoga"
 
 CHECKOUT OPTIONS:
   AppHub:
@@ -164,4 +164,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 81fa55023c9115777509729f1d7490b881688e37
 
-COCOAPODS: 1.3.0.beta.2
+COCOAPODS: 1.2.1

--- a/src/lib/Components/Inbox/Conversations/Preview/ArtworkPreview.tsx
+++ b/src/lib/Components/Inbox/Conversations/Preview/ArtworkPreview.tsx
@@ -73,7 +73,7 @@ export class ArtworkPreview extends React.Component<Props, any> {
               <Title numberOfLines={1}>
                 {artwork.title}
               </Title>
-              {artwork.date && <Date>{`, ${artwork.date}`}</Date>}
+              {!!artwork.date && <Date>{`, ${artwork.date}`}</Date>}
             </TitleAndDate>
           </TextContainer>
         </Container>

--- a/src/lib/Components/Inbox/Conversations/Preview/__tests__/ArtworkPreview-tests.tsx
+++ b/src/lib/Components/Inbox/Conversations/Preview/__tests__/ArtworkPreview-tests.tsx
@@ -9,6 +9,14 @@ it("renders correctly", () => {
   expect(tree).toMatchSnapshot()
 })
 
+it("handles dateless artworks", () => {
+  const dateless = artwork
+  dateless.date = ""
+  const tree = renderer.create(<ArtworkPreview artwork={dateless} />)
+
+  expect(tree).toMatchSnapshot()
+})
+
 const artwork = {
   id: "bradley-theodore-karl-and-anna-face-off-diptych",
   href: "/artwork/bradley-theodore-karl-and-anna-face-off-diptych",

--- a/src/lib/Components/Inbox/Conversations/Preview/__tests__/__snapshots__/ArtworkPreview-tests.tsx.snap
+++ b/src/lib/Components/Inbox/Conversations/Preview/__tests__/__snapshots__/ArtworkPreview-tests.tsx.snap
@@ -1,5 +1,144 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`handles dateless artworks 1`] = `
+<View
+  accessibilityComponentType={undefined}
+  accessibilityLabel={undefined}
+  accessibilityTraits={undefined}
+  accessible={true}
+  hasTVPreferredFocus={undefined}
+  hitSlop={undefined}
+  isTVSelectable={true}
+  nativeID={undefined}
+  onLayout={undefined}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Array [
+      Object {
+        "backgroundColor": "transparent",
+      },
+      undefined,
+    ]
+  }
+  testID={undefined}
+  tvParallaxProperties={undefined}
+>
+  <View
+    style={
+      Array [
+        Object {
+          "borderColor": "#e5e5e5",
+          "borderWidth": 1,
+          "flexDirection": "row",
+        },
+        undefined,
+      ]
+    }
+  >
+    <AROpaqueImageView
+      imageURL="https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/normalized.jpg"
+      style={
+        Array [
+          Object {
+            "height": 55,
+            "marginBottom": 12,
+            "marginLeft": 12,
+            "marginTop": 12,
+            "width": 80,
+          },
+          undefined,
+        ]
+      }
+    />
+    <View
+      style={
+        Array [
+          Object {
+            "flexBasis": 0,
+            "flexDirection": "column",
+            "flexGrow": 1,
+            "flexShrink": 1,
+          },
+          Array [
+            Object {
+              "alignSelf": "center",
+              "marginLeft": 25,
+            },
+            undefined,
+          ],
+        ]
+      }
+    >
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        disabled={false}
+        ellipsizeMode="tail"
+        numberOfLines={1}
+        style={
+          Array [
+            Object {
+              "color": "black",
+              "fontSize": 16,
+              "textAlign": "left",
+            },
+            Array [
+              Object {
+                "fontSize": 14,
+              },
+              undefined,
+            ],
+            Object {
+              "fontFamily": "AGaramondPro-Regular",
+            },
+          ]
+        }
+      >
+        Bradley Theodore
+      </Text>
+      <View
+        style={
+          Array [
+            Object {
+              "flexDirection": "row",
+              "marginTop": 3,
+            },
+            undefined,
+          ]
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          disabled={false}
+          ellipsizeMode="tail"
+          numberOfLines={1}
+          style={
+            Array [
+              Object {
+                "flexBasis": 0,
+                "flexGrow": 3,
+                "flexShrink": 1,
+                "fontFamily": "AGaramondPro-Italic",
+                "fontSize": 14,
+              },
+              undefined,
+            ]
+          }
+        >
+          Karl and Anna Face Off (Diptych)
+        </Text>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
 exports[`renders correctly 1`] = `
 <View
   accessibilityComponentType={undefined}


### PR DESCRIPTION
A cautionary tale.

This is a fix for artworks without dates - `this.props.artwork.date` was an empty string in this case instead of a `null`, resulting in this bug:

![simulator screen shot jul 12 2017 5 02 22 pm](https://user-images.githubusercontent.com/2712962/28145419-ff08f626-6726-11e7-8430-432886f8dce7.png)
