### PR TITLE
Add an automated setup script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,49 @@
+BREW := $(shell command -v brew 2> /dev/null)
+YARN := $(shell command -v yarn 2> /dev/null)
+WATCHMAN := $(shell command -v watchman 2> /dev/null)
+CODE := $(shell command -v code 2> /dev/null)
+
+oss:
+ifndef BREW
+    $(error "Please install homebrew before running `make oss`: https://brew.sh")
+endif
+
+ifndef YARN
+	@echo "Installing Yarn"
+	brew install yarn
+endif
+
+ifndef WATCHMAN
+	@echo "Installing Watchman"
+	brew install pcre
+	brew link pcre
+	brew install watchman --HEAD
+endif
+
+ifndef CODE
+	@echo "Installing Visual Studio Code"
+	brew cask install visual-studio-code
+endif
+
+	@echo "Installing Node Dependencies"
+	yarn install
+
+	@echo "Installing Cocoa Dependencies"
+	cd Example && bundle && bundle exec pod install
+
+	@echo "Installing Hooks for Styling and Compile-checks"
+	echo "#!/bin/sh\nyarn run lint-staged\n" > .git/hooks/pre-commit; chmod +x .git/hooks/pre-commit
+	echo "#!/bin/sh\nyarn run type-check\n" > .git/hooks/pre-push; chmod +x .git/hooks/pre-push
+
+	@echo "";
+	@echo "";
+	@echo "That is all of the dependencies for Emission set up, to run the app:";
+	@echo "";
+	@echo " - Ensure you have an Artsy account: $$(tput setaf 3)https://www.artsy.net/sign_up$$(tput sgr0)"
+	@echo " - Open the folder in VS Code: '$$(tput setaf 3)code .$$(tput sgr0)'"
+	@echo " - Start the dev server: '$$(tput setaf 3)yarn start$$(tput sgr0)'"
+	@echo " - Open Xcode, and run Emission: '$$(tput setaf 3)open Example/Emission.xcworkspace$$(tput sgr0)'"
+	@echo ""
+	@echo "Any other details can be found in the README."
+	@echo "Enjoy!"
+	@echo ""

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Want to know more about Emission? Read the [mobile](http://artsy.github.io/blog/
 
 ### Installation
 
+*Automated install*: `git clone https://github.com/artsy/emission.git; cd emission; make oss`.
+
+*Manual install*
+
 1. Make sure to check out submodules with `git submodule update --init`
 1. Install [Node.js][node], and [Yarn][yarn]: `$ brew install node yarn`
 1. Install file watcher used by React Native:


### PR DESCRIPTION
I had to re-install my repo from scratch after getting #632 merged, due to caps issues (that PR predated the first major capitalisation changes) 

Setting up the project takes a bunch of commands, and every time I blow the repo, I forget the commit hooks. So I've automated that away. Opted for `make oss` as that's consistent with other Artsy mobile projects.