### PR TITLE
[WIP][MSG] Pending state and recommit for Messages in poor connectivity

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -145,7 +145,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/artsy/Artsy-Authentication.git
 
 SPEC CHECKSUMS:
-  AppHub: '03788112dd48c42b60d51321c0ffff4ef15a4432'
+  AppHub: 03788112dd48c42b60d51321c0ffff4ef15a4432
   ARGenericTableViewController: 61a0897ba66c35111b5d1cc3b44884282bd3c1a5
   Artsy+Authentication: 3bf11ceca61c52e9e31490535bf5798f625406fa
   Artsy+UIColors: 31c03c4146f5e6618a9b950f37dfe02dd9ac09a6

--- a/src/lib/Components/Inbox/Conversations/Message.tsx
+++ b/src/lib/Components/Inbox/Conversations/Message.tsx
@@ -84,6 +84,11 @@ export class Message extends React.Component<Props, any> {
   render() {
     const { artworkPreview, initials, message, senderName } = this.props
     const isSent = this.props.relay ? !this.props.relay.hasOptimisticUpdate(message) : true
+    const transactions = this.props.relay.getPendingTransactions(message)
+
+    if (transactions && transactions.length) {
+      console.log(transactions[0].getStatus())
+    }
 
     return (
       <Container>

--- a/yarn.lock
+++ b/yarn.lock
@@ -271,13 +271,7 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
-ansi-styles@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.0.0.tgz#5404e93a544c4fec7f048262977bebfe3155e0c1"
-  dependencies:
-    color-convert "^1.0.0"
-
-ansi-styles@^3.1.0:
+ansi-styles@^3.0.0, ansi-styles@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.1.0.tgz#09c202d5c917ec23188caa5c9cb9179cd9547750"
   dependencies:


### PR DESCRIPTION
What I would like to do is create the pending state for Messages that are sent under conditions of poor connectivity: 

<img width="308" alt="screen shot 2017-07-20 at 10 43 28 am" src="https://user-images.githubusercontent.com/2712962/28431185-4cec3b02-6d38-11e7-8b3a-305591c4ba3b.png">


Unfortunately, what I've put together so far results in this error once network returns and `transaction.recommit()` is called:

![simulator screen shot jul 20 2017 10 40 38 am](https://user-images.githubusercontent.com/2712962/28431222-75586a34-6d38-11e7-9121-4a663a2da519.png)

I think the Message component is created with the optimistic update but then destroyed when the transaction fails, taking the transaction with it. The question is, how can we get the optimistically updated component to persist and try again when the network connection returns?

Here are some things I've been looking at and trying to make sense of:
https://facebook.github.io/relay/docs/api-reference-relay-container.html#hasoptimisticupdate-example
https://github.com/facebook/relay/issues/1402
http://mgiroux.me/2016/relays-apply-update-function/

@l2succes and I talked about possibly waiting on this until we have support for local storage, and then creating a queue of pending messages. Otherwise, we can give Relay Modern a shot, but I'm not sure if it'll solve the problem or not.

