### PR TITLE
Changes post-sale artwork supplementary info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ###### Dev
 
 -   Adds stylelint to the dev-experience, not validated on CI yet - orta
+-   Changes post-sale supplementary artwork info - ash
 
 ### 1.4.0-beta.3
 

--- a/src/lib/Components/ArtworkGrids/Artwork.tsx
+++ b/src/lib/Components/ArtworkGrids/Artwork.tsx
@@ -79,11 +79,7 @@ class Artwork extends React.Component<RelayProps, any> {
           </View>
         )
       } else {
-        return (
-          <SerifText style={styles.text}>
-            Auction Closed
-          </SerifText>
-        )
+        return <SerifText style={styles.text}>Auction Closed</SerifText>
       }
     } else {
       return (

--- a/src/lib/Components/ArtworkGrids/Artwork.tsx
+++ b/src/lib/Components/ArtworkGrids/Artwork.tsx
@@ -63,20 +63,28 @@ class Artwork extends React.Component<RelayProps, any> {
 
   saleMessage() {
     const artwork = this.props.artwork
-    if (artwork.is_in_auction && artwork.sale_artwork.sale.is_open) {
-      const numberOfBids = artwork.sale_artwork.bidder_positions_count
-      let text = artwork.sale_artwork.opening_bid.display
-      if (numberOfBids > 0) {
-        text = `${artwork.sale_artwork.current_bid.display} (${numberOfBids} bid${numberOfBids === 1 ? "" : "s"})`
-      }
-      return (
-        <View style={{ flexDirection: "row" }}>
-          <Image style={{ marginRight: 4 }} source={require("../../../../images/paddle.png")} />
+    if (artwork.is_in_auction) {
+      if (artwork.sale_artwork.sale.is_open) {
+        const numberOfBids = artwork.sale_artwork.bidder_positions_count
+        let text = artwork.sale_artwork.opening_bid.display
+        if (numberOfBids > 0) {
+          text = `${artwork.sale_artwork.current_bid.display} (${numberOfBids} bid${numberOfBids === 1 ? "" : "s"})`
+        }
+        return (
+          <View style={{ flexDirection: "row" }}>
+            <Image style={{ marginRight: 4 }} source={require("../../../../images/paddle.png")} />
+            <SerifText style={styles.text}>
+              {text}
+            </SerifText>
+          </View>
+        )
+      } else {
+        return (
           <SerifText style={styles.text}>
-            {text}
+            Auction Closed
           </SerifText>
-        </View>
-      )
+        )
+      }
     } else {
       return (
         artwork.sale_message &&

--- a/src/lib/Components/ArtworkGrids/__tests__/__snapshots__/Artwork-tests.tsx.snap
+++ b/src/lib/Components/ArtworkGrids/__tests__/__snapshots__/Artwork-tests.tsx.snap
@@ -150,7 +150,7 @@ exports[`in a closed sale renders without any price information 1`] = `
       ]
     }
   >
-    Contact Gallery
+    Auction Closed
   </Text>
 </View>
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -271,13 +271,7 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
-ansi-styles@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.0.0.tgz#5404e93a544c4fec7f048262977bebfe3155e0c1"
-  dependencies:
-    color-convert "^1.0.0"
-
-ansi-styles@^3.1.0:
+ansi-styles@^3.0.0, ansi-styles@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.1.0.tgz#09c202d5c917ec23188caa5c9cb9179cd9547750"
   dependencies:


### PR DESCRIPTION
This is work for https://github.com/artsy/auctions/issues/531 and the Emission equivalent of Eigen's https://github.com/artsy/eigen/pull/2402

Not sure about the yarn.lock file changes – please take a look.