### PR TITLE
@alloy => Show inquiries

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -1481,12 +1481,17 @@ type Collection implements Node {
   # A type-specific Gravity Mongo Document ID.
   _id: String!
   cached: Int
-  artworks_connection(after: String, first: Int, before: String, last: Int): ArtworkConnection
+  artworks_connection(after: String, first: Int, before: String, last: Int, private: Boolean = false, sort: CollectionSorts): ArtworkConnection
   description: String!
   default: Boolean!
   name: String!
   private: Boolean!
   slug: String!
+}
+
+enum CollectionSorts {
+  POSITION_ASC
+  POSITION_DESC
 }
 
 type CollectorProfileType {
@@ -1570,7 +1575,12 @@ type Conversation implements Node {
     # Specify a tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
   ): String
+
+  # Only the artworks discussed in the conversation.
   artworks: [Artwork]
+
+  # The artworks and/or partner shows discussed in the conversation.
+  items: [ConversationItem]
 
   # A connection for all messages in a single conversation
   messages(after: String, first: Int, before: String, last: Int): MessageConnection
@@ -1605,6 +1615,14 @@ type ConversationInitiator {
   email: String!
   initials(length: Int = 3): String
 }
+
+type ConversationItem {
+  item: ConversationItemType
+  title: String
+  permalink: String
+}
+
+union ConversationItemType = Artwork | Show
 
 # The participant responding to the conversation, currently always a Partner
 type ConversationResponder {
@@ -2714,6 +2732,8 @@ type Me implements Node {
     # The ID of the Conversation
     id: String!
   ): Conversation
+
+  # Conversations, usually between a user and partner.
   conversations(after: String, first: Int, before: String, last: Int): ConversationConnection
   created_at(
     convert_to_utc: Boolean
@@ -2808,6 +2828,9 @@ type Message implements Node {
   # Full unsanitized text.
   raw_text: String!
   attachments: [Attachment]
+
+  # True if message is an invoice message
+  is_invoice: Boolean
   created_at(
     convert_to_utc: Boolean
     format: String
@@ -2838,6 +2861,8 @@ type MessageEdge {
 type Mutation {
   followArtist(input: FollowArtistInput!): FollowArtistPayload
   updateCollectorProfile(input: UpdateCollectorProfileInput!): UpdateCollectorProfilePayload
+
+  # Updating buyer outcome of a conversation.
   updateConversation(input: UpdateConversationMutationInput!): UpdateConversationMutationPayload
 
   # Appending a message to a conversation thread

--- a/data/schema.json
+++ b/data/schema.json
@@ -16674,6 +16674,26 @@
                     "ofType": null
                   },
                   "defaultValue": null
+                },
+                {
+                  "name": "private",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false"
+                },
+                {
+                  "name": "sort",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "CollectionSorts",
+                    "ofType": null
+                  },
+                  "defaultValue": null
                 }
               ],
               "type": {
@@ -16774,6 +16794,29 @@
             }
           ],
           "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "CollectionSorts",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "POSITION_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "POSITION_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {
@@ -22225,7 +22268,7 @@
             },
             {
               "name": "conversations",
-              "description": null,
+              "description": "Conversations, usually between a user and partner.",
               "args": [
                 {
                   "name": "after",
@@ -24393,7 +24436,7 @@
             },
             {
               "name": "artworks",
-              "description": null,
+              "description": "Only the artworks discussed in the conversation.",
               "args": [],
               "type": {
                 "kind": "LIST",
@@ -24401,6 +24444,22 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "Artwork",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "items",
+              "description": "The artworks and/or partner shows discussed in the conversation.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ConversationItem",
                   "ofType": null
                 }
               },
@@ -24674,6 +24733,74 @@
         },
         {
           "kind": "OBJECT",
+          "name": "ConversationItem",
+          "description": null,
+          "fields": [
+            {
+              "name": "item",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "UNION",
+                "name": "ConversationItemType",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "title",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "permalink",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "UNION",
+          "name": "ConversationItemType",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "Artwork",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Show",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "OBJECT",
           "name": "MessageConnection",
           "description": "A connection to a list of items.",
           "fields": [
@@ -24859,6 +24986,18 @@
                   "name": "Attachment",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "is_invoice",
+              "description": "True if message is an invoice message",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -34934,7 +35073,7 @@
             },
             {
               "name": "updateConversation",
-              "description": null,
+              "description": "Updating buyer outcome of a conversation.",
               "args": [
                 {
                   "name": "input",

--- a/src/lib/Components/Inbox/Conversations/Message.tsx
+++ b/src/lib/Components/Inbox/Conversations/Message.tsx
@@ -51,6 +51,7 @@ interface Props extends RelayProps {
   senderName: string
   initials?: string
   artworkPreview?: JSX.Element
+  showPreview?: JSX.Element
   relay?: Relay.RelayProp
 }
 
@@ -82,7 +83,7 @@ export class Message extends React.Component<Props, any> {
   }
 
   render() {
-    const { artworkPreview, initials, message, senderName } = this.props
+    const { artworkPreview, initials, message, senderName, showPreview } = this.props
     const isSent = this.props.relay ? !this.props.relay.hasOptimisticUpdate(message) : true
 
     return (
@@ -101,6 +102,11 @@ export class Message extends React.Component<Props, any> {
           {artworkPreview &&
             <ArtworkPreviewContainer>
               {artworkPreview}
+            </ArtworkPreviewContainer>}
+
+          {showPreview &&
+            <ArtworkPreviewContainer>
+              {showPreview}
             </ArtworkPreviewContainer>}
 
           {this.renderAttachmentPreviews(message.attachments)}

--- a/src/lib/Components/Inbox/Conversations/Preview/ShowPreview.tsx
+++ b/src/lib/Components/Inbox/Conversations/Preview/ShowPreview.tsx
@@ -1,0 +1,84 @@
+import * as React from "react"
+import * as Relay from "react-relay"
+
+import { TouchableHighlight } from "react-native"
+
+import { PreviewText as P, Subtitle } from "../../Typography"
+
+import styled from "styled-components/native"
+import colors from "../../../../../data/colors"
+import fonts from "../../../../../data/fonts"
+import OpaqueImageView from "../../../OpaqueImageView"
+
+const Container = styled.View`
+  border-width: 1;
+  border-color: ${colors["gray-regular"]};
+  flex-direction: row;
+`
+
+const VerticalLayout = styled.View`
+  flex: 1;
+  flex-direction: column;
+`
+
+const Image = styled(OpaqueImageView)`
+  margin-top: 12;
+  margin-left: 12;
+  margin-bottom: 12;
+  width: 80;
+  height: 55;
+`
+
+const TextContainer = styled(VerticalLayout)`
+  margin-left: 25;
+  align-self: center;
+`
+
+const SerifText = styled(P)`
+  font-size: 14;
+`
+
+interface Props extends RelayProps {
+  onSelected?: () => void
+}
+
+export class ShowPreview extends React.Component<Props, any> {
+  render() {
+    const show = this.props.show
+
+    return (
+      <TouchableHighlight underlayColor={colors["gray-light"]} onPress={this.props.onSelected}>
+        <Container>
+          <Image imageURL={show.cover_image.url} />
+          <TextContainer>
+            <SerifText>
+              {show.name}
+            </SerifText>
+          </TextContainer>
+        </Container>
+      </TouchableHighlight>
+    )
+  }
+}
+
+export default Relay.createContainer(ShowPreview, {
+  fragments: {
+    show: () => Relay.QL`
+      fragment on Show {
+        name
+        cover_image {
+          url
+        }
+      }
+    `,
+  },
+})
+
+interface RelayProps {
+  show: {
+    name: string | null
+    cover_image: {
+      url: string | null
+    } | null
+  }
+}

--- a/src/lib/Components/Inbox/Conversations/__stories__/ConversationSnippet.story.tsx
+++ b/src/lib/Components/Inbox/Conversations/__stories__/ConversationSnippet.story.tsx
@@ -15,15 +15,19 @@ const conversation: Conversation = {
   to: { name: "ACA Galleries" },
   last_message: "Karl and Anna... Fab!",
   last_message_at: moment().subtract(30, "minutes").toISOString(),
-  artworks: [
+  items: [
     {
-      id: "bradley-theodore-karl-and-anna-face-off-diptych",
-      href: "/artwork/bradley-theodore-karl-and-anna-face-off-diptych",
       title: "Karl and Anna Face Off (Diptych)",
-      date: "2016",
-      artist_names: "Bradley Theodore",
-      image: {
-        url: "https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/normalized.jpg",
+      item: {
+        __typename: "Artwork",
+        id: "bradley-theodore-karl-and-anna-face-off-diptych",
+        href: "/artwork/bradley-theodore-karl-and-anna-face-off-diptych",
+        title: "Karl and Anna Face Off (Diptych)",
+        date: "2016",
+        artist_names: "Bradley Theodore",
+        image: {
+          url: "https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/normalized.jpg",
+        },
       },
     },
   ],

--- a/src/lib/Components/Inbox/Conversations/__tests__/ConversationSnippet-tests.tsx
+++ b/src/lib/Components/Inbox/Conversations/__tests__/ConversationSnippet-tests.tsx
@@ -18,16 +18,20 @@ const conversation = {
   last_message: "Karl and Anna... Fab!",
   last_message_at: moment().subtract(30, "minutes").toISOString(),
   created_at: "2017-06-01T14:14:35.538Z",
-  artworks: [
+  items: [
     {
-      id: "bradley-theodore-karl-and-anna-face-off-diptych",
-      href: "/artwork/bradley-theodore-karl-and-anna-face-off-diptych",
       title: "Karl and Anna Face Off (Diptych)",
-      date: "2016",
-      artist_names: "Bradley Theodore",
-      image: {
-        url: "https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/normalized.jpg",
-        image_url: "https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/:version.jpg",
+      item: {
+        __typename: "Artwork",
+        id: "bradley-theodore-karl-and-anna-face-off-diptych",
+        href: "/artwork/bradley-theodore-karl-and-anna-face-off-diptych",
+        title: "Karl and Anna Face Off (Diptych)",
+        date: "2016",
+        artist_names: "Bradley Theodore",
+        image: {
+          url: "https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/normalized.jpg",
+          image_url: "https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/:version.jpg",
+        },
       },
     },
   ],

--- a/src/lib/Components/Inbox/Conversations/__tests__/Conversations-tests.tsx
+++ b/src/lib/Components/Inbox/Conversations/__tests__/Conversations-tests.tsx
@@ -23,16 +23,20 @@ const meProps = {
           last_message: "Karl and Anna... Fab!",
           last_message_at: moment().subtract(30, "minutes").toISOString(),
           created_at: "2017-06-01T14:14:35.538Z",
-          artworks: [
+          items: [
             {
-              id: "bradley-theodore-karl-and-anna-face-off-diptych",
-              href: "/artwork/bradley-theodore-karl-and-anna-face-off-diptych",
               title: "Karl and Anna Face Off (Diptych)",
-              date: "2016",
-              artist_names: "Bradley Theodore",
-              image: {
-                url: "https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/normalized.jpg",
-                image_url: "https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/:version.jpg",
+              item: {
+                __typename: "Artwork",
+                id: "bradley-theodore-karl-and-anna-face-off-diptych",
+                href: "/artwork/bradley-theodore-karl-and-anna-face-off-diptych",
+                title: "Karl and Anna Face Off (Diptych)",
+                date: "2016",
+                artist_names: "Bradley Theodore",
+                image: {
+                  url: "https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/normalized.jpg",
+                  image_url: "https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/:version.jpg",
+                },
               },
             },
           ],
@@ -49,16 +53,20 @@ const meProps = {
                     Could you please provide more information about the piece?",
           last_message_at: moment().subtract(1, "hours").toISOString(),
           created_at: "2017-06-01T14:12:19.155Z",
-          artworks: [
+          items: [
             {
-              id: "aida-muluneh-darkness-give-way-to-light-1",
-              href: "/artwork/aida-muluneh-darkness-give-way-to-light-1",
               title: "Darkness Give Way to Light",
-              date: "2016",
-              artist_names: "Aida Muluneh",
-              image: {
-                url: "https://d32dm0rphc51dk.cloudfront.net/FDIuqbZUY1kLR-1Pd-Ec8w/normalized.jpg",
-                image_url: "https://d32dm0rphc51dk.cloudfront.net/FDIuqbZUY1kLR-1Pd-Ec8w/:version.jpg",
+              item: {
+                __typename: "Artwork",
+                id: "aida-muluneh-darkness-give-way-to-light-1",
+                href: "/artwork/aida-muluneh-darkness-give-way-to-light-1",
+                title: "Darkness Give Way to Light",
+                date: "2016",
+                artist_names: "Aida Muluneh",
+                image: {
+                  url: "https://d32dm0rphc51dk.cloudfront.net/FDIuqbZUY1kLR-1Pd-Ec8w/normalized.jpg",
+                  image_url: "https://d32dm0rphc51dk.cloudfront.net/FDIuqbZUY1kLR-1Pd-Ec8w/:version.jpg",
+                },
               },
             },
           ],

--- a/src/lib/Containers/__tests__/Conversation-tests.tsx
+++ b/src/lib/Containers/__tests__/Conversation-tests.tsx
@@ -63,16 +63,20 @@ const props = {
         },
       ],
     },
-    artworks: [
+    items: [
       {
-        id: "adrian-piper-the-mythic-being-sols-drawing-number-1-5",
-        href: "/artwork/adrian-piper-the-mythic-being-sols-drawing-number-1-5",
         title: "The Mythic Being: Sol’s Drawing #1–5",
-        date: "1974",
-        artist_names: "Adrian Piper",
-        image: {
-          url: "https://d32dm0rphc51dk.cloudfront.net/W1FkNoM9IjrND_xv_DTkeg/normalized.jpg",
-          image_url: "https://d32dm0rphc51dk.cloudfront.net/J0uofgV9e8cIxGiZwn12mg/:version.jpg",
+        item: {
+          __typename: "Artwork",
+          id: "adrian-piper-the-mythic-being-sols-drawing-number-1-5",
+          href: "/artwork/adrian-piper-the-mythic-being-sols-drawing-number-1-5",
+          title: "The Mythic Being: Sol’s Drawing #1–5",
+          date: "1974",
+          artist_names: "Adrian Piper",
+          image: {
+            url: "https://d32dm0rphc51dk.cloudfront.net/W1FkNoM9IjrND_xv_DTkeg/normalized.jpg",
+            image_url: "https://d32dm0rphc51dk.cloudfront.net/J0uofgV9e8cIxGiZwn12mg/:version.jpg",
+          },
         },
       },
     ],

--- a/src/lib/Containers/__tests__/Inbox-tests.tsx
+++ b/src/lib/Containers/__tests__/Inbox-tests.tsx
@@ -29,16 +29,20 @@ const meProps = (withBids: boolean = true, withMessages: boolean = true) => {
               to: { name: "ACA Galleries" },
               last_message: "Karl and Anna... Fab!",
               created_at: "2017-06-01T14:14:35.538Z",
-              artworks: [
+              items: [
                 {
-                  id: "bradley-theodore-karl-and-anna-face-off-diptych",
-                  href: "/artwork/bradley-theodore-karl-and-anna-face-off-diptych",
                   title: "Karl and Anna Face Off (Diptych)",
-                  date: "2016",
-                  artist_names: "Bradley Theodore",
-                  image: {
-                    url: "https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/normalized.jpg",
-                    image_url: "https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/:version.jpg",
+                  item: {
+                    __typename: "Artwork",
+                    title: "Karl and Anna Face Off (Diptych)",
+                    id: "bradley-theodore-karl-and-anna-face-off-diptych",
+                    href: "/artwork/bradley-theodore-karl-and-anna-face-off-diptych",
+                    date: "2016",
+                    artist_names: "Bradley Theodore",
+                    image: {
+                      url: "https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/normalized.jpg",
+                      image_url: "https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/:version.jpg",
+                    },
                   },
                 },
               ],
@@ -54,16 +58,20 @@ const meProps = (withBids: boolean = true, withMessages: boolean = true) => {
                 "Hi, I’m interested in purchasing this work. \
                     Could you please provide more information about the piece?",
               created_at: "2017-06-01T14:12:19.155Z",
-              artworks: [
+              items: [
                 {
-                  id: "aida-muluneh-darkness-give-way-to-light-1",
-                  href: "/artwork/aida-muluneh-darkness-give-way-to-light-1",
                   title: "Darkness Give Way to Light",
-                  date: "2016",
-                  artist_names: "Aida Muluneh",
-                  image: {
-                    url: "https://d32dm0rphc51dk.cloudfront.net/FDIuqbZUY1kLR-1Pd-Ec8w/normalized.jpg",
-                    image_url: "https://d32dm0rphc51dk.cloudfront.net/FDIuqbZUY1kLR-1Pd-Ec8w/:version.jpg",
+                  item: {
+                    __typename: "Artwork",
+                    id: "aida-muluneh-darkness-give-way-to-light-1",
+                    href: "/artwork/aida-muluneh-darkness-give-way-to-light-1",
+                    title: "Darkness Give Way to Light",
+                    date: "2016",
+                    artist_names: "Aida Muluneh",
+                    image: {
+                      url: "https://d32dm0rphc51dk.cloudfront.net/FDIuqbZUY1kLR-1Pd-Ec8w/normalized.jpg",
+                      image_url: "https://d32dm0rphc51dk.cloudfront.net/FDIuqbZUY1kLR-1Pd-Ec8w/:version.jpg",
+                    },
                   },
                 },
               ],


### PR DESCRIPTION
<img width="372" alt="screen shot 2017-07-25 at 4 31 11 pm" src="https://user-images.githubusercontent.com/1457859/28592354-b665c284-7156-11e7-93f3-a46ce99755b5.png">


<img width="355" alt="screen shot 2017-07-25 at 4 31 18 pm" src="https://user-images.githubusercontent.com/1457859/28592362-b9abf490-7156-11e7-8284-0faaa26b3322.png">

Refactors to use the new `items` generic schema, and also renders show inquiries/previews.

Basically it just includes the show title and show cover image, so it's pretty analogous to artworks.
I didn't see any comps for this and have to show this to @katarinabatina , so I left out any new snapshot tests (but will add).
