### PR TITLE
@joeyAghion => Switch to use body instead of raw_text to render messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ###### Messaging
 
+-   Update `Message` to use `body` over `raw_text` to take advantage of some parsing. - matt
 -   Update `Message` to also show an informative signature when the message is not from the user. - matt
 -   Create `ShowPreview` and support show inquiries, plus refactor to use more generic conversation item schema - matt
 -   Fix for bug in `ArtworkPreview` related to the falsiness of an empty string - sarah

--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -2827,7 +2827,10 @@ type Message implements Node {
   from: MessageInitiator
 
   # Full unsanitized text.
-  raw_text: String!
+  raw_text: String! @deprecated(reason: "Prefer to use the parsed/cleaned-up `body`.")
+
+  # Text which has been parsed/sanitized of quoted replies (among other things).
+  body: String
   attachments: [Attachment]
 
   # True if message is an invoice message

--- a/data/schema.json
+++ b/data/schema.json
@@ -24983,6 +24983,18 @@
                   "ofType": null
                 }
               },
+              "isDeprecated": true,
+              "deprecationReason": "Prefer to use the parsed/cleaned-up `body`."
+            },
+            {
+              "name": "body",
+              "description": "Text which has been parsed/sanitized of quoted replies (among other things).",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
               "isDeprecated": false,
               "deprecationReason": null
             },

--- a/src/lib/Components/Inbox/Conversations/Message.tsx
+++ b/src/lib/Components/Inbox/Conversations/Message.tsx
@@ -125,7 +125,7 @@ export class Message extends React.Component<Props, any> {
           {this.renderAttachmentPreviews(message.attachments)}
 
           <BodyText disabled={!isSent}>
-            {message.raw_text.split("\n\nAbout")[0]}
+            {message.body.split("\n\nAbout")[0]}
           </BodyText>
 
           {!message.is_from_user &&
@@ -142,7 +142,7 @@ export default Relay.createContainer(Message, {
   fragments: {
     message: () => Relay.QL`
       fragment on Message {
-        raw_text
+        body
         created_at
         is_from_user
         from {
@@ -164,7 +164,7 @@ export default Relay.createContainer(Message, {
 
 interface RelayProps {
   message: {
-    raw_text: string | null
+    body: string | null
     created_at: string | null
     is_from_user: boolean
     from: {

--- a/src/lib/Components/Inbox/Conversations/__tests__/Message-tests.tsx
+++ b/src/lib/Components/Inbox/Conversations/__tests__/Message-tests.tsx
@@ -13,7 +13,7 @@ it("looks correct when rendered", () => {
   const props = {
     key: 0,
     created_at: moment().subtract(30, "minutes").toISOString(),
-    raw_text: messageBody,
+    body: messageBody,
     is_from_user: true,
     attachments: [],
     from: {

--- a/src/lib/Containers/Conversation.tsx
+++ b/src/lib/Containers/Conversation.tsx
@@ -274,7 +274,7 @@ class SendConversationMessageMutation extends Relay.Mutation<MutationProps, any>
     return {
       messageEdge: {
         node: {
-          raw_text: this.props.body_text,
+          body: this.props.body_text,
           is_from_user: true,
           created_at: new Date().toISOString(),
           attachments: [],

--- a/src/lib/Containers/__tests__/Conversation-tests.tsx
+++ b/src/lib/Containers/__tests__/Conversation-tests.tsx
@@ -56,7 +56,7 @@ const props = {
         {
           node: {
             id: 222,
-            raw_text: "Adoro! Por favor envie-me mais informações",
+            body: "Adoro! Por favor envie-me mais informações",
             from_email_address: "anita@garibaldi.br",
             attachments: [],
             from: {


### PR DESCRIPTION
<img width="360" alt="screen shot 2017-07-27 at 5 01 44 pm" src="https://user-images.githubusercontent.com/1457859/28692540-063c95aa-72ef-11e7-9f86-b89df03dd147.png">

<img width="355" alt="screen shot 2017-07-27 at 5 01 55 pm" src="https://user-images.githubusercontent.com/1457859/28692544-090bad66-72ef-11e7-88a8-0fb449e9ef2a.png">

Already looking better re: forwards/signatures!
