### PR TITLE
Adds Provenance for Consignments flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,14 @@
 ###### Consignments
 
 -   Adds a camera roll screen for getting photos for consignments - orta
+-   Adds a provenance screen - ash
 
 ###### Messaging
 
 -   Small composer UI tweaks - maxim
 
 ### 1.4.0-beta.3
+
 -   Changes post-sale supplementary artwork info - ash
 -   Attempt to fix a crash by not assuming a work in auction has a `sale_artwork` - alloy
 -   Expect `null` to indicate that no settings were refined - alloy
@@ -40,7 +42,7 @@
 
 ###### Messaging
 
-- Remove statusbar in inquiry modal view - maxim
+-   Remove statusbar in inquiry modal view - maxim
 
 ### 1.4.0-beta.2
 

--- a/src/lib/Components/Consignments/Components/DoneButton.tsx
+++ b/src/lib/Components/Consignments/Components/DoneButton.tsx
@@ -10,7 +10,7 @@ export interface DoneButtonProps {
 const render = (props: DoneButtonProps) => {
   const doneButtonStyles = {
     backgroundColor: "black",
-    marginBottom: 20,
+    marginBottom: 0,
     paddingTop: 18,
     height: 56,
   }

--- a/src/lib/Components/Consignments/Components/DoneButton.tsx
+++ b/src/lib/Components/Consignments/Components/DoneButton.tsx
@@ -1,0 +1,23 @@
+import * as React from "react"
+
+import BottomAlignedButton from "./BottomAlignedButton"
+
+export interface DoneButtonProps {
+  onPress: () => void
+}
+
+const render = (props: DoneButtonProps) => {
+  const doneButtonStyles = {
+    backgroundColor: "black",
+    marginBottom: 20,
+    paddingTop: 18,
+    height: 56,
+  }
+  return <BottomAlignedButton onPress={props.onPress} bodyStyle={doneButtonStyles} buttonText="DONE" />
+}
+
+export default class DoneButton extends React.Component<DoneButtonProps, null> {
+  render() {
+    return render(this.props)
+  }
+}

--- a/src/lib/Components/Consignments/Components/DoneButton.tsx
+++ b/src/lib/Components/Consignments/Components/DoneButton.tsx
@@ -4,6 +4,7 @@ import BottomAlignedButton from "./BottomAlignedButton"
 
 export interface DoneButtonProps {
   onPress: () => void
+  children?: any[]
 }
 
 const render = (props: DoneButtonProps) => {
@@ -13,7 +14,11 @@ const render = (props: DoneButtonProps) => {
     paddingTop: 18,
     height: 56,
   }
-  return <BottomAlignedButton onPress={props.onPress} bodyStyle={doneButtonStyles} buttonText="DONE" />
+  return (
+    <BottomAlignedButton onPress={props.onPress} bodyStyle={doneButtonStyles} buttonText="DONE">
+      {props.children}
+    </BottomAlignedButton>
+  )
 }
 
 export default class DoneButton extends React.Component<DoneButtonProps, null> {

--- a/src/lib/Components/Consignments/Components/TextArea.tsx
+++ b/src/lib/Components/Consignments/Components/TextArea.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+import { ActivityIndicator, Text, TextInput, TextInputProperties, View, ViewProperties } from "react-native"
+
+import styled from "styled-components/native"
+import colors from "../../../../data/colors"
+import fonts from "../../../../data/fonts"
+
+export interface TextAreaProps extends ViewProperties {
+  text?: TextInputProperties
+}
+
+const Input = styled.TextInput`
+  height: 100%;
+  background-color: black;
+  color: white;
+  font-family: "${fonts["garamond-regular"]}";
+  font-size: 20;
+  flex: 1;
+`
+
+const render = (props: TextAreaProps) =>
+  <View style={{ flex: 1, ...props.style }}>
+    <View style={{ flexDirection: "row" }}>
+      <Input
+        autoCapitalize={"sentences"}
+        keyboardAppearance="dark"
+        placeholderTextColor={colors["gray-medium"]} // TODO: Placeholder isn't multiline.
+        selectionColor={colors["gray-medium"]}
+        multiline={true}
+        numberOfLines={4} // TODO: How to scroll multiline text area?
+        {...props.text}
+      />
+    </View>
+  </View>
+
+export default render

--- a/src/lib/Components/Consignments/Components/TextArea.tsx
+++ b/src/lib/Components/Consignments/Components/TextArea.tsx
@@ -27,7 +27,6 @@ const render = (props: TextAreaProps) =>
         placeholderTextColor={colors["gray-medium"]} // TODO: Placeholder isn't multiline.
         selectionColor={colors["gray-medium"]}
         multiline={true}
-        numberOfLines={4} // TODO: How to scroll multiline text area?
         {...props.text}
       />
     </View>

--- a/src/lib/Components/Consignments/Components/TextArea.tsx
+++ b/src/lib/Components/Consignments/Components/TextArea.tsx
@@ -9,27 +9,68 @@ export interface TextAreaProps extends ViewProperties {
   text?: TextInputProperties
 }
 
+interface State {
+  text: string
+}
+
+// We need to use our own placeholder as there is a bug with multiline placeholders we're working around.
+// See discussion in https://github.com/artsy/emission/pull/699
+const Placeholder = styled.Text`
+  position: absolute;
+  z-index: -1;
+  color: ${colors["gray-medium"]};
+  font-family: "${fonts["garamond-regular"]}";
+  font-size: 20;
+  margin-top: 5px;
+  width: 100%;
+`
+
 const Input = styled.TextInput`
   height: 100%;
-  background-color: black;
+  background-color: transparent;
   color: white;
   font-family: "${fonts["garamond-regular"]}";
   font-size: 20;
   flex: 1;
 `
 
-const render = (props: TextAreaProps) =>
-  <View style={{ flex: 1, ...props.style }}>
-    <View style={{ flexDirection: "row" }}>
-      <Input
-        autoCapitalize={"sentences"}
-        keyboardAppearance="dark"
-        placeholderTextColor={colors["gray-medium"]} // TODO: Placeholder isn't multiline.
-        selectionColor={colors["gray-medium"]}
-        multiline={true}
-        {...props.text}
-      />
-    </View>
-  </View>
+export default class TextArea extends React.Component<TextAreaProps, State> {
+  constructor(props) {
+    super(props)
+    this.state = {
+      text: props.text.value ? props.text.value : "",
+    }
+  }
 
-export default render
+  onChangeText = text => {
+    this.props.text.onChangeText(text)
+    this.setState({ text })
+  }
+
+  render() {
+    const displayPlaceholder = this.state.text.length === 0
+
+    const placeholderText = this.props.text.placeholder
+    delete this.props.text.placeholder
+
+    return (
+      <View style={{ flex: 1, ...this.props.style }}>
+        <View style={{ flexDirection: "row" }}>
+          {displayPlaceholder
+            ? <Placeholder>
+                {placeholderText}
+              </Placeholder>
+            : null}
+          <Input
+            autoCapitalize={"sentences"}
+            keyboardAppearance="dark"
+            selectionColor={colors["gray-medium"]}
+            multiline={true}
+            {...this.props.text}
+            onChangeText={this.onChangeText}
+          />
+        </View>
+      </View>
+    )
+  }
+}

--- a/src/lib/Components/Consignments/Components/__tests__/TextArea-tests.tsx
+++ b/src/lib/Components/Consignments/Components/__tests__/TextArea-tests.tsx
@@ -1,0 +1,15 @@
+import * as React from "react"
+import * as renderer from "react-test-renderer"
+import TextArea from "../TextArea"
+
+it("shows the placeholder when text is empty", () => {
+  const component = renderer.create(<TextArea text={{ placeholder: "some placeholder text" }} />).toJSON()
+  expect(component).toMatchSnapshot()
+})
+
+it("doesn't show placeholder when initial text is present", () => {
+  const component = renderer
+    .create(<TextArea text={{ placeholder: "some placeholder text", value: "any text at all" }} />)
+    .toJSON()
+  expect(component).toMatchSnapshot()
+})

--- a/src/lib/Components/Consignments/Components/__tests__/__snapshots__/TextArea-tests.tsx.snap
+++ b/src/lib/Components/Consignments/Components/__tests__/__snapshots__/TextArea-tests.tsx.snap
@@ -1,0 +1,106 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`doesn't show placeholder when initial text is present 1`] = `
+<View
+  style={
+    Object {
+      "flex": 1,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+      }
+    }
+  >
+    <TextInput
+      autoCapitalize="sentences"
+      keyboardAppearance="dark"
+      multiline={true}
+      onChangeText={[Function]}
+      selectionColor="#cccccc"
+      style={
+        Array [
+          Object {
+            "backgroundColor": "transparent",
+            "color": "white",
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
+            "fontFamily": "AGaramondPro-Regular",
+            "fontSize": 20,
+            "height": "100%",
+          },
+          undefined,
+        ]
+      }
+      value="any text at all"
+    />
+  </View>
+</View>
+`;
+
+exports[`shows the placeholder when text is empty 1`] = `
+<View
+  style={
+    Object {
+      "flex": 1,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+      }
+    }
+  >
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      disabled={false}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "#cccccc",
+            "fontFamily": "AGaramondPro-Regular",
+            "fontSize": 20,
+            "marginTop": 5,
+            "position": "absolute",
+            "width": "100%",
+            "zIndex": -1,
+          },
+          undefined,
+        ]
+      }
+    >
+      some placeholder text
+    </Text>
+    <TextInput
+      autoCapitalize="sentences"
+      keyboardAppearance="dark"
+      multiline={true}
+      onChangeText={[Function]}
+      selectionColor="#cccccc"
+      style={
+        Array [
+          Object {
+            "backgroundColor": "transparent",
+            "color": "white",
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
+            "fontFamily": "AGaramondPro-Regular",
+            "fontSize": 20,
+            "height": "100%",
+          },
+          undefined,
+        ]
+      }
+    />
+  </View>
+</View>
+`;

--- a/src/lib/Components/Consignments/Screens/Artist.tsx
+++ b/src/lib/Components/Consignments/Screens/Artist.tsx
@@ -1,8 +1,8 @@
 import * as React from "react"
 
 import ArtistSearch from "../Components/ArtistSearchResults"
-import DoneButton from "../Components/BottomAlignedButton"
 import ConsignmentBG from "../Components/ConsignmentBG"
+import DoneButton from "../Components/DoneButton"
 
 import { ArtistResult, ConsignmentSetup } from "../index"
 
@@ -66,17 +66,9 @@ export default class Artist extends React.Component<Props, State> {
   }
 
   render() {
-    // This might become a higher order component for reuse, if used more elsewhere
-    const doneButtonStyles = {
-      backgroundColor: "black",
-      marginBottom: 20,
-      paddingTop: 18,
-      height: 56,
-    }
-
     return (
       <ConsignmentBG>
-        <DoneButton onPress={this.doneTapped} bodyStyle={doneButtonStyles} buttonText="DONE">
+        <DoneButton onPress={this.doneTapped}>
           <View
             style={{ alignContent: "center", justifyContent: "flex-end", flexGrow: 1, marginLeft: 20, marginRight: 20 }}
           >

--- a/src/lib/Components/Consignments/Screens/Overview.tsx
+++ b/src/lib/Components/Consignments/Screens/Overview.tsx
@@ -28,17 +28,21 @@ export default class Info extends React.Component<Props, ConsignmentSetup> {
       component: Artist,
       passProps: { ...this.state, updateWithResult: this.updateArtist },
     })
+  goToProvenanceTapped = () =>
+    this.props.navigator.push({
+      component: Provenance,
+      passProps: { ...this.state, updateWithProvenance: this.updateProvenance },
+    })
 
   goToPhotosTapped = () => this.props.navigator.push({ component: SelectFromPhotoLibrary, passProps: this.props })
   goToMetadataTapped = () => this.props.navigator.push({ component: Welcome, passProps: this.props })
   goToLocationTapped = () => this.props.navigator.push({ component: Welcome, passProps: this.props })
-  goToProvenanceTapped = () => this.props.navigator.push({ component: Provenance, passProps: this.props })
 
   updateArtist = (result: ArtistResult) => {
     this.setState({ artist: result })
   }
 
-  updateProvenace = (result: string) => {
+  updateProvenance = (result: string) => {
     this.setState({ provenance: result })
   }
 

--- a/src/lib/Components/Consignments/Screens/Overview.tsx
+++ b/src/lib/Components/Consignments/Screens/Overview.tsx
@@ -7,6 +7,7 @@ import { LargeHeadline, Subtitle } from "../Typography"
 import { ArtistResult, ConsignmentSetup } from "../"
 import TODO from "../Components/ArtworkConsignmentTodo"
 import Artist from "./Artist"
+import Provenance from "./Provenance"
 import SelectFromPhotoLibrary from "./SelectFromPhotoLibrary"
 import Welcome from "./Welcome"
 
@@ -31,10 +32,14 @@ export default class Info extends React.Component<Props, ConsignmentSetup> {
   goToPhotosTapped = () => this.props.navigator.push({ component: SelectFromPhotoLibrary, passProps: this.props })
   goToMetadataTapped = () => this.props.navigator.push({ component: Welcome, passProps: this.props })
   goToLocationTapped = () => this.props.navigator.push({ component: Welcome, passProps: this.props })
-  goToProvenanceTapped = () => this.props.navigator.push({ component: Welcome, passProps: this.props })
+  goToProvenanceTapped = () => this.props.navigator.push({ component: Provenance, passProps: this.props })
 
   updateArtist = (result: ArtistResult) => {
     this.setState({ artist: result })
+  }
+
+  updateProvenace = (result: string) => {
+    this.setState({ provenance: result })
   }
 
   render() {

--- a/src/lib/Components/Consignments/Screens/Provenance.tsx
+++ b/src/lib/Components/Consignments/Screens/Provenance.tsx
@@ -34,7 +34,14 @@ export default class Provenance extends React.Component<Props, State> {
       <ConsignmentBG>
         <DoneButton onPress={this.doneTapped}>
           <View
-            style={{ alignContent: "center", justifyContent: "flex-end", flexGrow: 1, marginLeft: 20, marginRight: 20 }}
+            style={{
+              alignContent: "center",
+              justifyContent: "flex-end",
+              flexGrow: 1,
+              marginLeft: 20,
+              marginRight: 20,
+              marginTop: 20,
+            }}
           >
             <TextArea
               text={{

--- a/src/lib/Components/Consignments/Screens/Provenance.tsx
+++ b/src/lib/Components/Consignments/Screens/Provenance.tsx
@@ -1,0 +1,60 @@
+import * as React from "react"
+
+import DoneButton from "../Components/BottomAlignedButton"
+import ConsignmentBG from "../Components/ConsignmentBG"
+
+import { NavigatorIOS, Route, View } from "react-native"
+import TextArea, { TextAreaProps } from "../Components/TextArea"
+import { ConsignmentSetup } from "../index"
+
+interface Props extends ConsignmentSetup {
+  navigator: NavigatorIOS
+  route: Route
+  updateWithProvenance?: (provenance: string) => void
+}
+
+interface State {
+  provenance: string
+}
+
+export default class Provenance extends React.Component<Props, State> {
+  constructor(props) {
+    super(props)
+    this.state = {
+      provenance: null,
+    }
+  }
+
+  doneTapped = () => {
+    this.props.navigator.pop()
+  }
+
+  render() {
+    // TODO: Move this and occurence in Artist.tsx to its own file.
+    // This might become a higher order component for reuse, if used more elsewhere
+    const doneButtonStyles = {
+      backgroundColor: "black",
+      marginBottom: 20,
+      paddingTop: 18,
+      height: 56,
+    }
+
+    return (
+      <ConsignmentBG>
+        <DoneButton onPress={this.doneTapped} bodyStyle={doneButtonStyles} buttonText="DONE">
+          <View
+            style={{ alignContent: "center", justifyContent: "flex-end", flexGrow: 1, marginLeft: 20, marginRight: 20 }}
+          >
+            <TextArea
+              text={{
+                placeholder:
+                  "Add notes about how you aquired the work. If you’re not sure add any details about how long you’ve had the work.",
+                autoFocus: typeof jest === "undefined" /* TODO: https://github.com/facebook/jest/issues/3707 */,
+              }}
+            />
+          </View>
+        </DoneButton>
+      </ConsignmentBG>
+    )
+  }
+}

--- a/src/lib/Components/Consignments/Screens/Provenance.tsx
+++ b/src/lib/Components/Consignments/Screens/Provenance.tsx
@@ -51,6 +51,7 @@ export default class Provenance extends React.Component<Props, State> {
             <TextArea
               text={{
                 onChangeText: this.textChanged,
+                value: this.props.provenance,
                 placeholder:
                   "Add notes about how you aquired the work. If you’re not sure add any details about how long you’ve had the work.",
                 autoFocus: typeof jest === "undefined" /* TODO: https://github.com/facebook/jest/issues/3707 */,

--- a/src/lib/Components/Consignments/Screens/Provenance.tsx
+++ b/src/lib/Components/Consignments/Screens/Provenance.tsx
@@ -3,11 +3,11 @@ import * as React from "react"
 import ConsignmentBG from "../Components/ConsignmentBG"
 import DoneButton from "../Components/DoneButton"
 
-import { NavigatorIOS, Route, View } from "react-native"
+import { NavigatorIOS, Route, View, ViewProperties } from "react-native"
 import TextArea, { TextAreaProps } from "../Components/TextArea"
 import { ConsignmentSetup } from "../index"
 
-interface Props extends ConsignmentSetup {
+interface Props extends ConsignmentSetup, ViewProperties {
   navigator: NavigatorIOS
   route: Route
   updateWithProvenance?: (provenance: string) => void

--- a/src/lib/Components/Consignments/Screens/Provenance.tsx
+++ b/src/lib/Components/Consignments/Screens/Provenance.tsx
@@ -26,7 +26,12 @@ export default class Provenance extends React.Component<Props, State> {
   }
 
   doneTapped = () => {
+    this.props.updateWithProvenance(this.state.provenance)
     this.props.navigator.pop()
+  }
+
+  textChanged = text => {
+    this.setState({ provenance: text })
   }
 
   render() {
@@ -45,6 +50,7 @@ export default class Provenance extends React.Component<Props, State> {
           >
             <TextArea
               text={{
+                onChangeText: this.textChanged,
                 placeholder:
                   "Add notes about how you aquired the work. If you’re not sure add any details about how long you’ve had the work.",
                 autoFocus: typeof jest === "undefined" /* TODO: https://github.com/facebook/jest/issues/3707 */,

--- a/src/lib/Components/Consignments/Screens/Provenance.tsx
+++ b/src/lib/Components/Consignments/Screens/Provenance.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 
-import DoneButton from "../Components/BottomAlignedButton"
 import ConsignmentBG from "../Components/ConsignmentBG"
+import DoneButton from "../Components/DoneButton"
 
 import { NavigatorIOS, Route, View } from "react-native"
 import TextArea, { TextAreaProps } from "../Components/TextArea"
@@ -30,18 +30,9 @@ export default class Provenance extends React.Component<Props, State> {
   }
 
   render() {
-    // TODO: Move this and occurence in Artist.tsx to its own file.
-    // This might become a higher order component for reuse, if used more elsewhere
-    const doneButtonStyles = {
-      backgroundColor: "black",
-      marginBottom: 20,
-      paddingTop: 18,
-      height: 56,
-    }
-
     return (
       <ConsignmentBG>
-        <DoneButton onPress={this.doneTapped} bodyStyle={doneButtonStyles} buttonText="DONE">
+        <DoneButton onPress={this.doneTapped}>
           <View
             style={{ alignContent: "center", justifyContent: "flex-end", flexGrow: 1, marginLeft: 20, marginRight: 20 }}
           >

--- a/src/lib/Components/Consignments/Screens/__tests__/Provenance-tests.tsx
+++ b/src/lib/Components/Consignments/Screens/__tests__/Provenance-tests.tsx
@@ -1,0 +1,41 @@
+import Provenance from "../Provenance"
+
+const emptyProps = { navigator: {} as any, route: {} as any }
+
+describe("callbacks", () => {
+  it("calls pop when done is tapped", () => {
+    const navigator: any = { pop: jest.fn() }
+    const provenance = new Provenance({ navigator, route: {}, updateWithProvenance: jest.fn() })
+
+    provenance.doneTapped()
+
+    expect(navigator.pop).toHaveBeenCalled()
+  })
+
+  it("calls updateWithProvenance when done is tapped", () => {
+    const navigator: any = { pop: jest.fn() }
+    const updateWithProvenance = jest.fn()
+    const provenance = new Provenance({ navigator, route: {}, updateWithProvenance })
+    provenance.setState({ provenance: "Acquired by my father somewhere" })
+
+    provenance.doneTapped()
+
+    expect(updateWithProvenance).toHaveBeenCalled()
+  })
+})
+
+describe("state", () => {
+  it("is set up with empty props", () => {
+    const provenance = new Provenance(emptyProps)
+    expect(provenance.state).toEqual({ provenance: null })
+  })
+
+  it("sets new state when text is changed", () => {
+    const provenance = new Provenance(emptyProps)
+    provenance.setState = jest.fn()
+
+    provenance.textChanged("Acquired by my father somewhere")
+
+    expect(provenance.setState).toHaveBeenCalledWith({ provenance: "Acquired by my father somewhere" })
+  })
+})

--- a/src/lib/Components/Consignments/Screens/__tests__/Provenance-tests.tsx
+++ b/src/lib/Components/Consignments/Screens/__tests__/Provenance-tests.tsx
@@ -1,3 +1,6 @@
+import * as React from "react"
+import "react-native"
+import * as renderer from "react-test-renderer"
 import Provenance from "../Provenance"
 
 const emptyProps = { navigator: {} as any, route: {} as any }
@@ -37,5 +40,25 @@ describe("state", () => {
     provenance.textChanged("Acquired by my father somewhere")
 
     expect(provenance.setState).toHaveBeenCalledWith({ provenance: "Acquired by my father somewhere" })
+  })
+})
+
+it("Sets up the right view hierarchy", () => {
+  const nav = {} as any
+  const route = {} as any
+
+  const tree = renderer.create(<Provenance navigator={nav} route={route} />).toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+describe("with an existing state", () => {
+  it("Sets up the right view hierarchy", () => {
+    const nav = {} as any
+    const route = {} as any
+
+    const tree = renderer
+      .create(<Provenance navigator={nav} route={route} provenance="Acquired by my father somewhere" />)
+      .toJSON()
+    expect(tree).toMatchSnapshot()
   })
 })

--- a/src/lib/Components/Consignments/Screens/__tests__/__snapshots__/Provenance-tests.tsx.snap
+++ b/src/lib/Components/Consignments/Screens/__tests__/__snapshots__/Provenance-tests.tsx.snap
@@ -1,0 +1,313 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Sets up the right view hierarchy 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "black",
+        "flexBasis": 0,
+        "flexGrow": 1,
+        "flexShrink": 1,
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    keyboardVerticalOffset={60}
+    onLayout={[Function]}
+    style={
+      Array [
+        Object {
+          "flex": 1,
+        },
+        Object {
+          "paddingBottom": 0,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        Object {
+          "flexGrow": 1,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "alignContent": "center",
+            "flexGrow": 1,
+            "justifyContent": "flex-end",
+            "marginLeft": 20,
+            "marginRight": 20,
+            "marginTop": 20,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "flex": 1,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "flexDirection": "row",
+              }
+            }
+          >
+            <TextInput
+              autoCapitalize="sentences"
+              autoFocus={false}
+              keyboardAppearance="dark"
+              multiline={true}
+              onChangeText={[Function]}
+              placeholder="Add notes about how you aquired the work. If you’re not sure add any details about how long you’ve had the work."
+              placeholderTextColor="#cccccc"
+              selectionColor="#cccccc"
+              style={
+                Array [
+                  Object {
+                    "backgroundColor": "black",
+                    "color": "white",
+                    "flexBasis": 0,
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                    "fontFamily": "AGaramondPro-Regular",
+                    "fontSize": 20,
+                    "height": "100%",
+                  },
+                  undefined,
+                ]
+              }
+              value={undefined}
+            />
+          </View>
+        </View>
+      </View>
+    </View>
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "#e5e5e5",
+            "height": 1,
+          },
+          undefined,
+        ]
+      }
+    />
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      isTVSelectable={true}
+      nativeID={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "backgroundColor": "black",
+          "height": 56,
+          "marginBottom": 0,
+          "opacity": 1,
+          "paddingTop": 18,
+        }
+      }
+      testID={undefined}
+      tvParallaxProperties={undefined}
+    >
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        disabled={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": "white",
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
+              "fontFamily": "Avant Garde Gothic ITCW01Dm",
+              "fontSize": 14,
+              "textAlign": "center",
+            },
+            undefined,
+          ]
+        }
+      >
+        DONE
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`with an existing state Sets up the right view hierarchy 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "black",
+        "flexBasis": 0,
+        "flexGrow": 1,
+        "flexShrink": 1,
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    keyboardVerticalOffset={60}
+    onLayout={[Function]}
+    style={
+      Array [
+        Object {
+          "flex": 1,
+        },
+        Object {
+          "paddingBottom": 0,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        Object {
+          "flexGrow": 1,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "alignContent": "center",
+            "flexGrow": 1,
+            "justifyContent": "flex-end",
+            "marginLeft": 20,
+            "marginRight": 20,
+            "marginTop": 20,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "flex": 1,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "flexDirection": "row",
+              }
+            }
+          >
+            <TextInput
+              autoCapitalize="sentences"
+              autoFocus={false}
+              keyboardAppearance="dark"
+              multiline={true}
+              onChangeText={[Function]}
+              placeholder="Add notes about how you aquired the work. If you’re not sure add any details about how long you’ve had the work."
+              placeholderTextColor="#cccccc"
+              selectionColor="#cccccc"
+              style={
+                Array [
+                  Object {
+                    "backgroundColor": "black",
+                    "color": "white",
+                    "flexBasis": 0,
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                    "fontFamily": "AGaramondPro-Regular",
+                    "fontSize": 20,
+                    "height": "100%",
+                  },
+                  undefined,
+                ]
+              }
+              value="Acquired by my father somewhere"
+            />
+          </View>
+        </View>
+      </View>
+    </View>
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "#e5e5e5",
+            "height": 1,
+          },
+          undefined,
+        ]
+      }
+    />
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      isTVSelectable={true}
+      nativeID={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "backgroundColor": "black",
+          "height": 56,
+          "marginBottom": 0,
+          "opacity": 1,
+          "paddingTop": 18,
+        }
+      }
+      testID={undefined}
+      tvParallaxProperties={undefined}
+    >
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        disabled={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": "white",
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
+              "fontFamily": "Avant Garde Gothic ITCW01Dm",
+              "fontSize": 14,
+              "textAlign": "center",
+            },
+            undefined,
+          ]
+        }
+      >
+        DONE
+      </Text>
+    </View>
+  </View>
+</View>
+`;

--- a/src/lib/Components/Consignments/Screens/__tests__/__snapshots__/Provenance-tests.tsx.snap
+++ b/src/lib/Components/Consignments/Screens/__tests__/__snapshots__/Provenance-tests.tsx.snap
@@ -61,19 +61,39 @@ exports[`Sets up the right view hierarchy 1`] = `
               }
             }
           >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              disabled={false}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "#cccccc",
+                    "fontFamily": "AGaramondPro-Regular",
+                    "fontSize": 20,
+                    "marginTop": 5,
+                    "position": "absolute",
+                    "width": "100%",
+                    "zIndex": -1,
+                  },
+                  undefined,
+                ]
+              }
+            >
+              Add notes about how you aquired the work. If you’re not sure add any details about how long you’ve had the work.
+            </Text>
             <TextInput
               autoCapitalize="sentences"
               autoFocus={false}
               keyboardAppearance="dark"
               multiline={true}
               onChangeText={[Function]}
-              placeholder="Add notes about how you aquired the work. If you’re not sure add any details about how long you’ve had the work."
-              placeholderTextColor="#cccccc"
               selectionColor="#cccccc"
               style={
                 Array [
                   Object {
-                    "backgroundColor": "black",
+                    "backgroundColor": "transparent",
                     "color": "white",
                     "flexBasis": 0,
                     "flexGrow": 1,
@@ -223,13 +243,11 @@ exports[`with an existing state Sets up the right view hierarchy 1`] = `
               keyboardAppearance="dark"
               multiline={true}
               onChangeText={[Function]}
-              placeholder="Add notes about how you aquired the work. If you’re not sure add any details about how long you’ve had the work."
-              placeholderTextColor="#cccccc"
               selectionColor="#cccccc"
               style={
                 Array [
                   Object {
-                    "backgroundColor": "black",
+                    "backgroundColor": "transparent",
                     "color": "white",
                     "flexBasis": 0,
                     "flexGrow": 1,

--- a/src/lib/Components/Consignments/__stories__/Consignments.story.tsx
+++ b/src/lib/Components/Consignments/__stories__/Consignments.story.tsx
@@ -4,6 +4,7 @@ import * as React from "react"
 import Nav from "../index"
 import Artist from "../Screens/Artist"
 import Overview from "../Screens/Overview"
+import Provenance from "../Screens/Provenance"
 import SelectFromPhotoLibrary from "../Screens/SelectFromPhotoLibrary"
 import Welcome from "../Screens/Welcome"
 
@@ -22,6 +23,9 @@ storiesOf("Consignments")
   })
   .add("Artist Page", () => {
     return <Artist navigator={nav} route={route} />
+  })
+  .add("Provenance", () => {
+    return <Provenance navigator={nav} route={route} />
   })
   .add("SelectFromPhotoLibrary Page", () => {
     return <SelectFromPhotoLibrary navigator={nav} route={route} />


### PR DESCRIPTION
There is one problem with this PR but it may be something with React Native we need to fix. The placeholder text is limited to one line:

![simulator screen shot jul 28 2017 2 42 57 pm](https://user-images.githubusercontent.com/498212/28731740-1a86acf8-73a3-11e7-9180-6de07bcfbab1.png)

When inspected in Reveal, placeholders are implemented internally to RN as a `UILabel` but the multiline property of the text input isn't passed through. 

![screen shot 2017-07-28 at 2 43 36 pm](https://user-images.githubusercontent.com/498212/28731773-3866da18-73a3-11e7-8f8b-12ca53290f7d.png)

Not sure if that's a blocker for this PR; I'm keen to hear next steps.