### PR TITLE
Remove annoying logs around proptypes and createClass from RN codebase

### DIFF
--- a/src/setupJest.ts
+++ b/src/setupJest.ts
@@ -1,3 +1,18 @@
+const originalConsoleError = console.error
+
+// Remove on the next React-Native update.
+console.error = (message?: any, ...optionalParams: any[]) => {
+  if (
+    typeof message === "string" &&
+    (message.includes("PropTypes has been moved to a separate package.") ||
+      message.includes("React.createClass is no longer supported."))
+  ) {
+    // NOOP
+  } else {
+    originalConsoleError(message)
+  }
+}
+
 function mockedModule(path: string, moduleName: string) {
   jest.mock(path, () => ({ default: moduleName }))
 }


### PR DESCRIPTION
I finally get some peace and quiet in the test runner

![screen shot 2017-07-28 at 15 59 23](https://user-images.githubusercontent.com/49038/28734199-c3997ef6-73ad-11e7-8e55-43307941f8d1.png)

Most of these errors are fixed in the latest version of RN - so we can delete this on the next update.