### PR TITLE
Convert AREmission to be created with an AREmissionConfiguration, and add googleMapsAPIKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 -   Adds stylelint to the dev-experience, not validated on CI yet - orta
 -   Updates Storybooks to 3.2 - orta
 -   CocoaPods/Danger updates - orta
+-   AREmission bridging updates which require integration work in Eigen - orta
+-   You can choose any URL for gravity/metaphysics - orta
+-   Adds an env var for google maps API - orta
 
 ###### Consignments
 

--- a/Example/Emission/AppDelegate.m
+++ b/Example/Emission/AppDelegate.m
@@ -107,7 +107,15 @@ randomBOOL(void)
   AREmission *emission = nil;
   NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
 
+  NSString *gravityURL = @"https://api.artsy.net";
+  NSString *metaphysicsURL = @"https://metaphysics-production.artsy.net";
+
   BOOL useStaging = [defaults boolForKey:ARUseStagingDefault];
+  if (useStaging) {
+    gravityURL = @"https://stagingapi.artsy.net";
+    metaphysicsURL = @"https://metaphysics-staging.artsy.net";
+  }
+
   BOOL usePRBuild = [defaults boolForKey:ARUsePREmissionDefault];
   BOOL useRNP = NO;
   BOOL useAppHub = NO;
@@ -144,7 +152,9 @@ randomBOOL(void)
     self.emissionLoadedFromString = @"Using bundled JS";
   }
 
-  emission = [[AREmission alloc] initWithUserID:userID authenticationToken:accessToken packagerURL:jsCodeLocation useStagingEnvironment:useStaging];
+  AREmissionConfiguration *config = [[AREmissionConfiguration alloc] initWithUserID:userID authenticationToken:accessToken sentryDSN:nil googleMapsAPIKey:nil gravityHost:gravityURL metaphysicsHost:metaphysicsURL];
+
+  emission = [[AREmission alloc] initWithConfiguration:config packagerURL:jsCodeLocation];
   [AREmission setSharedInstance:emission];
 
   ARRootViewController *controller = (id)self.navigationController.topViewController;

--- a/Pod/Classes/Core/AREmission.h
+++ b/Pod/Classes/Core/AREmission.h
@@ -1,8 +1,39 @@
 #import <Foundation/Foundation.h>
+#import <React/RCTBridge.h>
+#import <React/RCTBridgeModule.h>
 
 @class AREventsModule, ARSwitchBoardModule, ARTemporaryAPIModule, ARRefineOptionsModule, ARWorksForYouModule, ARTakeCameraPhotoModule, RCTBridge;
 
 NS_ASSUME_NONNULL_BEGIN
+
+/// A configuration object for running Emission
+@interface AREmissionConfiguration : NSObject <RCTBridgeModule>
+
+// Pre-requisites for Emission to work
+@property (nonatomic, copy, readonly) NSString *userID;
+@property (nonatomic, copy, readonly) NSString *authenticationToken;
+
+// ENV Variables
+@property (nonatomic, copy, readonly, nullable) NSString *sentryDSN;
+@property (nonatomic, copy, readonly, nullable) NSString *googleMapsAPIKey;
+
+// Server configuration
+@property (nonatomic, copy, readonly) NSString *gravityAPIHost;
+@property (nonatomic, copy, readonly) NSString *metaphysicsAPIHost;
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
+
+// Forces us to always include all properties
+- (instancetype)initWithUserID:(NSString *)userID
+           authenticationToken:(NSString *)token
+                     sentryDSN:(nullable NSString *)sentryDSN
+              googleMapsAPIKey:(nullable NSString *)googleAPIKey
+                   gravityHost:(NSString *)gravity
+               metaphysicsHost:(NSString *)metaphysics;
+@end
+
 
 @interface AREmission : NSObject
 
@@ -17,19 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)sharedInstance;
 + (void)setSharedInstance:(AREmission *)instance;
 
-- (instancetype)initWithUserID:(NSString *)userID
-           authenticationToken:(NSString *)authenticationToken;
-
-- (instancetype)initWithUserID:(NSString *)userID
-           authenticationToken:(NSString *)authenticationToken
-                   packagerURL:(nullable NSURL *)packagerURL
-         useStagingEnvironment:(BOOL)useStagingEnvironmen;
-
-- (instancetype)initWithUserID:(NSString *)userID
-           authenticationToken:(NSString *)authenticationToken
-                   packagerURL:(nullable NSURL *)packagerURL
-         useStagingEnvironment:(BOOL)useStagingEnvironment
-                     sentryDSN:(nullable NSString *)sentryDSN NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithConfiguration:(AREmissionConfiguration *)config packagerURL:(nullable NSURL *)packagerURL NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/Pod/Classes/Core/AREmission.m
+++ b/Pod/Classes/Core/AREmission.m
@@ -6,17 +6,7 @@
 #import "ARWorksForYouModule.h"
 #import "ARTakeCameraPhotoModule.h"
 
-#import <React/RCTBridge.h>
-#import <React/RCTBridgeModule.h>
 #import <SentryReactNative/RNSentry.h>
-
-
-@interface AREmissionConfiguration : NSObject <RCTBridgeModule>
-@property (nonatomic, copy, readwrite) NSString *userID;
-@property (nonatomic, copy, readwrite) NSString *authenticationToken;
-@property (nonatomic, copy, readwrite) NSString *sentryDSN;
-@property (nonatomic, assign, readwrite) BOOL useStagingEnvironment;
-@end
 
 @implementation AREmissionConfiguration
 
@@ -27,11 +17,32 @@ RCT_EXPORT_MODULE(Emission);
   return @{
     @"userID": self.userID,
     @"authenticationToken": self.authenticationToken,
-    @"useStagingEnvironment": @(self.useStagingEnvironment),
-    @"sentryDSN": self.sentryDSN ?: @"", // Empty is falsy in JS, so this is fine too.
+
+    @"gravityAPIHost": self.gravityAPIHost,
+    @"metaphysicsAPIHost": self.metaphysicsAPIHost,
+
+    // Empty is falsy in JS, so these are fine too.
+    @"googleMapsAPIKey": self.googleMapsAPIKey ?: @"",
+    @"sentryDSN": self.sentryDSN ?: @"",
   };
 }
 
+- (instancetype)initWithUserID:(NSString *)userID
+           authenticationToken:(NSString *)token
+                     sentryDSN:(NSString *)sentryDSN
+              googleMapsAPIKey:(NSString *)googleAPIKey
+                   gravityHost:(NSString *)gravity
+               metaphysicsHost:(NSString *)metaphysics
+{
+    self = [super init];
+    _userID = userID.copy;
+    _authenticationToken = token.copy;
+    _sentryDSN = sentryDSN.copy;
+    _googleMapsAPIKey = googleAPIKey.copy;
+    _gravityAPIHost = gravity.copy;
+    _metaphysicsAPIHost = metaphysics.copy;
+    return self;
+}
 @end
 
 
@@ -54,37 +65,17 @@ static AREmission *_sharedInstance = nil;
   return _sharedInstance;
 }
 
-- (instancetype)initWithUserID:(NSString *)userID
-           authenticationToken:(NSString *)authenticationToken;
+- (instancetype)initWithConfiguration:(AREmissionConfiguration *)config packagerURL:(nullable NSURL *)packagerURL
 {
-  return [self initWithUserID:userID
-          authenticationToken:authenticationToken
-                  packagerURL:nil
-        useStagingEnvironment:NO];
-}
-
-- (instancetype)initWithUserID:(NSString *)userID
-           authenticationToken:(NSString *)authenticationToken
-                   packagerURL:(nullable NSURL *)packagerURL
-         useStagingEnvironment:(BOOL)useStagingEnvironment;
-{
-  return [self initWithUserID:userID
-          authenticationToken:authenticationToken
-                  packagerURL:packagerURL
-        useStagingEnvironment:useStagingEnvironment
-                    sentryDSN:nil];
-}
-
-- (instancetype)initWithUserID:(NSString *)userID
-           authenticationToken:(NSString *)authenticationToken
-                   packagerURL:(nullable NSURL *)packagerURL
-         useStagingEnvironment:(BOOL)useStagingEnvironment
-                     sentryDSN:(nullable NSString *)sentryDSN;
-{
-  NSParameterAssert(userID);
-  NSParameterAssert(authenticationToken);
+  NSParameterAssert(config);
+  NSParameterAssert(config.userID);
+  NSParameterAssert(config.authenticationToken);
+  NSParameterAssert(config.gravityAPIHost);
+  NSParameterAssert(config.metaphysicsAPIHost);
 
   if ((self = [super init])) {
+    // When adding a new native module, remember to add it
+    // to the array of modules below.
     _eventsModule = [AREventsModule new];
     _switchBoardModule = [ARSwitchBoardModule new];
     _APIModule = [ARTemporaryAPIModule new];
@@ -92,11 +83,7 @@ static AREmission *_sharedInstance = nil;
     _worksForYouModule = [ARWorksForYouModule new];
     _cameraModule = [ARTakeCameraPhotoModule new];
 
-    _configurationModule = [AREmissionConfiguration new];
-    _configurationModule.userID = userID;
-    _configurationModule.authenticationToken = authenticationToken;
-    _configurationModule.useStagingEnvironment = useStagingEnvironment;
-    _configurationModule.sentryDSN = sentryDSN;
+    _configurationModule = config;
 
     NSArray *modules = @[_APIModule, _configurationModule, _eventsModule, _switchBoardModule, _refineModule, _worksForYouModule, _cameraModule];
 
@@ -104,7 +91,7 @@ static AREmission *_sharedInstance = nil;
                                     moduleProvider:^{ return modules; }
                                      launchOptions:nil];
     
-    if (sentryDSN) {
+    if (config.sentryDSN) {
       [RNSentry installWithBridge:_bridge];
     }
   }

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -69,6 +69,7 @@ const testFilesThatDontExist = correspondingTestsForAppFiles
   .filter(f => !f.includes("AppRegistry")) // skip registry, kinda untestable
   .filter(f => !f.includes("Routes")) // skip routes, kinda untestable
   .filter(f => !f.includes("NativeModules")) // skip modules that are native, they are untestable
+  .filter(f => !f.includes("lib/relay/")) // skip modules that are native, they are untestable
   .filter(f => !fs.existsSync(f))
 
 if (testFilesThatDontExist.length > 0) {

--- a/src/lib/relay/config.tsx
+++ b/src/lib/relay/config.tsx
@@ -5,9 +5,9 @@ const { Emission } = NativeModules
 let metaphysicsURL
 let gravityURL
 
-if (Emission && Emission.useStagingEnvironment) {
-  metaphysicsURL = "https://metaphysics-staging.artsy.net"
-  gravityURL = "https://stagingapi.artsy.net"
+if (Emission && Emission.gravityAPIHost && Emission.metaphysicsAPIHost) {
+  metaphysicsURL = Emission.metaphysicsAPIHost
+  gravityURL = Emission.gravityAPIHost
 } else {
   metaphysicsURL = "https://metaphysics-production.artsy.net"
   gravityURL = "https://api.artsy.net"


### PR DESCRIPTION
Switches out the old init functions, and replaces it with a compulsory `AREmissionConfiguration`. 

Converts the URLs for grav/metaphysics to be DI'd in too.

This will need the same changes in Eigen on the next deploy. Should just be a matter of consolidating the existing env vars into the object.