### PR TITLE
remove unneeded placeholderBackgroundColor from props

### DIFF
--- a/src/lib/Components/OpaqueImageView.tsx
+++ b/src/lib/Components/OpaqueImageView.tsx
@@ -121,14 +121,17 @@ export default class OpaqueImageView extends React.Component<Props, State> {
     // If no imageURL is given at all, simply set the placeholder background color as a view backgroundColor style so
     // that it shows immediately.
     let backgroundColorStyle = null
+    let remainderProps = props
     if (this.props.imageURL) {
       const anyProps = props as any
       anyProps.placeholderBackgroundColor = processColor(props.placeholderBackgroundColor)
     } else {
+      const { placeholderBackgroundColor, ...remainder } = props
+      remainderProps = remainder
       backgroundColorStyle = { backgroundColor: props.placeholderBackgroundColor }
     }
 
-    return <NativeOpaqueImageView style={[style, backgroundColorStyle]} {...props} />
+    return <NativeOpaqueImageView style={[style, backgroundColorStyle]} {...remainderProps} />
   }
 }
 


### PR DESCRIPTION
This PR resolves a minor storybook bug in displaying a single/multi-item article.

In `OpaqueImageView` the placeholder background color is processed with `processColor` if needed, but passed into props as a regular hex color string if not. This causes an error in the storybook.