### PR TITLE
[Dev/Admin] Update the admin/beta/dev UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 -   AREmission bridging updates which require integration work in Eigen - orta
 -   You can choose any URL for gravity/metaphysics - orta
 -   Adds an env var for google maps API - orta
+-   Updates the beta/dev UI - orta
 
 ###### Consignments
 

--- a/Example/Emission/ARRootViewController+AppHub.m
+++ b/Example/Emission/ARRootViewController+AppHub.m
@@ -11,9 +11,14 @@
   ARSectionData *section = [[ARSectionData alloc] initWithCellDataArray:@[
     [self appHubBuildChooser],
     [self appHubMetadata],
-    [self showPRForBuild]
   ]];
-  [self setupSection:section withTitle:@"AppHub"];
+
+  id prInfo = [self showPRForBuild];
+  if (prInfo) {
+    [section addCellData:prInfo];
+  }
+
+  [self setupSection:section withTitle:@"Beta Versioning"];
   return section;
 }
 
@@ -45,11 +50,16 @@
     pr = [[build.buildDescription componentsSeparatedByString:@"- #"] lastObject];
   }
 
+  // Hide this button if we can't get a useful PR link
+  if (build && [pr isEqualToString:build.buildDescription]) {
+    return nil;
+  }
+
   cellData.cellConfigurationBlock = ^(UITableViewCell *cell) {
     if (!pr) {
       cell.textLabel.text = @"Not on an AppHub build...";
     } else {
-      cell.textLabel.text = [NSString stringWithFormat:@"Link to PR %@", pr];
+      cell.textLabel.text = [NSString stringWithFormat:@"Last PR %@", pr];
     }
   };
 
@@ -66,7 +76,7 @@
 {
   ARCellData *cellData = [[ARCellData alloc] initWithIdentifier:AROptionCell];
   cellData.cellConfigurationBlock = ^(UITableViewCell *cell) {
-    cell.textLabel.text = @"Choose an RN build";
+    cell.textLabel.text = @"Choose a beta build";
   };
   cellData.cellSelectionBlock = ^(UITableView *tableView, NSIndexPath *indexPath) {
     [AppHub presentSelectorOnViewController:self withBuildHandler:^(AHBuild *build, NSError *error) {

--- a/Example/Emission/AppDelegate.m
+++ b/Example/Emission/AppDelegate.m
@@ -142,7 +142,7 @@ randomBOOL(void)
   } else if (useAppHub) {
     AHBuild *build = [[AppHub buildManager] currentBuild];
     jsCodeLocation = [build.bundle URLForResource:@"main" withExtension:@"jsbundle"];
-    self.emissionLoadedFromString = [NSString stringWithFormat:@"Using AppHub build %@", build.name];
+    self.emissionLoadedFromString = [NSString stringWithFormat:@"Using AppHub %@", build.name];
   }
 
   // Fall back to the bundled Emission JS for release

--- a/Example/Emission/EigenLikeAdminViewController.m
+++ b/Example/Emission/EigenLikeAdminViewController.m
@@ -22,10 +22,8 @@ NSString *const ARLabOptionCell = @"LabOptionCell";
 - (NSString *)titleForApp
 {
   NSDictionary *metadata = [[NSBundle mainBundle] infoDictionary];
-  NSString *name = [metadata objectForKey:@"CFBundleIdentifier"];
   NSString *build = [metadata objectForKey:@"CFBundleVersion"];
-  NSString *version = [metadata objectForKey:@"CFBundleShortVersionString"];
-  return [NSString stringWithFormat:@"%@ v%@, build %@", name, version, build];
+  return [NSString stringWithFormat:@"Emission build %@", build];
 }
 
 - (void)setupSection:(ARSectionData *)section withTitle:(NSString *)title

--- a/src/lib/Components/Inbox/Conversations/__tests__/Conversations-tests.tsx
+++ b/src/lib/Components/Inbox/Conversations/__tests__/Conversations-tests.tsx
@@ -21,7 +21,7 @@ const meProps = {
           from: { name: "Jean-Luc Collecteur", email: "luc+messaging@artsymail.com" },
           to: { name: "ACA Galleries" },
           last_message: "Karl and Anna... Fab!",
-          last_message_at: moment().subtract(30, "minutes").toISOString(),
+          last_message_at: moment().subtract(1, "year").toISOString(),
           created_at: "2017-06-01T14:14:35.538Z",
           items: [
             {

--- a/src/lib/Components/Inbox/Conversations/__tests__/__snapshots__/Conversations-tests.tsx.snap
+++ b/src/lib/Components/Inbox/Conversations/__tests__/__snapshots__/Conversations-tests.tsx.snap
@@ -197,7 +197,7 @@ exports[`looks correct when rendered 1`] = `
                   ]
                 }
               >
-                30 MINUTES
+                A YEAR
               </Text>
             </View>
           </View>

--- a/src/lib/Containers/Conversation.tsx
+++ b/src/lib/Containers/Conversation.tsx
@@ -1,4 +1,3 @@
-import * as moment from "moment"
 import * as React from "react"
 import * as Relay from "react-relay"
 


### PR DESCRIPTION
We have betas being released *mostly* automatically now (sometimes Xcode fails, so it needs too be re-built). Both in terms of the native code via TestFlight, and master JS commits via AppHub as of last Friday.

So, I downloaded a copy and played around with it. I think it's in a pretty reasonable state but it uses a lot of dev terminology which could be simplified.

So here's what a beta version looks like now:

<img width="504" alt="screen shot 2017-08-20 at 12 24 58" src="https://user-images.githubusercontent.com/49038/29496611-f3da0fa6-85a3-11e7-85dc-a16d47d79989.png">

If you wanted to choose a PR build:

<img width="504" alt="screen shot 2017-08-20 at 12 35 23" src="https://user-images.githubusercontent.com/49038/29496621-175e7ec6-85a4-11e7-8ab2-74faeb7b5495.png">

(the tick indicates that it's definitely available to use)

Then you end up with a much simpler UI:

<img width="504" alt="screen shot 2017-08-20 at 12 35 32" src="https://user-images.githubusercontent.com/49038/29496625-1fa88572-85a4-11e7-85a1-b11a167c24fd.png">

This is because there's no guarantee that any of the other things will work. You get access to the storybooks and you're good to go. Reverting from the PR build brings you back to a similar main menu.

---

I also removed the additional view controllers from the betas, it should encourage us to think a bit more about story hierarchy and coverage. Plus stories are dynamically updated per commit, whereas the view controllers are using native code and we should be moving away from requiring those changes unless necessary.

They're still there in dev mode though.

<img width="504" alt="screen shot 2017-08-20 at 12 40 03" src="https://user-images.githubusercontent.com/49038/29496641-b7a72f18-85a4-11e7-8c99-7ad680ec7f39.png">