### PR TITLE
[dev] Update Jest SVG renderer #trivial

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "danger": "^1.2.0",
     "jest": "^20.0.4",
     "jest-react-native": "18.0.0",
-    "jest-snapshots-svg": "^0.0.14",
+    "jest-snapshots-svg": "^0.0.16",
     "lint-staged": "^3.4.1",
     "prettier": "^1.5.2",
     "react-dom": "16.0.0-alpha.12",

--- a/src/lib/Components/Consignments/Components/__tests__/__snapshots__/Toggle-tests.tsx-looks-good-as-an-svg.svg
+++ b/src/lib/Components/Consignments/Components/__tests__/__snapshots__/Toggle-tests.tsx-looks-good-as-an-svg.svg
@@ -4,7 +4,7 @@
  <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="64" height="34"/>
 
  <g transform='translate(0, 0)'>
-   <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="64" height="55"/>
+   <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="64" height="31"/>
 
    <g transform='translate(0, 0)'>
      <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="8" y="9" width="48" height="22"/>
@@ -14,10 +14,10 @@
        <rect type="Text" fill-opacity="0.1" stroke-width="1" stroke="black" x="24" y="0" width="24" height="22"/>
      </g>
 
-     <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="31" width="64" height="24"/>
+     <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="6" y="4" width="52" height="24"/>
 
-     <g transform='translate(0, 31)'>
-       <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="40" y="0" width="24" height="24"/>
+     <g transform='translate(6, 4)'>
+       <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="28" y="0" width="24" height="24"/>
      </g>
 
    </g>

--- a/src/lib/Components/Consignments/Screens/__tests__/__snapshots__/FinalSubmissionQuestions-tests.tsx-shows-3-sets-of-questions-when-there's-no-edition-info.svg
+++ b/src/lib/Components/Consignments/Screens/__tests__/__snapshots__/FinalSubmissionQuestions-tests.tsx-shows-3-sets-of-questions-when-there's-no-edition-info.svg
@@ -7,24 +7,24 @@
    <rect type="RCTScrollView" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="750" height="1334"/>
 
    <g transform='translate(0, 0)'>
-     <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="750" height="328"/>
+     <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="750" height="364"/>
 
      <g transform='translate(0, 0)'>
-       <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="750" height="328"/>
+       <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="750" height="364"/>
 
        <g transform='translate(0, 0)'>
          <rect type="Text" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="40" width="750" height="60"/>
-         <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="100" width="750" height="228"/>
+         <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="100" width="750" height="264"/>
 
          <g transform='translate(0, 100)'>
-           <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="750" height="76"/>
+           <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="750" height="88"/>
 
            <g transform='translate(0, 0)'>
-             <rect type="Text" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="18" width="686" height="40"/>
-             <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="686" y="21" width="64" height="34"/>
+             <rect type="Text" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="24" width="686" height="40"/>
+             <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="686" y="27" width="64" height="34"/>
 
-             <g transform='translate(686, 21)'>
-               <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="64" height="55"/>
+             <g transform='translate(686, 27)'>
+               <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="64" height="31"/>
 
                <g transform='translate(0, 0)'>
                  <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="8" y="9" width="48" height="22"/>
@@ -34,9 +34,9 @@
                    <rect type="Text" fill-opacity="0.1" stroke-width="1" stroke="black" x="24" y="0" width="24" height="22"/>
                  </g>
 
-                 <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="31" width="64" height="24"/>
+                 <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="6" y="4" width="52" height="24"/>
 
-                 <g transform='translate(0, 31)'>
+                 <g transform='translate(6, 4)'>
                    <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="24" height="24"/>
                  </g>
 
@@ -46,14 +46,14 @@
 
            </g>
 
-           <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="76" width="750" height="76"/>
+           <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="88" width="750" height="88"/>
 
-           <g transform='translate(0, 76)'>
-             <rect type="Text" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="18" width="686" height="40"/>
-             <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="686" y="21" width="64" height="34"/>
+           <g transform='translate(0, 88)'>
+             <rect type="Text" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="24" width="686" height="40"/>
+             <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="686" y="27" width="64" height="34"/>
 
-             <g transform='translate(686, 21)'>
-               <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="64" height="55"/>
+             <g transform='translate(686, 27)'>
+               <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="64" height="31"/>
 
                <g transform='translate(0, 0)'>
                  <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="8" y="9" width="48" height="22"/>
@@ -63,9 +63,9 @@
                    <rect type="Text" fill-opacity="0.1" stroke-width="1" stroke="black" x="24" y="0" width="24" height="22"/>
                  </g>
 
-                 <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="31" width="64" height="24"/>
+                 <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="6" y="4" width="52" height="24"/>
 
-                 <g transform='translate(0, 31)'>
+                 <g transform='translate(6, 4)'>
                    <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="24" height="24"/>
                  </g>
 
@@ -75,14 +75,14 @@
 
            </g>
 
-           <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="152" width="750" height="76"/>
+           <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="176" width="750" height="88"/>
 
-           <g transform='translate(0, 152)'>
-             <rect type="Text" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="18" width="686" height="40"/>
-             <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="686" y="21" width="64" height="34"/>
+           <g transform='translate(0, 176)'>
+             <rect type="Text" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="24" width="686" height="40"/>
+             <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="686" y="27" width="64" height="34"/>
 
-             <g transform='translate(686, 21)'>
-               <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="64" height="55"/>
+             <g transform='translate(686, 27)'>
+               <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="64" height="31"/>
 
                <g transform='translate(0, 0)'>
                  <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="8" y="9" width="48" height="22"/>
@@ -92,9 +92,9 @@
                    <rect type="Text" fill-opacity="0.1" stroke-width="1" stroke="black" x="24" y="0" width="24" height="22"/>
                  </g>
 
-                 <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="31" width="64" height="24"/>
+                 <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="6" y="4" width="52" height="24"/>
 
-                 <g transform='translate(0, 31)'>
+                 <g transform='translate(6, 4)'>
                    <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="24" height="24"/>
                  </g>
 

--- a/src/lib/Components/Consignments/Screens/__tests__/__snapshots__/FinalSubmissionQuestions-tests.tsx-shows-and-additional-2-inputs-when-there's-edition-info.svg
+++ b/src/lib/Components/Consignments/Screens/__tests__/__snapshots__/FinalSubmissionQuestions-tests.tsx-shows-and-additional-2-inputs-when-there's-edition-info.svg
@@ -7,82 +7,24 @@
    <rect type="RCTScrollView" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="750" height="1334"/>
 
    <g transform='translate(0, 0)'>
-     <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="750" height="369"/>
+     <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="750" height="417"/>
 
      <g transform='translate(0, 0)'>
-       <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="750" height="369"/>
+       <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="750" height="417"/>
 
        <g transform='translate(0, 0)'>
          <rect type="Text" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="40" width="750" height="60"/>
-         <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="100" width="750" height="269"/>
+         <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="100" width="750" height="317"/>
 
          <g transform='translate(0, 100)'>
-           <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="750" height="76"/>
+           <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="750" height="88"/>
 
            <g transform='translate(0, 0)'>
-             <rect type="Text" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="18" width="686" height="40"/>
-             <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="686" y="21" width="64" height="34"/>
+             <rect type="Text" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="24" width="686" height="40"/>
+             <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="686" y="27" width="64" height="34"/>
 
-             <g transform='translate(686, 21)'>
-               <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="64" height="55"/>
-
-               <g transform='translate(0, 0)'>
-                 <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="8" y="9" width="48" height="22"/>
-
-                 <g transform='translate(8, 9)'>
-                   <rect type="Text" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="24" height="22"/>
-                   <rect type="Text" fill-opacity="0.1" stroke-width="1" stroke="black" x="24" y="0" width="24" height="22"/>
-                 </g>
-
-                 <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="31" width="64" height="24"/>
-
-                 <g transform='translate(0, 31)'>
-                   <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="40" y="0" width="24" height="24"/>
-                 </g>
-
-               </g>
-
-             </g>
-
-           </g>
-
-           <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="76" width="750" height="41"/>
-
-           <g transform='translate(0, 76)'>
-             <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="375" height="41"/>
-
-             <g transform='translate(0, 0)'>
-               <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="375" height="40"/>
-
-               <g transform='translate(0, 0)'>
-                 <rect type="TextInput" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="0" height="40"/>
-               </g>
-
-               <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="40" width="375" height="1"/>
-             </g>
-
-             <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="375" y="0" width="375" height="41"/>
-
-             <g transform='translate(375, 0)'>
-               <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="375" height="40"/>
-
-               <g transform='translate(0, 0)'>
-                 <rect type="TextInput" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="0" height="40"/>
-               </g>
-
-               <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="40" width="375" height="1"/>
-             </g>
-
-           </g>
-
-           <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="117" width="750" height="76"/>
-
-           <g transform='translate(0, 117)'>
-             <rect type="Text" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="18" width="686" height="40"/>
-             <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="686" y="21" width="64" height="34"/>
-
-             <g transform='translate(686, 21)'>
-               <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="64" height="55"/>
+             <g transform='translate(686, 27)'>
+               <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="64" height="31"/>
 
                <g transform='translate(0, 0)'>
                  <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="8" y="9" width="48" height="22"/>
@@ -92,9 +34,67 @@
                    <rect type="Text" fill-opacity="0.1" stroke-width="1" stroke="black" x="24" y="0" width="24" height="22"/>
                  </g>
 
-                 <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="31" width="64" height="24"/>
+                 <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="6" y="4" width="52" height="24"/>
 
-                 <g transform='translate(0, 31)'>
+                 <g transform='translate(6, 4)'>
+                   <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="28" y="0" width="24" height="24"/>
+                 </g>
+
+               </g>
+
+             </g>
+
+           </g>
+
+           <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="88" width="750" height="53"/>
+
+           <g transform='translate(0, 88)'>
+             <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="6" width="375" height="41"/>
+
+             <g transform='translate(0, 6)'>
+               <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="375" height="40"/>
+
+               <g transform='translate(0, 0)'>
+                 <rect type="TextInput" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="375" height="40"/>
+               </g>
+
+               <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="40" width="375" height="1"/>
+             </g>
+
+             <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="375" y="6" width="375" height="41"/>
+
+             <g transform='translate(375, 6)'>
+               <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="375" height="40"/>
+
+               <g transform='translate(0, 0)'>
+                 <rect type="TextInput" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="375" height="40"/>
+               </g>
+
+               <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="40" width="375" height="1"/>
+             </g>
+
+           </g>
+
+           <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="141" width="750" height="88"/>
+
+           <g transform='translate(0, 141)'>
+             <rect type="Text" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="24" width="686" height="40"/>
+             <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="686" y="27" width="64" height="34"/>
+
+             <g transform='translate(686, 27)'>
+               <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="64" height="31"/>
+
+               <g transform='translate(0, 0)'>
+                 <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="8" y="9" width="48" height="22"/>
+
+                 <g transform='translate(8, 9)'>
+                   <rect type="Text" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="24" height="22"/>
+                   <rect type="Text" fill-opacity="0.1" stroke-width="1" stroke="black" x="24" y="0" width="24" height="22"/>
+                 </g>
+
+                 <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="6" y="4" width="52" height="24"/>
+
+                 <g transform='translate(6, 4)'>
                    <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="24" height="24"/>
                  </g>
 
@@ -104,14 +104,14 @@
 
            </g>
 
-           <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="193" width="750" height="76"/>
+           <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="229" width="750" height="88"/>
 
-           <g transform='translate(0, 193)'>
-             <rect type="Text" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="18" width="686" height="40"/>
-             <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="686" y="21" width="64" height="34"/>
+           <g transform='translate(0, 229)'>
+             <rect type="Text" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="24" width="686" height="40"/>
+             <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="686" y="27" width="64" height="34"/>
 
-             <g transform='translate(686, 21)'>
-               <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="64" height="55"/>
+             <g transform='translate(686, 27)'>
+               <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="64" height="31"/>
 
                <g transform='translate(0, 0)'>
                  <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="8" y="9" width="48" height="22"/>
@@ -121,9 +121,9 @@
                    <rect type="Text" fill-opacity="0.1" stroke-width="1" stroke="black" x="24" y="0" width="24" height="22"/>
                  </g>
 
-                 <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="31" width="64" height="24"/>
+                 <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="6" y="4" width="52" height="24"/>
 
-                 <g transform='translate(0, 31)'>
+                 <g transform='translate(6, 4)'>
                    <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="24" height="24"/>
                  </g>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -152,7 +152,7 @@ JSONStream@^0.8.4:
     jsonparse "0.0.5"
     through ">=2.2.7 <3"
 
-abab@^1.0.0, abab@^1.0.3:
+abab@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.3.tgz#b81de5f7274ec4e756d797cd834f303642724e5d"
 
@@ -184,21 +184,11 @@ acorn-dynamic-import@^2.0.0:
   dependencies:
     acorn "^4.0.3"
 
-acorn-globals@^1.0.4:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-1.0.9.tgz#55bb5e98691507b74579d0513413217c380c54cf"
-  dependencies:
-    acorn "^2.1.0"
-
 acorn-globals@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-3.1.0.tgz#fd8270f71fbb4996b004fa880ee5d46573a731bf"
   dependencies:
     acorn "^4.0.4"
-
-acorn@^2.1.0, acorn@^2.4.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-2.7.0.tgz#ab6e7d9d886aaca8b085bc3312b79a198433f0e7"
 
 acorn@^4.0.3, acorn@^4.0.4:
   version "4.0.11"
@@ -498,7 +488,7 @@ aws4@^1.2.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
-babel-code-frame@^6.11.0, babel-code-frame@^6.22.0, babel-code-frame@^6.8.0:
+babel-code-frame@^6.11.0, babel-code-frame@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
   dependencies:
@@ -552,17 +542,6 @@ babel-core@^6.24.1:
     path-is-absolute "^1.0.0"
     private "^0.1.6"
     slash "^1.0.0"
-    source-map "^0.5.0"
-
-babel-generator@6.11.4:
-  version "6.11.4"
-  resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.11.4.tgz#14f6933abb20c62666d27e3b7b9f5b9dc0712a9a"
-  dependencies:
-    babel-messages "^6.8.0"
-    babel-runtime "^6.9.0"
-    babel-types "^6.10.2"
-    detect-indent "^3.0.1"
-    lodash "^4.2.0"
     source-map "^0.5.0"
 
 babel-generator@^6.18.0, babel-generator@^6.25.0:
@@ -759,7 +738,7 @@ babel-loader@^7.0.0:
     loader-utils "^1.0.2"
     mkdirp "^0.5.1"
 
-babel-messages@^6.23.0, babel-messages@^6.8.0:
+babel-messages@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
   dependencies:
@@ -1483,7 +1462,7 @@ babel-register@^6.24.1:
   dependencies:
     graphql "^0.6.0"
 
-babel-runtime@6.x.x, babel-runtime@^6.0.0, babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.5.0, babel-runtime@^6.6.1, babel-runtime@^6.9.0:
+babel-runtime@6.x.x, babel-runtime@^6.0.0, babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.5.0, babel-runtime@^6.6.1:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
   dependencies:
@@ -1508,20 +1487,6 @@ babel-template@^6.24.1:
     babel-traverse "^6.24.1"
     babel-types "^6.24.1"
     babylon "^6.11.0"
-    lodash "^4.2.0"
-
-babel-traverse@6.12.0:
-  version "6.12.0"
-  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.12.0.tgz#f22f54fa0d6eeb7f63585246bab6e637858f5d94"
-  dependencies:
-    babel-code-frame "^6.8.0"
-    babel-messages "^6.8.0"
-    babel-runtime "^6.9.0"
-    babel-types "^6.9.0"
-    babylon "^6.7.0"
-    debug "^2.2.0"
-    globals "^8.3.0"
-    invariant "^2.2.0"
     lodash "^4.2.0"
 
 babel-traverse@^6.16.0, babel-traverse@^6.24.1:
@@ -1552,7 +1517,7 @@ babel-traverse@^6.18.0, babel-traverse@^6.22.0, babel-traverse@^6.23.0, babel-tr
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-babel-types@^6.10.2, babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.22.0, babel-types@^6.23.0, babel-types@^6.25.0, babel-types@^6.9.0:
+babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.22.0, babel-types@^6.23.0, babel-types@^6.25.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.25.0.tgz#70afb248d5660e5d18f811d91c8303b54134a18e"
   dependencies:
@@ -1570,15 +1535,11 @@ babel-types@^6.24.1:
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babylon@6.14.1:
-  version "6.14.1"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.14.1.tgz#956275fab72753ad9b3435d7afe58f8bf0a29815"
-
 babylon@^6.11.0, babylon@^6.12.0, babylon@^6.15.0, babylon@^6.17.0:
   version "6.17.1"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.1.tgz#17f14fddf361b695981fe679385e4f1c01ebd86f"
 
-babylon@^6.13.0, babylon@^6.17.2, babylon@^6.7.0:
+babylon@^6.13.0, babylon@^6.17.2:
   version "6.17.4"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.4.tgz#3e8b7402b88d22c3423e137a1577883b15ff869a"
 
@@ -1668,10 +1629,6 @@ body-parser@~1.13.3:
     qs "4.0.0"
     raw-body "~2.1.2"
     type-is "~1.6.6"
-
-boolbase@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
 
 boom@2.x.x:
   version "2.10.1"
@@ -1942,39 +1899,6 @@ chalk@^2.0.1:
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
-cheerio@0.20.0:
-  version "0.20.0"
-  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-0.20.0.tgz#5c710f2bab95653272842ba01c6ea61b3545ec35"
-  dependencies:
-    css-select "~1.2.0"
-    dom-serializer "~0.1.0"
-    entities "~1.1.1"
-    htmlparser2 "~3.8.1"
-    lodash "^4.1.0"
-  optionalDependencies:
-    jsdom "^7.0.2"
-
-cheerio@0.22.0:
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-0.22.0.tgz#a9baa860a3f9b595a6b81b1a86873121ed3a269e"
-  dependencies:
-    css-select "~1.2.0"
-    dom-serializer "~0.1.0"
-    entities "~1.1.1"
-    htmlparser2 "^3.9.1"
-    lodash.assignin "^4.0.9"
-    lodash.bind "^4.1.4"
-    lodash.defaults "^4.0.1"
-    lodash.filter "^4.4.0"
-    lodash.flatten "^4.2.0"
-    lodash.foreach "^4.3.0"
-    lodash.map "^4.4.0"
-    lodash.merge "^4.4.0"
-    lodash.pick "^4.2.1"
-    lodash.reduce "^4.4.0"
-    lodash.reject "^4.4.0"
-    lodash.some "^4.4.0"
-
 chokidar@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
@@ -2095,10 +2019,6 @@ color-convert@^1.0.0, color-convert@^1.3.0:
 color-diff@^0.1.3:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/color-diff/-/color-diff-0.1.7.tgz#6db78cd9482a8e459d40821eaf4b503283dcb8e2"
-
-color-logger@0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/color-logger/-/color-logger-0.0.3.tgz#d9b22dd1d973e166b18bf313f9f481bba4df2018"
 
 color-name@^1.0.0, color-name@^1.1.1:
   version "1.1.2"
@@ -2487,15 +2407,6 @@ css-rule-stream@^1.1.0:
     ldjson-stream "^1.2.1"
     through2 "^0.6.3"
 
-css-select@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
-  dependencies:
-    boolbase "~1.0.0"
-    css-what "2.1"
-    domutils "1.5.1"
-    nth-check "~1.0.1"
-
 css-selector-tokenizer@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz#e6988474ae8c953477bf5e7efecfceccd9cf4c86"
@@ -2518,10 +2429,6 @@ css-tokenize@^1.0.1:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^1.0.33"
-
-css-what@2.1:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
 
 cssesc@^0.1.0:
   version "0.1.0"
@@ -2571,11 +2478,11 @@ csso@~2.3.1:
     clap "^1.0.9"
     source-map "^0.5.3"
 
-cssom@0.3.x, "cssom@>= 0.3.0 < 0.4.0", "cssom@>= 0.3.2 < 0.4.0":
+cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.2.tgz#b8036170c79f07a90ff2f16e22284027a243848b"
 
-"cssstyle@>= 0.2.29 < 0.3.0", "cssstyle@>= 0.2.37 < 0.3.0":
+"cssstyle@>= 0.2.37 < 0.3.0":
   version "0.2.37"
   resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-0.2.37.tgz#541097234cb2513c83ceed3acddc27ff27987d54"
   dependencies:
@@ -2601,17 +2508,6 @@ d@1:
   resolved "https://registry.yarnpkg.com/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
   dependencies:
     es5-ext "^0.10.9"
-
-danger-plugin-yarn@^0.2.10:
-  version "0.2.10"
-  resolved "https://registry.yarnpkg.com/danger-plugin-yarn/-/danger-plugin-yarn-0.2.10.tgz#4bd2b7860cd970b786b31df7c8e7ed396695e010"
-  dependencies:
-    date-fns "^1.28.5"
-    lodash.flatten "^4.4.0"
-    lodash.includes "^4.3.0"
-    node-fetch "^1.7.1"
-  optionalDependencies:
-    esdoc "^0.5.2"
 
 danger@^1.2.0:
   version "1.2.0"
@@ -2643,7 +2539,7 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-date-fns@^1.27.2, date-fns@^1.28.5:
+date-fns@^1.27.2:
   version "1.28.5"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.28.5.tgz#257cfc45d322df45ef5658665967ee841cd73faf"
 
@@ -2745,14 +2641,6 @@ destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
 
-detect-indent@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-3.0.1.tgz#9dc5e5ddbceef8325764b9451b02bc6d54084f75"
-  dependencies:
-    get-stdin "^4.0.1"
-    minimist "^1.1.0"
-    repeating "^1.1.0"
-
 detect-indent@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
@@ -2792,13 +2680,6 @@ dom-helpers@^3.2.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.2.1.tgz#3203e07fed217bd1f424b019735582fc37b2825a"
 
-dom-serializer@0, dom-serializer@~0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
-  dependencies:
-    domelementtype "~1.1.1"
-    entities "~1.1.1"
-
 dom-walk@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
@@ -2806,33 +2687,6 @@ dom-walk@^0.1.0:
 domain-browser@^1.1.1:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.1.7.tgz#867aa4b093faa05f1de08c06f4d7b21fdf8698bc"
-
-domelementtype@1, domelementtype@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.0.tgz#b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
-
-domelementtype@~1.1.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.1.3.tgz#bd28773e2642881aec51544924299c5cd822185b"
-
-domhandler@2.3:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.3.0.tgz#2de59a0822d5027fabff6f032c2b25a2a8abe738"
-  dependencies:
-    domelementtype "1"
-
-domhandler@^2.3.0:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.1.tgz#892e47000a99be55bbf3774ffea0561d8879c259"
-  dependencies:
-    domelementtype "1"
-
-domutils@1.5, domutils@1.5.1, domutils@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
-  dependencies:
-    dom-serializer "0"
-    domelementtype "1"
 
 dot@^1.1.1:
   version "1.1.2"
@@ -2918,14 +2772,6 @@ enhanced-resolve@^3.4.0:
     object-assign "^4.0.1"
     tapable "^0.2.7"
 
-entities@1.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-1.0.0.tgz#b2987aa3821347fcde642b24fdfc9e4fb712bf26"
-
-entities@^1.1.1, entities@~1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
-
 "errno@>=0.1.1 <0.2.0-0", errno@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.4.tgz#b896e23a9e5e8ba33871fc996abd3635fc9a1c7d"
@@ -3001,7 +2847,7 @@ escape-html@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.2.tgz#d77d32fa98e38c2f41ae85e9278e0e0e6ba1022c"
 
-escape-html@1.0.3, escape-html@~1.0.3:
+escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
 
@@ -3032,22 +2878,6 @@ escope@^3.6.0:
     es6-weak-map "^2.0.1"
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
-
-esdoc@^0.5.2:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/esdoc/-/esdoc-0.5.2.tgz#cbfd0b20e3d1cacc23c93c328eed987e21ba0067"
-  dependencies:
-    babel-generator "6.11.4"
-    babel-traverse "6.12.0"
-    babylon "6.14.1"
-    cheerio "0.22.0"
-    color-logger "0.0.3"
-    escape-html "1.0.3"
-    fs-extra "1.0.0"
-    ice-cap "0.0.4"
-    marked "0.3.6"
-    minimist "1.2.0"
-    taffydb "2.7.2"
 
 esprima@^2.6.0, esprima@^2.7.1:
   version "2.7.3"
@@ -3446,7 +3276,7 @@ fresh@0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.0.tgz#f474ca5e6a9246d6fd8e0953cfa9b9c805afa78e"
 
-fs-extra@1.0.0, fs-extra@^1.0.0:
+fs-extra@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-1.0.0.tgz#cd3ce5f7e7cb6145883fcae3191e9877f8587950"
   dependencies:
@@ -3604,10 +3434,6 @@ global@^4.3.0, global@^4.3.2:
   dependencies:
     min-document "^2.19.0"
     process "~0.5.1"
-
-globals@^8.3.0:
-  version "8.18.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-8.18.0.tgz#93d4a62bdcac38cfafafc47d6b034768cb0ffcb4"
 
 globals@^9.0.0:
   version "9.16.0"
@@ -3828,27 +3654,6 @@ html-tags@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-2.0.0.tgz#10b30a386085f43cede353cc8fa7cb0deeea668b"
 
-htmlparser2@^3.9.1:
-  version "3.9.2"
-  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
-  dependencies:
-    domelementtype "^1.3.0"
-    domhandler "^2.3.0"
-    domutils "^1.5.1"
-    entities "^1.1.1"
-    inherits "^2.0.1"
-    readable-stream "^2.0.2"
-
-htmlparser2@~3.8.1:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.8.3.tgz#996c28b191516a8be86501a7d79757e5c70c1068"
-  dependencies:
-    domelementtype "1"
-    domhandler "2.3"
-    domutils "1.5"
-    entities "1.0"
-    readable-stream "1.1"
-
 http-errors@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.3.1.tgz#197e22cdebd4198585e8694ef6786197b91ed942"
@@ -3888,13 +3693,6 @@ https-proxy-agent@^1.0.0:
 hyphenate-style-name@^1.0.1, hyphenate-style-name@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
-
-ice-cap@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/ice-cap/-/ice-cap-0.0.4.tgz#8a6d31ab4cac8d4b56de4fa946df3352561b6e18"
-  dependencies:
-    cheerio "0.20.0"
-    color-logger "0.0.3"
 
 iconv-lite@0.4.11:
   version "0.4.11"
@@ -4539,9 +4337,9 @@ jest-snapshot@^20.0.3:
     natural-compare "^1.4.0"
     pretty-format "^20.0.3"
 
-jest-snapshots-svg@^0.0.14:
-  version "0.0.14"
-  resolved "https://registry.yarnpkg.com/jest-snapshots-svg/-/jest-snapshots-svg-0.0.14.tgz#252b93a88e7d4782d06f5c691dcbbcfe0fb1be4f"
+jest-snapshots-svg@^0.0.16:
+  version "0.0.16"
+  resolved "https://registry.yarnpkg.com/jest-snapshots-svg/-/jest-snapshots-svg-0.0.16.tgz#503dbb3bd762e16cf172cbb00e0146a836a9d601"
   dependencies:
     nbind "^0.3.12"
     yoga-layout "^1.5.0"
@@ -4613,26 +4411,6 @@ js-yaml@~3.7.0:
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
-
-jsdom@^7.0.2:
-  version "7.2.2"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-7.2.2.tgz#40b402770c2bda23469096bee91ab675e3b1fc6e"
-  dependencies:
-    abab "^1.0.0"
-    acorn "^2.4.0"
-    acorn-globals "^1.0.4"
-    cssom ">= 0.3.0 < 0.4.0"
-    cssstyle ">= 0.2.29 < 0.3.0"
-    escodegen "^1.6.1"
-    nwmatcher ">= 1.3.7 < 2.0.0"
-    parse5 "^1.5.1"
-    request "^2.55.0"
-    sax "^1.1.4"
-    symbol-tree ">= 3.1.0 < 4.0.0"
-    tough-cookie "^2.2.0"
-    webidl-conversions "^2.0.0"
-    whatwg-url-compat "~0.6.5"
-    xml-name-validator ">= 2.0.1 < 3.0.0"
 
 jsdom@^9.12.0:
   version "9.12.0"
@@ -4943,21 +4721,9 @@ lodash.assign@^4.0.3, lodash.assign@^4.0.6, lodash.assign@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
 
-lodash.assignin@^4.0.9:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.assignin/-/lodash.assignin-4.2.0.tgz#ba8df5fb841eb0a3e8044232b0e263a8dc6a28a2"
-
-lodash.bind@^4.1.4:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/lodash.bind/-/lodash.bind-4.2.1.tgz#7ae3017e939622ac31b7d7d7dcb1b34db1690d35"
-
 lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
-
-lodash.defaults@^4.0.1:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
 
 lodash.escape@^3.0.0:
   version "3.2.0"
@@ -4965,21 +4731,9 @@ lodash.escape@^3.0.0:
   dependencies:
     lodash._root "^3.0.0"
 
-lodash.filter@^4.4.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.filter/-/lodash.filter-4.6.0.tgz#668b1d4981603ae1cc5a6fa760143e480b4c4ace"
-
 lodash.find@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.find/-/lodash.find-4.6.0.tgz#cb0704d47ab71789ffa0de8b97dd926fb88b13b1"
-
-lodash.flatten@^4.2.0, lodash.flatten@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
-
-lodash.foreach@^4.3.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
 
 lodash.includes@^4.3.0:
   version "4.3.0"
@@ -5011,17 +4765,9 @@ lodash.keys@^4.0.8:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-4.2.0.tgz#a08602ac12e4fb83f91fc1fb7a360a4d9ba35205"
 
-lodash.map@^4.4.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
-
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
-
-lodash.merge@^4.4.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
 
 lodash.pad@^4.1.0:
   version "4.5.1"
@@ -5035,25 +4781,13 @@ lodash.padstart@^4.1.0:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.padstart/-/lodash.padstart-4.6.1.tgz#d2e3eebff0d9d39ad50f5cbd1b52a7bce6bb611b"
 
-lodash.pick@^4.2.1, lodash.pick@^4.4.0:
+lodash.pick@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
-
-lodash.reduce@^4.4.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.reduce/-/lodash.reduce-4.6.0.tgz#f1ab6b839299ad48f784abbf476596f03b914d3b"
-
-lodash.reject@^4.4.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.reject/-/lodash.reject-4.6.0.tgz#80d6492dc1470864bbf583533b651f42a9f52415"
 
 lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-
-lodash.some@^4.4.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.some/-/lodash.some-4.6.0.tgz#1bb9f314ef6b8baded13b549169b2a945eb68e4d"
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
@@ -5164,10 +4898,6 @@ mantra-core@^1.7.0:
 map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
-
-marked@0.3.6:
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.6.tgz#b2c6c618fccece4ef86c4fc6cb8a7cbf5aeda8d7"
 
 math-expression-evaluator@^1.2.14:
   version "1.2.17"
@@ -5319,13 +5049,13 @@ minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@1.2.0, minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-
 minimist@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.1.0.tgz#99df657a52574c21c9057497df742790b2b4c0de"
+
+minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
 "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
@@ -5421,7 +5151,7 @@ netrc@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/netrc/-/netrc-0.1.4.tgz#6be94fcaca8d77ade0a9670dc460914c94472444"
 
-node-fetch@^1.0.1, node-fetch@^1.7.1:
+node-fetch@^1.0.1:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.1.tgz#899cb3d0a3c92f952c47f1b876f4c8aeabd400d5"
   dependencies:
@@ -5592,12 +5322,6 @@ npmlog@^4.0.2:
     gauge "~2.7.3"
     set-blocking "~2.0.0"
 
-nth-check@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.1.tgz#9929acdf628fc2c41098deab82ac580cf149aae4"
-  dependencies:
-    boolbase "~1.0.0"
-
 num2fraction@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/num2fraction/-/num2fraction-1.2.2.tgz#6f682b6a027a4e9ddfa4564cd2589d1d4e669ede"
@@ -5606,7 +5330,7 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-"nwmatcher@>= 1.3.7 < 2.0.0", "nwmatcher@>= 1.3.9 < 2.0.0":
+"nwmatcher@>= 1.3.9 < 2.0.0":
   version "1.3.9"
   resolved "https://registry.yarnpkg.com/nwmatcher/-/nwmatcher-1.3.9.tgz#8bab486ff7fa3dfd086656bbe8b17116d3692d2a"
 
@@ -6752,18 +6476,18 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
-readable-stream@1.1, readable-stream@^1.0.33, readable-stream@~1.1.8, readable-stream@~1.1.9:
-  version "1.1.14"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
+"readable-stream@>=1.0.33-1 <1.1.0-0":
+  version "1.0.34"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.1"
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-"readable-stream@>=1.0.33-1 <1.1.0-0":
-  version "1.0.34"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
+readable-stream@^1.0.33, readable-stream@~1.1.8, readable-stream@~1.1.9:
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.1"
@@ -6928,12 +6652,6 @@ repeat-string@^1.5.2:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
 
-repeating@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/repeating/-/repeating-1.1.3.tgz#3d4114218877537494f97f77f9785fab810fa4ac"
-  dependencies:
-    is-finite "^1.0.0"
-
 repeating@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
@@ -6944,7 +6662,7 @@ replace-ext@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-0.0.1.tgz#29bbd92078a739f0bcce2b4ee41e837953522924"
 
-request@2, request@^2.55.0, request@^2.79.0, request@^2.81.0:
+request@2, request@^2.79.0, request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:
@@ -7106,7 +6824,7 @@ sane@~1.6.0:
     walker "~1.0.5"
     watch "~0.10.0"
 
-sax@^1.1.4, sax@^1.2.1, sax@~1.2.1:
+sax@^1.2.1, sax@~1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.2.tgz#fd8631a23bc7826bef5d871bdb87378c95647828"
 
@@ -7660,7 +7378,7 @@ symbol-observable@^1.0.1, symbol-observable@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
 
-"symbol-tree@>= 3.1.0 < 4.0.0", symbol-tree@^3.2.1:
+symbol-tree@^3.2.1:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
 
@@ -7680,10 +7398,6 @@ table@^4.0.1:
     lodash "^4.0.0"
     slice-ansi "0.0.4"
     string-width "^2.0.0"
-
-taffydb@2.7.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/taffydb/-/taffydb-2.7.2.tgz#7bf8106a5c1a48251b3e3bc0a0e1732489fd0dc8"
 
 tapable@^0.2.5, tapable@^0.2.7:
   version "0.2.7"
@@ -7801,13 +7515,13 @@ topo@1.x.x:
   dependencies:
     hoek "2.x.x"
 
-tough-cookie@^2.2.0, tough-cookie@^2.3.2, tough-cookie@~2.3.0:
+tough-cookie@^2.3.2, tough-cookie@~2.3.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.2.tgz#f081f76e4c85720e6c37a5faced737150d84072a"
   dependencies:
     punycode "^1.4.1"
 
-tr46@~0.0.1, tr46@~0.0.3:
+tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
 
@@ -8118,10 +7832,6 @@ watchpack@^1.4.0:
     chokidar "^1.7.0"
     graceful-fs "^4.1.2"
 
-webidl-conversions@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-2.0.1.tgz#3bf8258f7d318c7443c36f2e169402a1a6703506"
-
 webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
@@ -8192,12 +7902,6 @@ whatwg-encoding@^1.0.1:
 whatwg-fetch@>=0.10.0, whatwg-fetch@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-1.0.0.tgz#01c2ac4df40e236aaa18480e3be74bd5c8eb798e"
-
-whatwg-url-compat@~0.6.5:
-  version "0.6.5"
-  resolved "https://registry.yarnpkg.com/whatwg-url-compat/-/whatwg-url-compat-0.6.5.tgz#00898111af689bb097541cd5a45ca6c8798445bf"
-  dependencies:
-    tr46 "~0.0.1"
 
 whatwg-url@^4.3.0:
   version "4.6.0"
@@ -8319,7 +8023,7 @@ xcode@0.9.3, xcode@^0.9.1:
     simple-plist "^0.2.1"
     uuid "3.0.1"
 
-"xml-name-validator@>= 2.0.1 < 3.0.0", xml-name-validator@^2.0.1:
+xml-name-validator@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
 


### PR DESCRIPTION
Updates the SVG renderer.

In looking at the lockfile: I feel like `esdoc` was removed from a dependency (might have been a one of my danger plugins,  I remember doing something like this) and then this wasn't `yarn remove`'d - resulting in the new lockfile.