### PR TITLE
Dotted line component

### DIFF
--- a/Pod/Classes/DottedLineComponent/ARDottedLineManager.h
+++ b/Pod/Classes/DottedLineComponent/ARDottedLineManager.h
@@ -1,0 +1,4 @@
+#import <React/RCTViewManager.h>
+
+@interface ARDottedLineManager : RCTViewManager
+@end

--- a/Pod/Classes/DottedLineComponent/ARDottedLineManager.m
+++ b/Pod/Classes/DottedLineComponent/ARDottedLineManager.m
@@ -3,6 +3,8 @@
 
 
 @interface ARDottedLine : UIView
+@property (nonatomic, strong, readwrite) UIColor *color;
+@property (nonatomic, strong, readwrite) UIColor *processedBackgroundColor;
 @end
 
 
@@ -12,48 +14,46 @@
 {
     [super drawRect:rect];
     
-    [[UIColor whiteColor] setFill];
-    [[UIColor grayColor] setStroke];
+    [self.processedBackgroundColor setFill];
+    [self.color setStroke];
     
     CGContextFillRect(UIGraphicsGetCurrentContext(), rect);
-    //
     
     const CGFloat dotDiameter = rect.size.height / 2;
     const CGFloat gapSize = dotDiameter * 5;
     CGFloat pattern[4];
     pattern[0] = 0.0;
     pattern[1] = gapSize;
-//    const CGFloat pattern = 0.5;
+
     
     UIBezierPath *path = [UIBezierPath bezierPath];
     path.lineWidth = dotDiameter;
     path.lineCapStyle = kCGLineCapRound;
-    [path moveToPoint:CGPointMake(0, dotDiameter / 2)];
-    [path addLineToPoint:CGPointMake(rect.size.width, 2)];
+    [path moveToPoint:CGPointMake(0, dotDiameter)];
+    [path addLineToPoint:CGPointMake(rect.size.width, dotDiameter)];
     [path setLineDash:pattern count:2 phase:2];
 
     [path stroke];
 }
 
-//- (void) layoutSubviews {
-//    [super layoutSubviews];
-//    for(UIView* view in self.subviews) {
-//        [view setFrame:self.bounds];
-//    }
-//}
-
-
 @end
 
 
 @implementation ARDottedLineManager
+RCT_CUSTOM_VIEW_PROPERTY(color, NSNumber, ARDottedLine)
+{
+    view.color = [RCTConvert UIColor:json];
+}
+RCT_CUSTOM_VIEW_PROPERTY(processedBackgroundColor, NSNumber, ARDottedLine)
+{
+    view.processedBackgroundColor = [RCTConvert UIColor:json];
+}
 RCT_EXPORT_MODULE();
 
 - (UIView *)view
 {
     
     ARDottedLine *line = [ARDottedLine new];
-//    line.backgroundColor = [UIColor redColor];
     return line;
 }
 

--- a/Pod/Classes/DottedLineComponent/ARDottedLineManager.m
+++ b/Pod/Classes/DottedLineComponent/ARDottedLineManager.m
@@ -1,0 +1,60 @@
+#import "ARDottedLineManager.h"
+
+
+
+@interface ARDottedLine : UIView
+@end
+
+
+@implementation ARDottedLine
+
+- (void)drawRect:(CGRect)rect
+{
+    [super drawRect:rect];
+    
+    [[UIColor whiteColor] setFill];
+    [[UIColor grayColor] setStroke];
+    
+    CGContextFillRect(UIGraphicsGetCurrentContext(), rect);
+    //
+    
+    const CGFloat dotDiameter = rect.size.height / 2;
+    const CGFloat gapSize = dotDiameter * 5;
+    CGFloat pattern[4];
+    pattern[0] = 0.0;
+    pattern[1] = gapSize;
+//    const CGFloat pattern = 0.5;
+    
+    UIBezierPath *path = [UIBezierPath bezierPath];
+    path.lineWidth = dotDiameter;
+    path.lineCapStyle = kCGLineCapRound;
+    [path moveToPoint:CGPointMake(0, dotDiameter / 2)];
+    [path addLineToPoint:CGPointMake(rect.size.width, 2)];
+    [path setLineDash:pattern count:2 phase:2];
+
+    [path stroke];
+}
+
+//- (void) layoutSubviews {
+//    [super layoutSubviews];
+//    for(UIView* view in self.subviews) {
+//        [view setFrame:self.bounds];
+//    }
+//}
+
+
+@end
+
+
+@implementation ARDottedLineManager
+RCT_EXPORT_MODULE();
+
+- (UIView *)view
+{
+    
+    ARDottedLine *line = [ARDottedLine new];
+//    line.backgroundColor = [UIColor redColor];
+    return line;
+}
+
+@end

--- a/Pod/Classes/DottedLineComponent/ARDottedLineManager.m
+++ b/Pod/Classes/DottedLineComponent/ARDottedLineManager.m
@@ -4,7 +4,6 @@
 
 @interface ARDottedLine : UIView
 @property (nonatomic, strong, readwrite) UIColor *color;
-@property (nonatomic, strong, readwrite) UIColor *processedBackgroundColor;
 @end
 
 
@@ -14,13 +13,13 @@
 {
     [super drawRect:rect];
     
-    [self.processedBackgroundColor setFill];
+    [UIColor.whiteColor setFill];
     [self.color setStroke];
     
     CGContextFillRect(UIGraphicsGetCurrentContext(), rect);
     
     const CGFloat dotDiameter = rect.size.height / 2;
-    const CGFloat gapSize = dotDiameter * 5;
+    const CGFloat gapSize = dotDiameter * 4;
     CGFloat pattern[4];
     pattern[0] = 0.0;
     pattern[1] = gapSize;
@@ -43,11 +42,9 @@
 RCT_CUSTOM_VIEW_PROPERTY(color, NSNumber, ARDottedLine)
 {
     view.color = [RCTConvert UIColor:json];
+    [view setNeedsDisplay];
 }
-RCT_CUSTOM_VIEW_PROPERTY(processedBackgroundColor, NSNumber, ARDottedLine)
-{
-    view.processedBackgroundColor = [RCTConvert UIColor:json];
-}
+
 RCT_EXPORT_MODULE();
 
 - (UIView *)view

--- a/src/lib/Components/DottedLine.tsx
+++ b/src/lib/Components/DottedLine.tsx
@@ -4,7 +4,7 @@ import { ColorPropType, processColor, requireNativeComponent, View } from "react
 import colors from "../../data/colors"
 
 interface Props {
-  /** The color of the dots (default: Artsy grey-regular) */
+  /** The color of the dots (default: Artsy gray-medium) */
   color?: string
 }
 
@@ -12,8 +12,11 @@ class DottedLine extends React.Component<Props, null> {
   static propTypes = {
     color: ColorPropType,
   }
+  static defaultProps = {
+    color: colors["gray-medium"],
+  }
   render() {
-    return <NativeDottedLine style={{ height: 2 }} color={processColor(this.props.color || colors["gray-medium"])} />
+    return <NativeDottedLine style={{ height: 2 }} color={processColor(this.props.color)} />
   }
 }
 

--- a/src/lib/Components/DottedLine.tsx
+++ b/src/lib/Components/DottedLine.tsx
@@ -4,31 +4,16 @@ import { ColorPropType, processColor, requireNativeComponent, View } from "react
 import colors from "../../data/colors"
 
 interface Props {
-  /** Custom scaling for the dots themselves (default: 1) */
-  scale?: number
   /** The color of the dots (default: Artsy grey-regular) */
   color?: string
-  /** The background color (default: 'white') */
-  backgroundColor?: string
 }
 
 class DottedLine extends React.Component<Props, null> {
   static propTypes = {
-    scale: PropTypes.number,
     color: ColorPropType,
-    processedBackgroundColor: ColorPropType,
-  }
-  static defaultProps = {
-    scale: 1,
-    color: colors["grey-regular"],
-    backgroundColor: "white",
   }
   render() {
-    const colorProps = {
-      color: processColor(this.props.color),
-      processedBackgroundColor: processColor(this.props.backgroundColor),
-    }
-    return <NativeDottedLine style={{ height: this.props.scale * 2 }} {...colorProps} />
+    return <NativeDottedLine style={{ height: 2 }} color={processColor(this.props.color || colors["gray-medium"])} />
   }
 }
 

--- a/src/lib/Components/DottedLine.tsx
+++ b/src/lib/Components/DottedLine.tsx
@@ -1,11 +1,34 @@
+import * as PropTypes from "prop-types"
 import * as React from "react"
-import { requireNativeComponent, View } from "react-native"
+import { ColorPropType, processColor, requireNativeComponent, View } from "react-native"
+import colors from "../../data/colors"
 
-class DottedLine extends React.Component<any, any> {
-  static propTypes = { dotScale: React.PropTypes.number }
-  static defaultProps = { dotScale: 1 }
+interface Props {
+  /** Custom scaling for the dots themselves (default: 1) */
+  scale?: number
+  /** The color of the dots (default: Artsy grey-regular) */
+  color?: string
+  /** The background color (default: 'white') */
+  backgroundColor?: string
+}
+
+class DottedLine extends React.Component<Props, null> {
+  static propTypes = {
+    scale: PropTypes.number,
+    color: ColorPropType,
+    processedBackgroundColor: ColorPropType,
+  }
+  static defaultProps = {
+    scale: 1,
+    color: colors["grey-regular"],
+    backgroundColor: "white",
+  }
   render() {
-    return <NativeDottedLine style={{ height: this.props.dotScale * 2 }} />
+    const colorProps = {
+      color: processColor(this.props.color),
+      processedBackgroundColor: processColor(this.props.backgroundColor),
+    }
+    return <NativeDottedLine style={{ height: this.props.scale * 2 }} {...colorProps} />
   }
 }
 

--- a/src/lib/Components/DottedLine.tsx
+++ b/src/lib/Components/DottedLine.tsx
@@ -1,0 +1,14 @@
+import * as React from "react"
+import { requireNativeComponent, View } from "react-native"
+
+class DottedLine extends React.Component<any, any> {
+  static propTypes = { dotScale: React.PropTypes.number }
+  static defaultProps = { dotScale: 1 }
+  render() {
+    return <NativeDottedLine style={{ height: this.props.dotScale * 2 }} />
+  }
+}
+
+export default DottedLine
+
+const NativeDottedLine: React.ComponentClass<any> = requireNativeComponent("ARDottedLine", DottedLine)

--- a/src/lib/Components/Inbox/Conversations/ConversationSnippet.tsx
+++ b/src/lib/Components/Inbox/Conversations/ConversationSnippet.tsx
@@ -11,6 +11,8 @@ import colors from "../../../../data/colors"
 import fonts from "../../../../data/fonts"
 import OpaqueImageView from "../../OpaqueImageView"
 
+import DottedLine from "../../../Components/DottedLine"
+
 const Card = styled.View`
   margin: 10px 20px 0;
   min-height: 80px;
@@ -49,13 +51,13 @@ const UnreadIndicator = styled.View`
   margin-bottom: 3;
 `
 
-const Separator = styled.View`
-  height: 1;
-  width: 100%;
-  background-color: ${colors["gray-regular"]};
-  margin-top: 18px;
-  margin-bottom: 5px;
-`
+// const Separator = styled.View`
+//   height: 1;
+//   width: 100%;
+//   background-color: ${colors["gray-regular"]};
+//   margin-top: 18px;
+//   margin-bottom: 5px;
+// `
 
 const Subtitle = styled.Text`
   font-family: ${fonts["garamond-regular"]};
@@ -178,7 +180,7 @@ export class ConversationSnippet extends React.Component<Props, any> {
               </P>
             </TextPreview>
           </CardContent>
-          <Separator />
+          <DottedLine backgroundColor="white" />
         </Card>
       </TouchableWithoutFeedback>
     )

--- a/src/lib/Components/Inbox/Conversations/ConversationSnippet.tsx
+++ b/src/lib/Components/Inbox/Conversations/ConversationSnippet.tsx
@@ -34,6 +34,7 @@ const CardContent = styled(HorizontalLayout)`
 
 const TextPreview = styled(VerticalLayout)`
   margin-left: 15;
+  margin-bottom: 3;
 `
 
 const DateHeading = styled(HorizontalLayout)`
@@ -50,14 +51,6 @@ const UnreadIndicator = styled.View`
   margin-top: 3;
   margin-bottom: 3;
 `
-
-// const Separator = styled.View`
-//   height: 1;
-//   width: 100%;
-//   background-color: ${colors["gray-regular"]};
-//   margin-top: 18px;
-//   margin-bottom: 5px;
-// `
 
 const Subtitle = styled.Text`
   font-family: ${fonts["garamond-regular"]};

--- a/src/lib/Components/Inbox/Conversations/ConversationSnippet.tsx
+++ b/src/lib/Components/Inbox/Conversations/ConversationSnippet.tsx
@@ -10,7 +10,6 @@ import styled from "styled-components/native"
 import colors from "../../../../data/colors"
 import fonts from "../../../../data/fonts"
 import OpaqueImageView from "../../OpaqueImageView"
-
 import DottedLine from "../../../Components/DottedLine"
 
 const Card = styled.View`
@@ -173,7 +172,7 @@ export class ConversationSnippet extends React.Component<Props, any> {
               </P>
             </TextPreview>
           </CardContent>
-          <DottedLine backgroundColor="white" />
+          <DottedLine />
         </Card>
       </TouchableWithoutFeedback>
     )

--- a/src/lib/Components/__stories__/DottedLine.story.tsx
+++ b/src/lib/Components/__stories__/DottedLine.story.tsx
@@ -1,0 +1,15 @@
+import { action, storiesOf } from "@storybook/react-native"
+import * as React from "react"
+import { View } from "react-native"
+
+import DottedLine from "../DottedLine"
+
+storiesOf("App Style/Dotted Line")
+  .addDecorator(story =>
+    <View accessibilityLabel="wrapperView" style={{ height: 10, marginTop: 60, marginLeft: 20, marginRight: 20 }}>
+      {story()}
+    </View>
+  )
+  .add("Flat White", () => {
+    return <DottedLine />
+  })

--- a/src/lib/Components/__stories__/DottedLine.story.tsx
+++ b/src/lib/Components/__stories__/DottedLine.story.tsx
@@ -15,7 +15,7 @@ storiesOf("App Style/Dotted Line")
     return <DottedLine />
   })
   .add("With scaled dots", () => {
-    return <DottedLine scale={5} />
+    return <DottedLine />
   })
   .add("With custom color", () => {
     return <DottedLine color={colors["purple-regular"]} />

--- a/src/lib/Components/__stories__/DottedLine.story.tsx
+++ b/src/lib/Components/__stories__/DottedLine.story.tsx
@@ -1,6 +1,7 @@
 import { action, storiesOf } from "@storybook/react-native"
 import * as React from "react"
 import { View } from "react-native"
+import colors from "../../../data/colors"
 
 import DottedLine from "../DottedLine"
 
@@ -10,6 +11,12 @@ storiesOf("App Style/Dotted Line")
       {story()}
     </View>
   )
-  .add("Flat White", () => {
+  .add("Default", () => {
     return <DottedLine />
+  })
+  .add("With scaled dots", () => {
+    return <DottedLine scale={5} />
+  })
+  .add("With custom color", () => {
+    return <DottedLine color={colors["purple-regular"]} />
   })

--- a/src/lib/Components/__stories__/DottedLine.story.tsx
+++ b/src/lib/Components/__stories__/DottedLine.story.tsx
@@ -14,9 +14,6 @@ storiesOf("App Style/Dotted Line")
   .add("Default", () => {
     return <DottedLine />
   })
-  .add("With scaled dots", () => {
-    return <DottedLine />
-  })
   .add("With custom color", () => {
     return <DottedLine color={colors["purple-regular"]} />
   })

--- a/src/lib/Containers/Conversation.tsx
+++ b/src/lib/Containers/Conversation.tsx
@@ -11,6 +11,7 @@ import colors from "../../data/colors"
 import fonts from "../../data/fonts"
 import ConnectivityBanner from "../Components/ConnectivityBanner"
 
+import DottedLine from "../Components/DottedLine"
 import Composer from "../Components/Inbox/Conversations/Composer"
 import Message from "../Components/Inbox/Conversations/Message"
 import ArtworkPreview from "../Components/Inbox/Conversations/Preview/ArtworkPreview"
@@ -44,15 +45,6 @@ const BackButtonPlaceholder = styled.Image`
   height: 12;
   width: 7;
   transform: rotate(180deg);
-`
-
-const DottedBorder = styled.View`
-  height: 1;
-  border-width: 1;
-  border-style: dotted;
-  border-color: ${colors["gray-regular"]};
-  margin-left: 20;
-  margin-right: 20;
 `
 
 const MessagesList = styled(FlatList)`
@@ -180,7 +172,7 @@ export class Conversation extends React.Component<Props, State> {
             data={messages}
             renderItem={this.renderMessage.bind(this)}
             length={messages.length}
-            ItemSeparatorComponent={DottedBorder}
+            ItemSeparatorComponent={DottedLine}
           />
         </Container>
       </Composer>

--- a/src/lib/Containers/Conversation.tsx
+++ b/src/lib/Containers/Conversation.tsx
@@ -11,7 +11,6 @@ import colors from "../../data/colors"
 import fonts from "../../data/fonts"
 import ConnectivityBanner from "../Components/ConnectivityBanner"
 
-import DottedLine from "../Components/DottedLine"
 import Composer from "../Components/Inbox/Conversations/Composer"
 import Message from "../Components/Inbox/Conversations/Message"
 import ArtworkPreview from "../Components/Inbox/Conversations/Preview/ArtworkPreview"
@@ -45,6 +44,15 @@ const BackButtonPlaceholder = styled.Image`
   height: 12;
   width: 7;
   transform: rotate(180deg);
+`
+
+const DottedBorder = styled.View`
+  height: 1;
+  border-width: 1;
+  border-style: dotted;
+  border-color: ${colors["gray-regular"]};
+  margin-left: 20;
+  margin-right: 20;
 `
 
 const MessagesList = styled(FlatList)`
@@ -172,7 +180,7 @@ export class Conversation extends React.Component<Props, State> {
             data={messages}
             renderItem={this.renderMessage.bind(this)}
             length={messages.length}
-            ItemSeparatorComponent={DottedLine}
+            ItemSeparatorComponent={DottedBorder}
           />
         </Container>
       </Composer>

--- a/storybook/storyLoader.js
+++ b/storybook/storyLoader.js
@@ -19,6 +19,7 @@ function loadStories() {
   require('../src/lib/Components/Inbox/Conversations/__stories__/Inbox.story.tsx');
   require('../src/lib/Components/Inbox/Conversations/__stories__/ZeroStateInbox.story.tsx');
   require('../src/lib/Components/Text/__stories__/Typography.story.tsx');
+  require('../src/lib/Components/__stories__/DottedLine.story.tsx');
   require('../src/lib/Containers/__stories__/Artist.story.tsx');
   require('../src/lib/Containers/__stories__/Gene.story.tsx');
   require('../src/lib/Containers/__stories__/Inquiry.story.tsx');


### PR DESCRIPTION
tracked in https://github.com/artsy/emission/issues/677

This PR adds a simple horizontal `DottedLine` component to be used as a separator. Here is the actual aligned with the spec:
![image](https://user-images.githubusercontent.com/9088720/29741828-295ac876-8a42-11e7-8d41-c1c684cc7022.png)

With scaled dots (`scale={5}`):
![image](https://user-images.githubusercontent.com/9088720/29927257-ca1c93f8-8e33-11e7-86eb-79397cebe672.png)
With color (`color={colors['purple-regular']`}
![image](https://user-images.githubusercontent.com/9088720/29927287-e17aaecc-8e33-11e7-887e-99b919308597.png)

I'm not sure if anything is lacking for me to have it display in a conversation- whether i need to log in as a certain user or if these storybook views simply need to be created. **I'm also wondering - does this need a storybook implementation where it displays in context, or is the existing dotted line story sufficient?** 

Thanks!