### PR TITLE
[Dev] Separate deploy runs from CI runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,22 @@
 cache: yarn
-
 language: node_js
-node_js:
-  - "6.7"
 
-script:
-  - scripts/deploy_commit.sh
-  - yarn ci
-  - yarn danger
-  - scripts/deploy_apphub.sh
+matrix:
+  include:
+  - node_js: '6.7'
+    script:
+      - yarn ci
+      - yarn danger
+
+  # Deployment related tasks
+  - node_js: "node"
+    script: ""  # NOOP as we don't need to run tests etc
+    after_success: # This can never fail the build
+      - nvm install 6.7 # Enforce the same version
+      # Upload latest PR commit to S3
+      - test ! $TRAVIS_PULL_REQUEST == "false" && scripts/deploy_commit.sh
+      # Upload merges to master to apphub
+      - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then scripts/deploy_apphub.sh
 
 cache:
   yarn: true

--- a/scripts/deploy_apphub.sh
+++ b/scripts/deploy_apphub.sh
@@ -2,11 +2,6 @@
 # See: https://github.com/joshuapinter/apphubdeploy
 #
 
-if [ "$TRAVIS_BRANCH" != "master" ] ; then
-    echo "Skipping deploy of the commit"
-    exit 0
-fi
-
 # Set up our npm environment again
 npm install --global apphubdeploy
 

--- a/scripts/deploy_commit.sh
+++ b/scripts/deploy_commit.sh
@@ -1,10 +1,5 @@
 #!/bin/sh
 
-if [ -z "$TRAVIS_PULL_REQUEST" ]; then
-    echo "Skipping deploy of the commit"
-    exit 0
-fi
-
 # Give us a CLI to work with
 yarn global add s3-cli
 


### PR DESCRIPTION
Separates the Danger/Build/Lint runs from the deployment runs. I think they're also running when they shouldn't - so I took another stab at making them only run at the right place

#trivial