### PR TITLE
[WIP] React Native Upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ###### Dev
 
+-   Upgrades to React Native v0.48.0-rc.1 - sarah
 -   Adds stylelint to the dev-experience, not validated on CI yet - orta
 -   Updates Storybooks to 3.2 - orta
 -   CocoaPods/Danger updates - orta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ###### Dev
 
--   Upgrades to React Native v0.48.0-rc.1 - sarah
+-   Upgrades to React Native v0.48.0 - sarah
+-   Extracts connectivity banner into its own component - sarah
 -   Adds stylelint to the dev-experience, not validated on CI yet - orta
 -   Updates Storybooks to 3.2 - orta
 -   CocoaPods/Danger updates - orta

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -15,16 +15,16 @@ PODS:
     - Artsy+UIColors
     - Artsy+UIFonts (>= 3.0.0)
     - Extraction (>= 1.2.1)
-    - React/BatchedBridge (= 0.45.0-rc.2)
-    - React/Core (= 0.45.0-rc.2)
-    - React/RCTAnimation (= 0.45.0-rc.2)
-    - React/RCTCameraRoll (= 0.45.0-rc.2)
-    - React/RCTImage (= 0.45.0-rc.2)
-    - React/RCTNetwork (= 0.45.0-rc.2)
-    - React/RCTText (= 0.45.0-rc.2)
+    - React/BatchedBridge (= 0.48.0-rc.1)
+    - React/Core (= 0.48.0-rc.1)
+    - React/RCTAnimation (= 0.48.0-rc.1)
+    - React/RCTCameraRoll (= 0.48.0-rc.1)
+    - React/RCTImage (= 0.48.0-rc.1)
+    - React/RCTNetwork (= 0.48.0-rc.1)
+    - React/RCTText (= 0.48.0-rc.1)
     - SDWebImage (< 4, >= 3.7.2)
     - SentryReactNative (= 0.14.5)
-    - Yoga (= 0.45.0-rc.2.React)
+    - Yoga (= 0.48.0-rc.1.React)
   - Extraction (1.2.3):
     - Extraction/ARAnimationContinuation (= 1.2.3)
     - Extraction/ARLoadFailureView (= 1.2.3)
@@ -63,33 +63,36 @@ PODS:
   - NSURL+QueryDictionary (1.2.0)
   - ORStackView (2.0.3):
     - FLKAutoLayout
-  - React (0.45.0-rc.2):
-    - React/Core (= 0.45.0-rc.2)
-  - React/BatchedBridge (0.45.0-rc.2):
+  - React (0.48.0-rc.1):
+    - React/Core (= 0.48.0-rc.1)
+  - React/BatchedBridge (0.48.0-rc.1):
     - React/Core
     - React/cxxreact_legacy
-  - React/Core (0.45.0-rc.2):
-    - Yoga (= 0.45.0-rc.2.React)
-  - React/cxxreact_legacy (0.45.0-rc.2):
+  - React/Core (0.48.0-rc.1):
+    - Yoga (= 0.48.0-rc.1.React)
+  - React/cxxreact_legacy (0.48.0-rc.1):
     - React/jschelpers_legacy
-  - React/DevSupport (0.45.0-rc.2):
+  - React/DevSupport (0.48.0-rc.1):
     - React/Core
     - React/RCTWebSocket
-  - React/jschelpers_legacy (0.45.0-rc.2)
-  - React/RCTAnimation (0.45.0-rc.2):
+  - React/jschelpers_legacy (0.48.0-rc.1)
+  - React/RCTAnimation (0.48.0-rc.1):
     - React/Core
-  - React/RCTCameraRoll (0.45.0-rc.2):
+  - React/RCTBlob (0.48.0-rc.1):
+    - React/Core
+  - React/RCTCameraRoll (0.48.0-rc.1):
     - React/Core
     - React/RCTImage
-  - React/RCTImage (0.45.0-rc.2):
+  - React/RCTImage (0.48.0-rc.1):
     - React/Core
     - React/RCTNetwork
-  - React/RCTNetwork (0.45.0-rc.2):
+  - React/RCTNetwork (0.48.0-rc.1):
     - React/Core
-  - React/RCTText (0.45.0-rc.2):
+  - React/RCTText (0.48.0-rc.1):
     - React/Core
-  - React/RCTWebSocket (0.45.0-rc.2):
+  - React/RCTWebSocket (0.48.0-rc.1):
     - React/Core
+    - React/RCTBlob
   - SAMKeychain (1.5.0)
   - SDWebImage (3.7.5):
     - SDWebImage/Core (= 3.7.5)
@@ -104,7 +107,7 @@ PODS:
     - Sentry (~> 3.1.2)
     - Sentry/KSCrash (~> 3.1.2)
   - UIView+BooleanAnimations (1.0.2)
-  - Yoga (0.45.0-rc.2.React)
+  - Yoga (0.48.0-rc.1.React)
 
 DEPENDENCIES:
   - AppHub (from `https://github.com/orta/apphub.git`, branch `build_list`)
@@ -151,20 +154,20 @@ SPEC CHECKSUMS:
   Artsy+UIColors: 31c03c4146f5e6618a9b950f37dfe02dd9ac09a6
   Artsy+UIFonts: e66afb5c40100e2fc5bba28feb7487e252f2d06f
   Artsy-UIButtons: cdcc3ccf4d0d31ee80f45c1d11ffd2d772695b74
-  Emission: 6fc77205363e5070b0d4a99bf38a0763ea87b543
+  Emission: 2f6883eb60a9406f99f56a9ea621c37a23eba772
   Extraction: 612cf0866f74d4c0dd616677ff24146efa200958
   FLKAutoLayout: 106b14dbae09d32c6730190f4e78a959759ba4a4
   ISO8601DateFormatter: 4551b6ce4f83185425f583b0b3feb3c7b59b942c
   KSCrash: 7bd106ca4a2247774deeeb587c740ce0207de8f3
   NSURL+QueryDictionary: bae616404e2adf6409d3d5c02a093cbf44c8a236
   ORStackView: b9507271cb41fb9e0b3eecc6414d831201e7cf7c
-  React: c30b44eb8e84d2071fb78cd1ed58e1512a822a57
+  React: 464fe1f1d3a773fdb8dc89620df917dbfe563fdf
   SAMKeychain: 1fc9ae02f576365395758b12888c84704eebc423
   SDWebImage: 69c6303e3348fba97e03f65d65d4fbc26740f461
   Sentry: 5a578891f177e994d89d57effc70adb97bfb29db
   SentryReactNative: 8f251df76f03c5ee42e702f37a41803709632217
   UIView+BooleanAnimations: a760be9a066036e55f298b7b7350a6cb14cfcd97
-  Yoga: d43165f478a090e7b603edc5796965a1de27d473
+  Yoga: bccd69870c65f66f32a4047ae6efdab4b645f8e6
 
 PODFILE CHECKSUM: 0c385e9313daa3b7b7130176793f59f9c6ee2778
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -15,16 +15,16 @@ PODS:
     - Artsy+UIColors
     - Artsy+UIFonts (>= 3.0.0)
     - Extraction (>= 1.2.1)
-    - React/BatchedBridge (= 0.48.0-rc.1)
-    - React/Core (= 0.48.0-rc.1)
-    - React/RCTAnimation (= 0.48.0-rc.1)
-    - React/RCTCameraRoll (= 0.48.0-rc.1)
-    - React/RCTImage (= 0.48.0-rc.1)
-    - React/RCTNetwork (= 0.48.0-rc.1)
-    - React/RCTText (= 0.48.0-rc.1)
+    - React/BatchedBridge (= 0.48.0)
+    - React/Core (= 0.48.0)
+    - React/RCTAnimation (= 0.48.0)
+    - React/RCTCameraRoll (= 0.48.0)
+    - React/RCTImage (= 0.48.0)
+    - React/RCTNetwork (= 0.48.0)
+    - React/RCTText (= 0.48.0)
     - SDWebImage (< 4, >= 3.7.2)
     - SentryReactNative (= 0.14.5)
-    - Yoga (= 0.48.0-rc.1.React)
+    - Yoga (= 0.48.0.React)
   - Extraction (1.2.3):
     - Extraction/ARAnimationContinuation (= 1.2.3)
     - Extraction/ARLoadFailureView (= 1.2.3)
@@ -63,34 +63,34 @@ PODS:
   - NSURL+QueryDictionary (1.2.0)
   - ORStackView (2.0.3):
     - FLKAutoLayout
-  - React (0.48.0-rc.1):
-    - React/Core (= 0.48.0-rc.1)
-  - React/BatchedBridge (0.48.0-rc.1):
+  - React (0.48.0):
+    - React/Core (= 0.48.0)
+  - React/BatchedBridge (0.48.0):
     - React/Core
     - React/cxxreact_legacy
-  - React/Core (0.48.0-rc.1):
-    - Yoga (= 0.48.0-rc.1.React)
-  - React/cxxreact_legacy (0.48.0-rc.1):
+  - React/Core (0.48.0):
+    - Yoga (= 0.48.0.React)
+  - React/cxxreact_legacy (0.48.0):
     - React/jschelpers_legacy
-  - React/DevSupport (0.48.0-rc.1):
+  - React/DevSupport (0.48.0):
     - React/Core
     - React/RCTWebSocket
-  - React/jschelpers_legacy (0.48.0-rc.1)
-  - React/RCTAnimation (0.48.0-rc.1):
+  - React/jschelpers_legacy (0.48.0)
+  - React/RCTAnimation (0.48.0):
     - React/Core
-  - React/RCTBlob (0.48.0-rc.1):
+  - React/RCTBlob (0.48.0):
     - React/Core
-  - React/RCTCameraRoll (0.48.0-rc.1):
+  - React/RCTCameraRoll (0.48.0):
     - React/Core
     - React/RCTImage
-  - React/RCTImage (0.48.0-rc.1):
+  - React/RCTImage (0.48.0):
     - React/Core
     - React/RCTNetwork
-  - React/RCTNetwork (0.48.0-rc.1):
+  - React/RCTNetwork (0.48.0):
     - React/Core
-  - React/RCTText (0.48.0-rc.1):
+  - React/RCTText (0.48.0):
     - React/Core
-  - React/RCTWebSocket (0.48.0-rc.1):
+  - React/RCTWebSocket (0.48.0):
     - React/Core
     - React/RCTBlob
   - SAMKeychain (1.5.0)
@@ -107,7 +107,7 @@ PODS:
     - Sentry (~> 3.1.2)
     - Sentry/KSCrash (~> 3.1.2)
   - UIView+BooleanAnimations (1.0.2)
-  - Yoga (0.48.0-rc.1.React)
+  - Yoga (0.48.0.React)
 
 DEPENDENCIES:
   - AppHub (from `https://github.com/orta/apphub.git`, branch `build_list`)
@@ -154,20 +154,20 @@ SPEC CHECKSUMS:
   Artsy+UIColors: 31c03c4146f5e6618a9b950f37dfe02dd9ac09a6
   Artsy+UIFonts: e66afb5c40100e2fc5bba28feb7487e252f2d06f
   Artsy-UIButtons: cdcc3ccf4d0d31ee80f45c1d11ffd2d772695b74
-  Emission: 2f6883eb60a9406f99f56a9ea621c37a23eba772
+  Emission: 7cd023eeebd140217dc39f30b311a402af4ac4bc
   Extraction: 612cf0866f74d4c0dd616677ff24146efa200958
   FLKAutoLayout: 106b14dbae09d32c6730190f4e78a959759ba4a4
   ISO8601DateFormatter: 4551b6ce4f83185425f583b0b3feb3c7b59b942c
   KSCrash: 7bd106ca4a2247774deeeb587c740ce0207de8f3
   NSURL+QueryDictionary: bae616404e2adf6409d3d5c02a093cbf44c8a236
   ORStackView: b9507271cb41fb9e0b3eecc6414d831201e7cf7c
-  React: 464fe1f1d3a773fdb8dc89620df917dbfe563fdf
+  React: 830e32675a1cef76f854240fbda322282b150f98
   SAMKeychain: 1fc9ae02f576365395758b12888c84704eebc423
   SDWebImage: 69c6303e3348fba97e03f65d65d4fbc26740f461
   Sentry: 5a578891f177e994d89d57effc70adb97bfb29db
   SentryReactNative: 8f251df76f03c5ee42e702f37a41803709632217
   UIView+BooleanAnimations: a760be9a066036e55f298b7b7350a6cb14cfcd97
-  Yoga: bccd69870c65f66f32a4047ae6efdab4b645f8e6
+  Yoga: 056a82a5b4abd6b145f3d341176406e7174afff6
 
 PODFILE CHECKSUM: 0c385e9313daa3b7b7130176793f59f9c6ee2778
 

--- a/Pod/Classes/Core/RCTScrollView+EnclosingScrollView.m
+++ b/Pod/Classes/Core/RCTScrollView+EnclosingScrollView.m
@@ -18,195 +18,195 @@
 #import <React/RCTComponent.h>
 #import <React/UIView+React.h>
 
-@interface RCTScrollEvent : NSObject <RCTEvent>
-- (instancetype)initWithEventName:(NSString *)eventName
-                         reactTag:(NSNumber *)reactTag
-                       scrollView:(UIScrollView *)scrollView
-                         userData:(NSDictionary *)userData
-                    coalescingKey:(uint16_t)coalescingKey NS_DESIGNATED_INITIALIZER;
-@end
+//@interface RCTScrollEvent : NSObject <RCTEvent>
+//- (instancetype)initWithEventName:(NSString *)eventName
+//                         reactTag:(NSNumber *)reactTag
+//                       scrollView:(UIScrollView *)scrollView
+//                         userData:(NSDictionary *)userData
+//                    coalescingKey:(uint16_t)coalescingKey NS_DESIGNATED_INITIALIZER;
+//@end
 
 
-@interface RCTDescendantScrollEvent : RCTScrollEvent
-@end
+//@interface RCTDescendantScrollEvent : RCTScrollEvent
+//@end
 
-@implementation RCTDescendantScrollEvent
-{
-  NSDictionary *__userData;
-  UIScrollView *__scrollView;
-  UIScrollView *_enclosingScrollView;
-}
-
-- (instancetype)initWithEventName:(NSString *)eventName
-                         reactTag:(NSNumber *)reactTag
-                       scrollView:(UIScrollView *)scrollView
-              enclosingScrollView:(UIScrollView *)enclosingScrollView
-                         userData:(NSDictionary *)userData
-                    coalescingKey:(uint16_t)coalescingKey
-{
-    if ((self = [super initWithEventName:eventName
-                                reactTag:reactTag
-                              scrollView:scrollView
-                                userData:userData
-                           coalescingKey:coalescingKey])) {
-    __userData = userData;
-    __scrollView = scrollView;
-    _enclosingScrollView = enclosingScrollView;
-  }
-  return self;
-}
-
-- (NSDictionary *)body
-{
-  CGPoint originOffset = [__scrollView convertPoint:CGPointZero toView:_enclosingScrollView];
-  
-  CGPoint contentOffset = _enclosingScrollView.contentOffset;
-  // TODO: contentOffset.x -= originOffset.x;
-  contentOffset.x = __scrollView.contentOffset.x;
-  contentOffset.y -= originOffset.y;
-  
-  NSDictionary *body = @{
-                         @"contentOffset": @{
-                             @"x": @(contentOffset.x),
-                             @"y": @(contentOffset.y)
-                             },
-                         @"contentInset": @{
-                             @"top": @(__scrollView.contentInset.top),
-                             @"left": @(__scrollView.contentInset.left),
-                             @"bottom": @(__scrollView.contentInset.bottom),
-                             @"right": @(__scrollView.contentInset.right)
-                             },
-                         @"contentSize": @{
-                             @"width": @(__scrollView.contentSize.width),
-                             @"height": @(__scrollView.contentSize.height)
-                             },
-                         // Use the enclosing scrollview’s dimensions here, because it is likely that the receiver
-                         // wants to do calculations based on the location of the content in the enclosing scrollview.
-                         @"layoutMeasurement": @{
-                             @"width": @(_enclosingScrollView.frame.size.width),
-                             @"height": @(_enclosingScrollView.frame.size.height)
-                             },
-                         @"zoomScale": @(__scrollView.zoomScale ?: 1),
-                         };
-  
-  if (__userData) {
-    NSMutableDictionary *mutableBody = [body mutableCopy];
-    [mutableBody addEntriesFromDictionary:__userData];
-    body = mutableBody;
-  }
-  
-  return body;
-}
-
-@end
-
-
-@implementation RCTScrollEvent (RCTEnclosingScrollView)
-
-- (RCTDescendantScrollEvent *)scrollEventRelativeToDescendant:(UIScrollView *)descendantScrollView
-                                                     reactTag:(NSNumber *)reactTag
-                                                coalescingKey:(uint16_t)coalescingKey
-{
-  return [[RCTDescendantScrollEvent alloc] initWithEventName:self.eventName
-                                                    reactTag:reactTag
-                                                  scrollView:descendantScrollView
-                                         enclosingScrollView:[self valueForKey:@"_scrollView"]
-                                                    userData:[self valueForKey:@"_userData"]
-                                               coalescingKey:coalescingKey];
-}
-
-@end
+//@implementation RCTDescendantScrollEvent
+//{
+//  NSDictionary *__userData;
+//  UIScrollView *__scrollView;
+//  UIScrollView *_enclosingScrollView;
+//}
+//
+//- (instancetype)initWithEventName:(NSString *)eventName
+//                         reactTag:(NSNumber *)reactTag
+//                       scrollView:(UIScrollView *)scrollView
+//              enclosingScrollView:(UIScrollView *)enclosingScrollView
+//                         userData:(NSDictionary *)userData
+//                    coalescingKey:(uint16_t)coalescingKey
+//{
+//    if ((self = [super initWithEventName:eventName
+//                                reactTag:reactTag
+//                              scrollView:scrollView
+//                                userData:userData
+//                           coalescingKey:coalescingKey])) {
+//    __userData = userData;
+//    __scrollView = scrollView;
+//    _enclosingScrollView = enclosingScrollView;
+//  }
+//  return self;
+//}
+//
+//- (NSDictionary *)body
+//{
+//  CGPoint originOffset = [__scrollView convertPoint:CGPointZero toView:_enclosingScrollView];
+//  
+//  CGPoint contentOffset = _enclosingScrollView.contentOffset;
+//  // TODO: contentOffset.x -= originOffset.x;
+//  contentOffset.x = __scrollView.contentOffset.x;
+//  contentOffset.y -= originOffset.y;
+//  
+//  NSDictionary *body = @{
+//                         @"contentOffset": @{
+//                             @"x": @(contentOffset.x),
+//                             @"y": @(contentOffset.y)
+//                             },
+//                         @"contentInset": @{
+//                             @"top": @(__scrollView.contentInset.top),
+//                             @"left": @(__scrollView.contentInset.left),
+//                             @"bottom": @(__scrollView.contentInset.bottom),
+//                             @"right": @(__scrollView.contentInset.right)
+//                             },
+//                         @"contentSize": @{
+//                             @"width": @(__scrollView.contentSize.width),
+//                             @"height": @(__scrollView.contentSize.height)
+//                             },
+//                         // Use the enclosing scrollview’s dimensions here, because it is likely that the receiver
+//                         // wants to do calculations based on the location of the content in the enclosing scrollview.
+//                         @"layoutMeasurement": @{
+//                             @"width": @(_enclosingScrollView.frame.size.width),
+//                             @"height": @(_enclosingScrollView.frame.size.height)
+//                             },
+//                         @"zoomScale": @(__scrollView.zoomScale ?: 1),
+//                         };
+//  
+//  if (__userData) {
+//    NSMutableDictionary *mutableBody = [body mutableCopy];
+//    [mutableBody addEntriesFromDictionary:__userData];
+//    body = mutableBody;
+//  }
+//  
+//  return body;
+//}
+//
+//@end
 
 
-@implementation RCTScrollView (RCTEnclosingScrollView)
+//@implementation RCTScrollEvent (RCTEnclosingScrollView)
+//
+//- (RCTDescendantScrollEvent *)scrollEventRelativeToDescendant:(UIScrollView *)descendantScrollView
+//                                                     reactTag:(NSNumber *)reactTag
+//                                                coalescingKey:(uint16_t)coalescingKey
+//{
+//  return [[RCTDescendantScrollEvent alloc] initWithEventName:self.eventName
+//                                                    reactTag:reactTag
+//                                                  scrollView:descendantScrollView
+//                                         enclosingScrollView:[self valueForKey:@"_scrollView"]
+//                                                    userData:[self valueForKey:@"_userData"]
+//                                               coalescingKey:coalescingKey];
+//}
+//
+//@end
+//
 
-// Override method, because we want to send the generated event through the notification center.
-// Everything but the last line of the method are exactly as the original, except with a bunch of KVC shenanigans.
-- (void)sendScrollEventWithName:(NSString *)eventName
-                     scrollView:(UIScrollView *)scrollView
-                       userData:(NSDictionary *)userData
-{
-//    if (![_lastEmittedEventName isEqualToString:eventName]) {
-//        _coalescingKey++;
-//        _lastEmittedEventName = [eventName copy];
-//    }
-//    RCTScrollEvent *scrollEvent = [[RCTScrollEvent alloc] initWithEventName:eventName
-//                                                                   reactTag:self.reactTag
-//                                                                 scrollView:scrollView
-//                                                                   userData:userData
-//                                                              coalescingKey:_coalescingKey];
-//    [_eventDispatcher sendEvent:scrollEvent];
-    
-    
-  uint16_t coalescingKey = [[self valueForKey:@"_coalescingKey"] unsignedIntegerValue];
-  
-  if (![eventName isEqualToString:[self valueForKey:@"_lastEmittedEventName"]]) {
-    coalescingKey++;
-    [self setValue:@(coalescingKey) forKey:@"_coalescingKey"];
-    [self setValue:eventName forKey:@"_lastEmittedEventName"];
-  }
+//@implementation RCTScrollView (RCTEnclosingScrollView)
+//
+//// Override method, because we want to send the generated event through the notification center.
+//// Everything but the last line of the method are exactly as the original, except with a bunch of KVC shenanigans.
+//- (void)sendScrollEventWithName:(NSString *)eventName
+//                     scrollView:(UIScrollView *)scrollView
+//                       userData:(NSDictionary *)userData
+//{
+////    if (![_lastEmittedEventName isEqualToString:eventName]) {
+////        _coalescingKey++;
+////        _lastEmittedEventName = [eventName copy];
+////    }
+////    RCTScrollEvent *scrollEvent = [[RCTScrollEvent alloc] initWithEventName:eventName
+////                                                                   reactTag:self.reactTag
+////                                                                 scrollView:scrollView
+////                                                                   userData:userData
+////                                                              coalescingKey:_coalescingKey];
+////    [_eventDispatcher sendEvent:scrollEvent];
+//    
+//    
+//  uint16_t coalescingKey = [[self valueForKey:@"_coalescingKey"] unsignedIntegerValue];
+//  
+//  if (![eventName isEqualToString:[self valueForKey:@"_lastEmittedEventName"]]) {
+//    coalescingKey++;
+//    [self setValue:@(coalescingKey) forKey:@"_coalescingKey"];
+//    [self setValue:eventName forKey:@"_lastEmittedEventName"];
+//  }
+//
+//  RCTScrollEvent *scrollEvent = [[RCTScrollEvent alloc] initWithEventName:eventName
+//                                                                 reactTag:self.reactTag
+//                                                               scrollView:scrollView
+//                                                                 userData:userData
+//                                                            coalescingKey:coalescingKey];
+//  [[self valueForKey:@"_eventDispatcher"] sendEvent:scrollEvent];
+//
+//  // TODO: This doesn’t coalesce, which is something that’s done by the event dispatcher
+//  [[NSNotificationCenter defaultCenter] postNotificationName:@"RCTScrollEvent" object:self userInfo:@{ @"event": scrollEvent }];
+//}
+//
+//- (void)_enclosingRCTScrollViewEvent:(NSNotification *)notification;
+//{
+//  // TODO: Currently this receives notifications from any scrollView, it might be more
+//  //       efficient if this could be limited to just the enclosing one, if any, however
+//  //       I was not able to find a great place in RN where the ancestor view hierarchy
+//  //       is guaranteed to exist.
+//  //
+//  RCTScrollView *scrollView = notification.object;
+//  // Only handle events of scrollviews that actually enclose this scrollview.
+//  if (scrollView == self || ![self isDescendantOfView:scrollView]) {
+//    return;
+//  }
+//
+//  // TODO: This is even more of a hack than all the rest of the change!!!
+//  //       The enclosing scroll view *must* have a throttle amount set or
+//  //       it won’t send more scroll move events.
+//  //
+//  if (scrollView.scrollEventThrottle == 0) {
+//    scrollView.scrollEventThrottle = self.scrollEventThrottle;
+//  }
+//  
+//  RCTScrollEvent *scrollEvent = notification.userInfo[@"event"];
+//  
+//  uint16_t coalescingKey = [[self valueForKey:@"_coalescingKey"] unsignedIntegerValue];
+//    
+//  if (![scrollEvent.eventName isEqualToString:[self valueForKey:@"_lastEmittedEventName"]]) {
+//    coalescingKey++;
+//    [self setValue:@(coalescingKey) forKey:@"_coalescingKey"];
+//    [self setValue:scrollEvent.eventName forKey:@"_lastEmittedEventName"];
+//  }
+//
+//  scrollEvent = [scrollEvent scrollEventRelativeToDescendant:self.scrollView
+//                                                    reactTag:self.reactTag
+//                                               coalescingKey:coalescingKey];
+//  [[self valueForKey:@"_eventDispatcher"] sendEvent:scrollEvent];
+//}
 
-  RCTScrollEvent *scrollEvent = [[RCTScrollEvent alloc] initWithEventName:eventName
-                                                                 reactTag:self.reactTag
-                                                               scrollView:scrollView
-                                                                 userData:userData
-                                                            coalescingKey:coalescingKey];
-  [[self valueForKey:@"_eventDispatcher"] sendEvent:scrollEvent];
-
-  // TODO: This doesn’t coalesce, which is something that’s done by the event dispatcher
-  [[NSNotificationCenter defaultCenter] postNotificationName:@"RCTScrollEvent" object:self userInfo:@{ @"event": scrollEvent }];
-}
-
-- (void)_enclosingRCTScrollViewEvent:(NSNotification *)notification;
-{
-  // TODO: Currently this receives notifications from any scrollView, it might be more
-  //       efficient if this could be limited to just the enclosing one, if any, however
-  //       I was not able to find a great place in RN where the ancestor view hierarchy
-  //       is guaranteed to exist.
-  //
-  RCTScrollView *scrollView = notification.object;
-  // Only handle events of scrollviews that actually enclose this scrollview.
-  if (scrollView == self || ![self isDescendantOfView:scrollView]) {
-    return;
-  }
-
-  // TODO: This is even more of a hack than all the rest of the change!!!
-  //       The enclosing scroll view *must* have a throttle amount set or
-  //       it won’t send more scroll move events.
-  //
-  if (scrollView.scrollEventThrottle == 0) {
-    scrollView.scrollEventThrottle = self.scrollEventThrottle;
-  }
-  
-  RCTScrollEvent *scrollEvent = notification.userInfo[@"event"];
-  
-  uint16_t coalescingKey = [[self valueForKey:@"_coalescingKey"] unsignedIntegerValue];
-    
-  if (![scrollEvent.eventName isEqualToString:[self valueForKey:@"_lastEmittedEventName"]]) {
-    coalescingKey++;
-    [self setValue:@(coalescingKey) forKey:@"_coalescingKey"];
-    [self setValue:scrollEvent.eventName forKey:@"_lastEmittedEventName"];
-  }
-
-  scrollEvent = [scrollEvent scrollEventRelativeToDescendant:self.scrollView
-                                                    reactTag:self.reactTag
-                                               coalescingKey:coalescingKey];
-  [[self valueForKey:@"_eventDispatcher"] sendEvent:scrollEvent];
-}
-
-- (void)didMoveToSuperview
-{
-  [super didMoveToSuperview];
-  if (self.superview) {
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(_enclosingRCTScrollViewEvent:)
-                                                 name:@"RCTScrollEvent"
-                                               object:nil];
-  } else {
-    [[NSNotificationCenter defaultCenter] removeObserver:self
-                                                    name:@"RCTScrollEvent"
-                                                  object:nil];
-  }
-}
-
-@end
+//- (void)didMoveToSuperview
+//{
+//  [super didMoveToSuperview];
+//  if (self.superview) {
+//    [[NSNotificationCenter defaultCenter] addObserver:self
+//                                             selector:@selector(_enclosingRCTScrollViewEvent:)
+//                                                 name:@"RCTScrollEvent"
+//                                               object:nil];
+//  } else {
+//    [[NSNotificationCenter defaultCenter] removeObserver:self
+//                                                    name:@"RCTScrollEvent"
+//                                                  object:nil];
+//  }
+//}
+//
+//@end

--- a/package.json
+++ b/package.json
@@ -40,20 +40,28 @@
     "type": "git",
     "url": "git+https://github.com/artsy/emission.git"
   },
-  "keywords": ["artsy", "react", "react-native"],
+  "keywords": [
+    "artsy",
+    "react",
+    "react-native"
+  ],
   "author": "Eloy Durán",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/artsy/emission/issues"
   },
   "homepage": "https://github.com/artsy/emission#readme",
-  "files": ["index.js", "data", "lib"],
+  "files": [
+    "index.js",
+    "data",
+    "lib"
+  ],
   "dependencies": {
     "lodash": "^4.17.4",
     "moment": "latest",
     "prop-types": "^15.5.10",
     "react": "16.0.0-alpha.12",
-    "react-native": "0.48.0-rc.1",
+    "react-native": "0.48.0",
     "react-native-parallax-scroll-view": "https://github.com/orta/react-native-parallax-scroll-view",
     "react-native-reversed-flat-list": "^1.0.1",
     "react-native-sentry": "^0.14.5",
@@ -100,14 +108,23 @@
   },
   "jest": {
     "preset": "react-native",
-    "moduleFileExtensions": ["ts", "tsx", "js"],
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js"
+    ],
     "transform": {
       "^.+\\.js$": "<rootDir>/node_modules/babel-jest",
       ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
     },
     "testRegex": "/__tests__/.*-tests.(ts|tsx|js)$",
-    "testPathIgnorePatterns": ["\\.snap$", "<rootDir>/node_modules/"],
-    "setupFiles": ["./src/setupJest.ts"],
+    "testPathIgnorePatterns": [
+      "\\.snap$",
+      "<rootDir>/node_modules/"
+    ],
+    "setupFiles": [
+      "./src/setupJest.ts"
+    ],
     "cacheDirectory": ".jest/cache"
   },
   "graphql": {
@@ -115,11 +132,17 @@
     "tsInterfaceName": "RelayProps"
   },
   "lint-staged": {
-    "*.@(ts|tsx)": ["tslint --fix", "npm run prettier-write --", "git add"]
+    "*.@(ts|tsx)": [
+      "tslint --fix",
+      "npm run prettier-write --",
+      "git add"
+    ]
   },
   "config": {
     "react-native-storybook-loader": {
-      "searchDir": ["./src"],
+      "searchDir": [
+        "./src"
+      ],
       "pattern": "**/*.story.tsx",
       "outputFile": "./storybook/storyLoader.js"
     }

--- a/package.json
+++ b/package.json
@@ -40,28 +40,20 @@
     "type": "git",
     "url": "git+https://github.com/artsy/emission.git"
   },
-  "keywords": [
-    "artsy",
-    "react",
-    "react-native"
-  ],
+  "keywords": ["artsy", "react", "react-native"],
   "author": "Eloy Durán",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/artsy/emission/issues"
   },
   "homepage": "https://github.com/artsy/emission#readme",
-  "files": [
-    "index.js",
-    "data",
-    "lib"
-  ],
+  "files": ["index.js", "data", "lib"],
   "dependencies": {
     "lodash": "^4.17.4",
     "moment": "latest",
     "prop-types": "^15.5.10",
     "react": "16.0.0-alpha.12",
-    "react-native": "next",
+    "react-native": "0.48.0-rc.1",
     "react-native-parallax-scroll-view": "https://github.com/orta/react-native-parallax-scroll-view",
     "react-native-reversed-flat-list": "^1.0.1",
     "react-native-sentry": "^0.14.5",
@@ -108,23 +100,14 @@
   },
   "jest": {
     "preset": "react-native",
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js"
-    ],
+    "moduleFileExtensions": ["ts", "tsx", "js"],
     "transform": {
       "^.+\\.js$": "<rootDir>/node_modules/babel-jest",
       ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
     },
     "testRegex": "/__tests__/.*-tests.(ts|tsx|js)$",
-    "testPathIgnorePatterns": [
-      "\\.snap$",
-      "<rootDir>/node_modules/"
-    ],
-    "setupFiles": [
-      "./src/setupJest.ts"
-    ],
+    "testPathIgnorePatterns": ["\\.snap$", "<rootDir>/node_modules/"],
+    "setupFiles": ["./src/setupJest.ts"],
     "cacheDirectory": ".jest/cache"
   },
   "graphql": {
@@ -132,17 +115,11 @@
     "tsInterfaceName": "RelayProps"
   },
   "lint-staged": {
-    "*.@(ts|tsx)": [
-      "tslint --fix",
-      "npm run prettier-write --",
-      "git add"
-    ]
+    "*.@(ts|tsx)": ["tslint --fix", "npm run prettier-write --", "git add"]
   },
   "config": {
     "react-native-storybook-loader": {
-      "searchDir": [
-        "./src"
-      ],
+      "searchDir": ["./src"],
       "pattern": "**/*.story.tsx",
       "outputFile": "./storybook/storyLoader.js"
     }

--- a/rn-cli.config.js
+++ b/rn-cli.config.js
@@ -1,10 +1,8 @@
-var blacklist = require("react-native/packager/blacklist")
+const blacklist = require("metro-bundler/src/blacklist")
 
 var config = {
   getBlacklistRE(platform) {
-    return blacklist(platform, [
-      /coverage\/.*/
-    ])
+    return blacklist(platform, [/coverage\/.*/])
   },
 
   getSourceExts() {

--- a/transformer/index.js
+++ b/transformer/index.js
@@ -8,7 +8,7 @@ const { File } = require("babel-core/lib/transformation/file")
 const { SourceMapConsumer } = require("source-map")
 
 const upstream = require("./upstream")
-const { compactMapping } = require("react-native/packager/src/Bundler/source-map")
+const { compactMapping } = require("metro-bundler/src/Bundler/source-map")
 
 /**
  * This is a copy of upstream.transform, but modified to:
@@ -21,7 +21,7 @@ function transformTypeScript(src, filename, options) {
   options = options || {};
 
   const OLD_BABEL_ENV = process.env.BABEL_ENV;
-  process.env.BABEL_ENV = options.dev ? 'development' : 'production';
+  process.env.BABEL_ENV = options.dev ? "development" : "production";
 
   try {
     const compilerOptions = buildTSCompilerOptionsConfig()
@@ -30,13 +30,17 @@ function transformTypeScript(src, filename, options) {
     const babelConfig = buildBabelConfig(filename, options);
     const transformResult = babel.transform(tsResult.outputText, babelConfig);
 
-    const generateResult = generate(transformResult.ast, {
-      comments: false,
-      compact: false,
-      filename,
-      sourceFileName: filename,
-      sourceMaps: true,
-    }, src);
+    const generateResult = generate(
+      transformResult.ast,
+      {
+        comments: false,
+        compact: false,
+        filename,
+        sourceFileName: filename,
+        sourceMaps: true,
+      },
+      src
+    );
 
     // Translate generated source-map back to transformed JS source-map, which maps back to original TS code.
     generateResult.map = mergeSourceMaps(transformResult.map, generateResult.map)
@@ -103,17 +107,17 @@ function extractRawMappings(sourceMap) {
   return rawMappings
 }
 
-function transform(sourceCode, fileName, options) {
-    try {
-      let src = sourceCode
-      if (path.extname(fileName) == ".tsx" || path.extname(fileName) == ".ts") {
-        src = transformTypeScript(src, fileName, options)
-      } else {
-        src = upstream.transform(src, fileName, options)
-      }
-      return src
-    } catch(e) {
-      console.error(e)
+function transform({ filename, localPath, options, src }) {
+  try {
+    let sourceCode = src
+    if (filename && (path.extname(filename) == ".tsx" || path.extname(filename) == ".ts")) {
+      sourceCode = transformTypeScript(sourceCode, filename, options)
+    } else {
+      sourceCode = upstream.transform(sourceCode, filename, options)
     }
+    return sourceCode
+  } catch (e) {
+    console.error(e)
+  }
 }
 module.exports.transform = transform;

--- a/yarn.lock
+++ b/yarn.lock
@@ -152,7 +152,7 @@ JSONStream@^0.8.4:
     jsonparse "0.0.5"
     through ">=2.2.7 <3"
 
-abab@^1.0.0, abab@^1.0.3:
+abab@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.3.tgz#b81de5f7274ec4e756d797cd834f303642724e5d"
 
@@ -184,21 +184,11 @@ acorn-dynamic-import@^2.0.0:
   dependencies:
     acorn "^4.0.3"
 
-acorn-globals@^1.0.4:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-1.0.9.tgz#55bb5e98691507b74579d0513413217c380c54cf"
-  dependencies:
-    acorn "^2.1.0"
-
 acorn-globals@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-3.1.0.tgz#fd8270f71fbb4996b004fa880ee5d46573a731bf"
   dependencies:
     acorn "^4.0.4"
-
-acorn@^2.1.0, acorn@^2.4.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-2.7.0.tgz#ab6e7d9d886aaca8b085bc3312b79a198433f0e7"
 
 acorn@^4.0.3, acorn@^4.0.4:
   version "4.0.11"
@@ -259,6 +249,10 @@ ansi-escapes@^1.0.0, ansi-escapes@^1.1.0, ansi-escapes@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
 
+ansi-escapes@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-2.0.0.tgz#5bae52be424878dd9783e8910e3fc2922e83c81b"
+
 ansi-html@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz#813584021962a9e9e6fd039f940d12f56ca7859e"
@@ -270,6 +264,10 @@ ansi-regex@^0.2.0, ansi-regex@^0.2.1:
 ansi-regex@^2.0.0, ansi-regex@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
+
+ansi-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
 
 ansi-styles@^1.1.0:
   version "1.1.0"
@@ -498,7 +496,7 @@ aws4@^1.2.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
-babel-code-frame@^6.11.0, babel-code-frame@^6.22.0, babel-code-frame@^6.8.0:
+babel-code-frame@^6.11.0, babel-code-frame@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
   dependencies:
@@ -552,17 +550,6 @@ babel-core@^6.24.1:
     path-is-absolute "^1.0.0"
     private "^0.1.6"
     slash "^1.0.0"
-    source-map "^0.5.0"
-
-babel-generator@6.11.4:
-  version "6.11.4"
-  resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.11.4.tgz#14f6933abb20c62666d27e3b7b9f5b9dc0712a9a"
-  dependencies:
-    babel-messages "^6.8.0"
-    babel-runtime "^6.9.0"
-    babel-types "^6.10.2"
-    detect-indent "^3.0.1"
-    lodash "^4.2.0"
     source-map "^0.5.0"
 
 babel-generator@^6.18.0, babel-generator@^6.25.0:
@@ -759,7 +746,7 @@ babel-loader@^7.0.0:
     loader-utils "^1.0.2"
     mkdirp "^0.5.1"
 
-babel-messages@^6.23.0, babel-messages@^6.8.0:
+babel-messages@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
   dependencies:
@@ -896,7 +883,7 @@ babel-plugin-transform-class-constructor-call@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-plugin-transform-class-properties@^6.24.1, babel-plugin-transform-class-properties@^6.5.0, babel-plugin-transform-class-properties@^6.6.0, babel-plugin-transform-class-properties@^6.8.0:
+babel-plugin-transform-class-properties@^6.18.0, babel-plugin-transform-class-properties@^6.24.1, babel-plugin-transform-class-properties@^6.5.0, babel-plugin-transform-class-properties@^6.6.0, babel-plugin-transform-class-properties@^6.8.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz#6a79763ea61d33d36f37b611aa9def81a81b46ac"
   dependencies:
@@ -1334,9 +1321,9 @@ babel-preset-fbjs@^1.0.0:
     babel-plugin-transform-object-rest-spread "^6.6.5"
     object-assign "^4.0.1"
 
-babel-preset-fbjs@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/babel-preset-fbjs/-/babel-preset-fbjs-2.1.2.tgz#f52b2df56b1da883ffb7798b3b3be42c4c647a77"
+babel-preset-fbjs@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/babel-preset-fbjs/-/babel-preset-fbjs-2.1.4.tgz#22f358e6654073acf61e47a052a777d7bccf03af"
   dependencies:
     babel-plugin-check-es2015-constants "^6.8.0"
     babel-plugin-syntax-class-properties "^6.8.0"
@@ -1388,6 +1375,40 @@ babel-preset-jest@^20.0.3:
 babel-preset-react-native@^1.9.1:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/babel-preset-react-native/-/babel-preset-react-native-1.9.2.tgz#b22addd2e355ff3b39671b79be807e52dfa145f2"
+  dependencies:
+    babel-plugin-check-es2015-constants "^6.5.0"
+    babel-plugin-react-transform "2.0.2"
+    babel-plugin-syntax-async-functions "^6.5.0"
+    babel-plugin-syntax-class-properties "^6.5.0"
+    babel-plugin-syntax-flow "^6.5.0"
+    babel-plugin-syntax-jsx "^6.5.0"
+    babel-plugin-syntax-trailing-function-commas "^6.5.0"
+    babel-plugin-transform-class-properties "^6.5.0"
+    babel-plugin-transform-es2015-arrow-functions "^6.5.0"
+    babel-plugin-transform-es2015-block-scoping "^6.5.0"
+    babel-plugin-transform-es2015-classes "^6.5.0"
+    babel-plugin-transform-es2015-computed-properties "^6.5.0"
+    babel-plugin-transform-es2015-destructuring "^6.5.0"
+    babel-plugin-transform-es2015-for-of "^6.5.0"
+    babel-plugin-transform-es2015-function-name "^6.5.0"
+    babel-plugin-transform-es2015-literals "^6.5.0"
+    babel-plugin-transform-es2015-modules-commonjs "^6.5.0"
+    babel-plugin-transform-es2015-parameters "^6.5.0"
+    babel-plugin-transform-es2015-shorthand-properties "^6.5.0"
+    babel-plugin-transform-es2015-spread "^6.5.0"
+    babel-plugin-transform-es2015-template-literals "^6.5.0"
+    babel-plugin-transform-flow-strip-types "^6.5.0"
+    babel-plugin-transform-object-assign "^6.5.0"
+    babel-plugin-transform-object-rest-spread "^6.5.0"
+    babel-plugin-transform-react-display-name "^6.5.0"
+    babel-plugin-transform-react-jsx "^6.5.0"
+    babel-plugin-transform-react-jsx-source "^6.5.0"
+    babel-plugin-transform-regenerator "^6.5.0"
+    react-transform-hmr "^1.0.4"
+
+babel-preset-react-native@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-react-native/-/babel-preset-react-native-2.1.0.tgz#9013ebd82da1c88102bf588810ff59e209ca2b8a"
   dependencies:
     babel-plugin-check-es2015-constants "^6.5.0"
     babel-plugin-react-transform "2.0.2"
@@ -1483,7 +1504,7 @@ babel-register@^6.24.1:
   dependencies:
     graphql "^0.6.0"
 
-babel-runtime@6.x.x, babel-runtime@^6.0.0, babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.5.0, babel-runtime@^6.6.1, babel-runtime@^6.9.0:
+babel-runtime@6.x.x, babel-runtime@^6.0.0, babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.5.0, babel-runtime@^6.6.1:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
   dependencies:
@@ -1508,20 +1529,6 @@ babel-template@^6.24.1:
     babel-traverse "^6.24.1"
     babel-types "^6.24.1"
     babylon "^6.11.0"
-    lodash "^4.2.0"
-
-babel-traverse@6.12.0:
-  version "6.12.0"
-  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.12.0.tgz#f22f54fa0d6eeb7f63585246bab6e637858f5d94"
-  dependencies:
-    babel-code-frame "^6.8.0"
-    babel-messages "^6.8.0"
-    babel-runtime "^6.9.0"
-    babel-types "^6.9.0"
-    babylon "^6.7.0"
-    debug "^2.2.0"
-    globals "^8.3.0"
-    invariant "^2.2.0"
     lodash "^4.2.0"
 
 babel-traverse@^6.16.0, babel-traverse@^6.24.1:
@@ -1552,7 +1559,7 @@ babel-traverse@^6.18.0, babel-traverse@^6.22.0, babel-traverse@^6.23.0, babel-tr
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-babel-types@^6.10.2, babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.22.0, babel-types@^6.23.0, babel-types@^6.25.0, babel-types@^6.9.0:
+babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.22.0, babel-types@^6.23.0, babel-types@^6.25.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.25.0.tgz#70afb248d5660e5d18f811d91c8303b54134a18e"
   dependencies:
@@ -1570,15 +1577,11 @@ babel-types@^6.24.1:
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babylon@6.14.1:
-  version "6.14.1"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.14.1.tgz#956275fab72753ad9b3435d7afe58f8bf0a29815"
-
 babylon@^6.11.0, babylon@^6.12.0, babylon@^6.15.0, babylon@^6.17.0:
   version "6.17.1"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.1.tgz#17f14fddf361b695981fe679385e4f1c01ebd86f"
 
-babylon@^6.13.0, babylon@^6.17.2, babylon@^6.7.0:
+babylon@^6.13.0, babylon@^6.17.2:
   version "6.17.4"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.4.tgz#3e8b7402b88d22c3423e137a1577883b15ff869a"
 
@@ -1668,10 +1671,6 @@ body-parser@~1.13.3:
     qs "4.0.0"
     raw-body "~2.1.2"
     type-is "~1.6.6"
-
-boolbase@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
 
 boom@2.x.x:
   version "2.10.1"
@@ -1942,39 +1941,6 @@ chalk@^2.0.1:
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
-cheerio@0.20.0:
-  version "0.20.0"
-  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-0.20.0.tgz#5c710f2bab95653272842ba01c6ea61b3545ec35"
-  dependencies:
-    css-select "~1.2.0"
-    dom-serializer "~0.1.0"
-    entities "~1.1.1"
-    htmlparser2 "~3.8.1"
-    lodash "^4.1.0"
-  optionalDependencies:
-    jsdom "^7.0.2"
-
-cheerio@0.22.0:
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-0.22.0.tgz#a9baa860a3f9b595a6b81b1a86873121ed3a269e"
-  dependencies:
-    css-select "~1.2.0"
-    dom-serializer "~0.1.0"
-    entities "~1.1.1"
-    htmlparser2 "^3.9.1"
-    lodash.assignin "^4.0.9"
-    lodash.bind "^4.1.4"
-    lodash.defaults "^4.0.1"
-    lodash.filter "^4.4.0"
-    lodash.flatten "^4.2.0"
-    lodash.foreach "^4.3.0"
-    lodash.map "^4.4.0"
-    lodash.merge "^4.4.0"
-    lodash.pick "^4.2.1"
-    lodash.reduce "^4.4.0"
-    lodash.reject "^4.4.0"
-    lodash.some "^4.4.0"
-
 chokidar@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
@@ -2014,7 +1980,7 @@ classnames@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
 
-cli-cursor@^1.0.1, cli-cursor@^1.0.2:
+cli-cursor@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
   dependencies:
@@ -2095,10 +2061,6 @@ color-convert@^1.0.0, color-convert@^1.3.0:
 color-diff@^0.1.3:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/color-diff/-/color-diff-0.1.7.tgz#6db78cd9482a8e459d40821eaf4b503283dcb8e2"
-
-color-logger@0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/color-logger/-/color-logger-0.0.3.tgz#d9b22dd1d973e166b18bf313f9f481bba4df2018"
 
 color-name@^1.0.0, color-name@^1.1.1:
   version "1.1.2"
@@ -2487,15 +2449,6 @@ css-rule-stream@^1.1.0:
     ldjson-stream "^1.2.1"
     through2 "^0.6.3"
 
-css-select@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
-  dependencies:
-    boolbase "~1.0.0"
-    css-what "2.1"
-    domutils "1.5.1"
-    nth-check "~1.0.1"
-
 css-selector-tokenizer@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz#e6988474ae8c953477bf5e7efecfceccd9cf4c86"
@@ -2518,10 +2471,6 @@ css-tokenize@^1.0.1:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^1.0.33"
-
-css-what@2.1:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
 
 cssesc@^0.1.0:
   version "0.1.0"
@@ -2571,11 +2520,11 @@ csso@~2.3.1:
     clap "^1.0.9"
     source-map "^0.5.3"
 
-cssom@0.3.x, "cssom@>= 0.3.0 < 0.4.0", "cssom@>= 0.3.2 < 0.4.0":
+cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.2.tgz#b8036170c79f07a90ff2f16e22284027a243848b"
 
-"cssstyle@>= 0.2.29 < 0.3.0", "cssstyle@>= 0.2.37 < 0.3.0":
+"cssstyle@>= 0.2.37 < 0.3.0":
   version "0.2.37"
   resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-0.2.37.tgz#541097234cb2513c83ceed3acddc27ff27987d54"
   dependencies:
@@ -2601,17 +2550,6 @@ d@1:
   resolved "https://registry.yarnpkg.com/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
   dependencies:
     es5-ext "^0.10.9"
-
-danger-plugin-yarn@^0.2.10:
-  version "0.2.10"
-  resolved "https://registry.yarnpkg.com/danger-plugin-yarn/-/danger-plugin-yarn-0.2.10.tgz#4bd2b7860cd970b786b31df7c8e7ed396695e010"
-  dependencies:
-    date-fns "^1.28.5"
-    lodash.flatten "^4.4.0"
-    lodash.includes "^4.3.0"
-    node-fetch "^1.7.1"
-  optionalDependencies:
-    esdoc "^0.5.2"
 
 danger@^1.2.0:
   version "1.2.0"
@@ -2643,7 +2581,7 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-date-fns@^1.27.2, date-fns@^1.28.5:
+date-fns@^1.27.2:
   version "1.28.5"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.28.5.tgz#257cfc45d322df45ef5658665967ee841cd73faf"
 
@@ -2745,14 +2683,6 @@ destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
 
-detect-indent@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-3.0.1.tgz#9dc5e5ddbceef8325764b9451b02bc6d54084f75"
-  dependencies:
-    get-stdin "^4.0.1"
-    minimist "^1.1.0"
-    repeating "^1.1.0"
-
 detect-indent@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
@@ -2792,13 +2722,6 @@ dom-helpers@^3.2.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.2.1.tgz#3203e07fed217bd1f424b019735582fc37b2825a"
 
-dom-serializer@0, dom-serializer@~0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
-  dependencies:
-    domelementtype "~1.1.1"
-    entities "~1.1.1"
-
 dom-walk@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
@@ -2806,33 +2729,6 @@ dom-walk@^0.1.0:
 domain-browser@^1.1.1:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.1.7.tgz#867aa4b093faa05f1de08c06f4d7b21fdf8698bc"
-
-domelementtype@1, domelementtype@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.0.tgz#b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
-
-domelementtype@~1.1.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.1.3.tgz#bd28773e2642881aec51544924299c5cd822185b"
-
-domhandler@2.3:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.3.0.tgz#2de59a0822d5027fabff6f032c2b25a2a8abe738"
-  dependencies:
-    domelementtype "1"
-
-domhandler@^2.3.0:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.1.tgz#892e47000a99be55bbf3774ffea0561d8879c259"
-  dependencies:
-    domelementtype "1"
-
-domutils@1.5, domutils@1.5.1, domutils@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
-  dependencies:
-    dom-serializer "0"
-    domelementtype "1"
 
 dot@^1.1.1:
   version "1.1.2"
@@ -2918,13 +2814,13 @@ enhanced-resolve@^3.4.0:
     object-assign "^4.0.1"
     tapable "^0.2.7"
 
-entities@1.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-1.0.0.tgz#b2987aa3821347fcde642b24fdfc9e4fb712bf26"
-
-entities@^1.1.1, entities@~1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
+envinfo@^3.0.0:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-3.4.1.tgz#8c80e9f2eec2cd4e2adb2c5d0127ce07a2aaa2ae"
+  dependencies:
+    minimist "^1.2.0"
+    os-name "^2.0.1"
+    which "^1.2.14"
 
 "errno@>=0.1.1 <0.2.0-0", errno@^0.1.3:
   version "0.1.4"
@@ -3001,7 +2897,7 @@ escape-html@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.2.tgz#d77d32fa98e38c2f41ae85e9278e0e0e6ba1022c"
 
-escape-html@1.0.3, escape-html@~1.0.3:
+escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
 
@@ -3032,22 +2928,6 @@ escope@^3.6.0:
     es6-weak-map "^2.0.1"
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
-
-esdoc@^0.5.2:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/esdoc/-/esdoc-0.5.2.tgz#cbfd0b20e3d1cacc23c93c328eed987e21ba0067"
-  dependencies:
-    babel-generator "6.11.4"
-    babel-traverse "6.12.0"
-    babylon "6.14.1"
-    cheerio "0.22.0"
-    color-logger "0.0.3"
-    escape-html "1.0.3"
-    fs-extra "1.0.0"
-    ice-cap "0.0.4"
-    marked "0.3.6"
-    minimist "1.2.0"
-    taffydb "2.7.2"
 
 esprima@^2.6.0, esprima@^2.7.1:
   version "2.7.3"
@@ -3222,6 +3102,14 @@ external-editor@^2.0.1:
   dependencies:
     tmp "^0.0.31"
 
+external-editor@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.0.4.tgz#1ed9199da9cbfe2ef2f7a31b2fde8b0d12368972"
+  dependencies:
+    iconv-lite "^0.4.17"
+    jschardet "^1.4.2"
+    tmp "^0.0.31"
+
 extglob@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
@@ -3288,7 +3176,7 @@ fbjs@0.8.12, fbjs@^0.8.1, fbjs@^0.8.5, fbjs@^0.8.9:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
-figures@^1.3.5, figures@^1.7.0:
+figures@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
   dependencies:
@@ -3446,7 +3334,7 @@ fresh@0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.0.tgz#f474ca5e6a9246d6fd8e0953cfa9b9c805afa78e"
 
-fs-extra@1.0.0, fs-extra@^1.0.0:
+fs-extra@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-1.0.0.tgz#cd3ce5f7e7cb6145883fcae3191e9877f8587950"
   dependencies:
@@ -3472,6 +3360,13 @@ fsevents@^1.0.0:
   dependencies:
     nan "^2.3.0"
     node-pre-gyp "^0.6.29"
+
+fsevents@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.1.2.tgz#3282b713fb3ad80ede0e9fcf4611b5aa6fc033f4"
+  dependencies:
+    nan "^2.3.0"
+    node-pre-gyp "^0.6.36"
 
 fstream-ignore@^1.0.5:
   version "1.0.5"
@@ -3604,10 +3499,6 @@ global@^4.3.0, global@^4.3.2:
   dependencies:
     min-document "^2.19.0"
     process "~0.5.1"
-
-globals@^8.3.0:
-  version "8.18.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-8.18.0.tgz#93d4a62bdcac38cfafafc47d6b034768cb0ffcb4"
 
 globals@^9.0.0:
   version "9.16.0"
@@ -3828,27 +3719,6 @@ html-tags@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-2.0.0.tgz#10b30a386085f43cede353cc8fa7cb0deeea668b"
 
-htmlparser2@^3.9.1:
-  version "3.9.2"
-  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
-  dependencies:
-    domelementtype "^1.3.0"
-    domhandler "^2.3.0"
-    domutils "^1.5.1"
-    entities "^1.1.1"
-    inherits "^2.0.1"
-    readable-stream "^2.0.2"
-
-htmlparser2@~3.8.1:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.8.3.tgz#996c28b191516a8be86501a7d79757e5c70c1068"
-  dependencies:
-    domelementtype "1"
-    domhandler "2.3"
-    domutils "1.5"
-    entities "1.0"
-    readable-stream "1.1"
-
 http-errors@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.3.1.tgz#197e22cdebd4198585e8694ef6786197b91ed942"
@@ -3889,13 +3759,6 @@ hyphenate-style-name@^1.0.1, hyphenate-style-name@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
 
-ice-cap@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/ice-cap/-/ice-cap-0.0.4.tgz#8a6d31ab4cac8d4b56de4fa946df3352561b6e18"
-  dependencies:
-    cheerio "0.20.0"
-    color-logger "0.0.3"
-
 iconv-lite@0.4.11:
   version "0.4.11"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.11.tgz#2ecb42fd294744922209a2e7c404dac8793d8ade"
@@ -3903,6 +3766,10 @@ iconv-lite@0.4.11:
 iconv-lite@0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
+
+iconv-lite@^0.4.17:
+  version "0.4.18"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.18.tgz#23d8656b16aae6742ac29732ea8f0336a4789cf2"
 
 iconv-lite@~0.4.13:
   version "0.4.15"
@@ -3926,9 +3793,9 @@ ignore@^3.2.0:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.3.tgz#432352e57accd87ab3110e82d3fea0e47812156d"
 
-image-size@^0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.3.5.tgz#83240eab2fb5b00b04aab8c74b0471e9cba7ad8c"
+image-size@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.6.1.tgz#98122a562d59dcc097ef1b2c8191866eb8f5d663"
 
 immutable@^3.8.1:
   version "3.8.1"
@@ -4007,22 +3874,23 @@ inquirer@3.0.6:
     strip-ansi "^3.0.0"
     through "^2.3.6"
 
-inquirer@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-0.12.0.tgz#1ef2bfd63504df0bc75785fff8c2c41df12f077e"
+inquirer@^3.0.6:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.2.2.tgz#c2aaede1507cc54d826818737742d621bef2e823"
   dependencies:
-    ansi-escapes "^1.1.0"
-    ansi-regex "^2.0.0"
-    chalk "^1.0.0"
-    cli-cursor "^1.0.1"
+    ansi-escapes "^2.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
     cli-width "^2.0.0"
-    figures "^1.3.5"
+    external-editor "^2.0.4"
+    figures "^2.0.0"
     lodash "^4.3.0"
-    readline2 "^1.0.1"
-    run-async "^0.1.0"
-    rx-lite "^3.1.2"
-    string-width "^1.0.1"
-    strip-ansi "^3.0.0"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rx-lite "^4.0.8"
+    rx-lite-aggregates "^4.0.8"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
     through "^2.3.6"
 
 interpret@^1.0.0:
@@ -4206,10 +4074,6 @@ isarray@0.0.1:
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
-
-isemail@1.x.x:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/isemail/-/isemail-1.2.0.tgz#be03df8cc3e29de4d2c5df6501263f1fa4595e9a"
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -4406,9 +4270,21 @@ jest-diff@^20.0.3:
     jest-matcher-utils "^20.0.3"
     pretty-format "^20.0.3"
 
+jest-docblock@20.1.0-chi.1:
+  version "20.1.0-chi.1"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-20.1.0-chi.1.tgz#06981ab0e59498a2492333b0c5502a82e4603207"
+
+jest-docblock@20.1.0-delta.4:
+  version "20.1.0-delta.4"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-20.1.0-delta.4.tgz#360d4f5fb702730c4136c4e71e5706188a694682"
+
 jest-docblock@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-20.0.3.tgz#17bea984342cc33d83c50fbe1545ea0efaa44712"
+
+jest-docblock@^20.1.0-chi.1:
+  version "20.1.0-echo.1"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-20.1.0-echo.1.tgz#be02f43ee019f97e6b83267c746ac7b40d290fe8"
 
 jest-environment-jsdom@^20.0.3:
   version "20.0.3"
@@ -4424,6 +4300,28 @@ jest-environment-node@^20.0.0, jest-environment-node@^20.0.3:
   dependencies:
     jest-mock "^20.0.3"
     jest-util "^20.0.3"
+
+jest-haste-map@20.1.0-chi.1:
+  version "20.1.0-chi.1"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-20.1.0-chi.1.tgz#db5f5f31362c76e242b40ea9a3ccfa364719cee3"
+  dependencies:
+    fb-watchman "^2.0.0"
+    graceful-fs "^4.1.11"
+    jest-docblock "^20.1.0-chi.1"
+    micromatch "^2.3.11"
+    sane "^2.0.0"
+    worker-farm "^1.3.1"
+
+jest-haste-map@20.1.0-delta.4:
+  version "20.1.0-delta.4"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-20.1.0-delta.4.tgz#12e32b297a6dd49705cacde938029fc158834006"
+  dependencies:
+    fb-watchman "^2.0.0"
+    graceful-fs "^4.1.11"
+    jest-docblock "20.1.0-delta.4"
+    micromatch "^2.3.11"
+    sane "^2.0.0"
+    worker-farm "^1.3.1"
 
 jest-haste-map@^20.0.4:
   version "20.0.4"
@@ -4579,15 +4477,6 @@ jodid25519@^1.0.0:
   dependencies:
     jsbn "~0.1.0"
 
-joi@^6.6.1:
-  version "6.10.1"
-  resolved "https://registry.yarnpkg.com/joi/-/joi-6.10.1.tgz#4d50c318079122000fe5f16af1ff8e1917b77e06"
-  dependencies:
-    hoek "2.x.x"
-    isemail "1.x.x"
-    moment "2.x.x"
-    topo "1.x.x"
-
 js-base64@^2.1.9:
   version "2.1.9"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.1.9.tgz#f0e80ae039a4bd654b5f281fc93f04a914a7fcce"
@@ -4614,25 +4503,9 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
 
-jsdom@^7.0.2:
-  version "7.2.2"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-7.2.2.tgz#40b402770c2bda23469096bee91ab675e3b1fc6e"
-  dependencies:
-    abab "^1.0.0"
-    acorn "^2.4.0"
-    acorn-globals "^1.0.4"
-    cssom ">= 0.3.0 < 0.4.0"
-    cssstyle ">= 0.2.29 < 0.3.0"
-    escodegen "^1.6.1"
-    nwmatcher ">= 1.3.7 < 2.0.0"
-    parse5 "^1.5.1"
-    request "^2.55.0"
-    sax "^1.1.4"
-    symbol-tree ">= 3.1.0 < 4.0.0"
-    tough-cookie "^2.2.0"
-    webidl-conversions "^2.0.0"
-    whatwg-url-compat "~0.6.5"
-    xml-name-validator ">= 2.0.1 < 3.0.0"
+jschardet@^1.4.2:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/jschardet/-/jschardet-1.5.1.tgz#c519f629f86b3a5bedba58a88d311309eec097f9"
 
 jsdom@^9.12.0:
   version "9.12.0"
@@ -4943,21 +4816,9 @@ lodash.assign@^4.0.3, lodash.assign@^4.0.6, lodash.assign@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
 
-lodash.assignin@^4.0.9:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.assignin/-/lodash.assignin-4.2.0.tgz#ba8df5fb841eb0a3e8044232b0e263a8dc6a28a2"
-
-lodash.bind@^4.1.4:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/lodash.bind/-/lodash.bind-4.2.1.tgz#7ae3017e939622ac31b7d7d7dcb1b34db1690d35"
-
 lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
-
-lodash.defaults@^4.0.1:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
 
 lodash.escape@^3.0.0:
   version "3.2.0"
@@ -4965,21 +4826,9 @@ lodash.escape@^3.0.0:
   dependencies:
     lodash._root "^3.0.0"
 
-lodash.filter@^4.4.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.filter/-/lodash.filter-4.6.0.tgz#668b1d4981603ae1cc5a6fa760143e480b4c4ace"
-
 lodash.find@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.find/-/lodash.find-4.6.0.tgz#cb0704d47ab71789ffa0de8b97dd926fb88b13b1"
-
-lodash.flatten@^4.2.0, lodash.flatten@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
-
-lodash.foreach@^4.3.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
 
 lodash.includes@^4.3.0:
   version "4.3.0"
@@ -5011,17 +4860,9 @@ lodash.keys@^4.0.8:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-4.2.0.tgz#a08602ac12e4fb83f91fc1fb7a360a4d9ba35205"
 
-lodash.map@^4.4.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
-
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
-
-lodash.merge@^4.4.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
 
 lodash.pad@^4.1.0:
   version "4.5.1"
@@ -5035,25 +4876,13 @@ lodash.padstart@^4.1.0:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.padstart/-/lodash.padstart-4.6.1.tgz#d2e3eebff0d9d39ad50f5cbd1b52a7bce6bb611b"
 
-lodash.pick@^4.2.1, lodash.pick@^4.4.0:
+lodash.pick@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
-
-lodash.reduce@^4.4.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.reduce/-/lodash.reduce-4.6.0.tgz#f1ab6b839299ad48f784abbf476596f03b914d3b"
-
-lodash.reject@^4.4.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.reject/-/lodash.reject-4.6.0.tgz#80d6492dc1470864bbf583533b651f42a9f52415"
 
 lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-
-lodash.some@^4.4.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.some/-/lodash.some-4.6.0.tgz#1bb9f314ef6b8baded13b549169b2a945eb68e4d"
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
@@ -5141,6 +4970,10 @@ macaddress@^0.2.8:
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/macaddress/-/macaddress-0.2.8.tgz#5904dc537c39ec6dbefeae902327135fa8511f12"
 
+macos-release@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-1.1.0.tgz#831945e29365b470aa8724b0ab36c8f8959d10fb"
+
 make-dir@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.0.0.tgz#97a011751e91dd87cfadef58832ebb04936de978"
@@ -5164,10 +4997,6 @@ mantra-core@^1.7.0:
 map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
-
-marked@0.3.6:
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.6.tgz#b2c6c618fccece4ef86c4fc6cb8a7cbf5aeda8d7"
 
 math-expression-evaluator@^1.2.14:
   version "1.2.17"
@@ -5235,6 +5064,46 @@ method-override@~2.3.5:
 methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
+
+metro-bundler@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/metro-bundler/-/metro-bundler-0.11.0.tgz#ba5d2ae34943da28a37c2098047ad265c16fddf4"
+  dependencies:
+    absolute-path "^0.0.0"
+    async "^2.4.0"
+    babel-core "^6.24.1"
+    babel-generator "^6.24.1"
+    babel-plugin-external-helpers "^6.18.0"
+    babel-preset-es2015-node "^6.1.1"
+    babel-preset-fbjs "^2.1.4"
+    babel-preset-react-native "^2.0.0"
+    babel-register "^6.24.1"
+    babylon "^6.17.0"
+    chalk "^1.1.1"
+    concat-stream "^1.6.0"
+    core-js "^2.2.2"
+    debug "^2.2.0"
+    denodeify "^1.2.1"
+    fbjs "0.8.12"
+    graceful-fs "^4.1.3"
+    image-size "^0.6.0"
+    jest-docblock "20.1.0-chi.1"
+    jest-haste-map "20.1.0-chi.1"
+    json-stable-stringify "^1.0.1"
+    json5 "^0.4.0"
+    left-pad "^1.1.3"
+    lodash "^4.16.6"
+    merge-stream "^1.0.1"
+    mime-types "2.1.11"
+    mkdirp "^0.5.1"
+    request "^2.79.0"
+    rimraf "^2.5.4"
+    source-map "^0.5.6"
+    temp "0.8.3"
+    throat "^4.1.0"
+    uglify-js "2.7.5"
+    write-file-atomic "^1.2.0"
+    xpipe "^1.0.5"
 
 micromatch@^2.1.5, micromatch@^2.3.11:
   version "2.3.11"
@@ -5319,13 +5188,13 @@ minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@1.2.0, minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-
 minimist@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.1.0.tgz#99df657a52574c21c9057497df742790b2b4c0de"
+
+minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
 "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
@@ -5337,7 +5206,7 @@ mobx@^2.3.4:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/mobx/-/mobx-2.7.0.tgz#cf3d82d18c0ca7f458d8f2a240817b3dc7e54a01"
 
-moment@2.x.x, moment@^2.11.2, moment@latest:
+moment@^2.11.2, moment@latest:
   version "2.18.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
 
@@ -5385,10 +5254,6 @@ multipipe@^0.1.2:
   dependencies:
     duplexer2 "0.0.2"
 
-mute-stream@0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
-
 mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
@@ -5421,7 +5286,7 @@ netrc@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/netrc/-/netrc-0.1.4.tgz#6be94fcaca8d77ade0a9670dc460914c94472444"
 
-node-fetch@^1.0.1, node-fetch@^1.7.1:
+node-fetch@^1.0.1:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.1.tgz#899cb3d0a3c92f952c47f1b876f4c8aeabd400d5"
   dependencies:
@@ -5494,7 +5359,7 @@ node-notifier@^5.0.2:
     shellwords "^0.1.0"
     which "^1.2.12"
 
-node-pre-gyp@^0.6.29:
+node-pre-gyp@^0.6.29, node-pre-gyp@^0.6.36:
   version "0.6.36"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz#db604112cb74e0d477554e9b505b17abddfab786"
   dependencies:
@@ -5592,12 +5457,6 @@ npmlog@^4.0.2:
     gauge "~2.7.3"
     set-blocking "~2.0.0"
 
-nth-check@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.1.tgz#9929acdf628fc2c41098deab82ac580cf149aae4"
-  dependencies:
-    boolbase "~1.0.0"
-
 num2fraction@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/num2fraction/-/num2fraction-1.2.2.tgz#6f682b6a027a4e9ddfa4564cd2589d1d4e669ede"
@@ -5606,7 +5465,7 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-"nwmatcher@>= 1.3.7 < 2.0.0", "nwmatcher@>= 1.3.9 < 2.0.0":
+"nwmatcher@>= 1.3.9 < 2.0.0":
   version "1.3.9"
   resolved "https://registry.yarnpkg.com/nwmatcher/-/nwmatcher-1.3.9.tgz#8bab486ff7fa3dfd086656bbe8b17116d3692d2a"
 
@@ -5717,6 +5576,13 @@ os-locale@^2.0.0:
     execa "^0.5.0"
     lcid "^1.0.0"
     mem "^1.1.0"
+
+os-name@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/os-name/-/os-name-2.0.1.tgz#b9a386361c17ae3a21736ef0599405c9a8c5dc5e"
+  dependencies:
+    macos-release "^1.0.0"
+    win-release "^1.0.0"
 
 os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1:
   version "1.0.2"
@@ -6430,9 +6296,9 @@ react-deep-force-update@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-1.0.1.tgz#f911b5be1d2a6fe387507dd6e9a767aa2924b4c7"
 
-react-devtools-core@^2.1.8:
-  version "2.1.9"
-  resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-2.1.9.tgz#825e0582b7f8587cbf56bb5ef1ea94d8b158543e"
+react-devtools-core@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-2.5.0.tgz#5ad179f88f22d205940721e38e4ecc3a2d35bf03"
   dependencies:
     shell-quote "^1.6.1"
     ws "^2.0.3"
@@ -6529,9 +6395,9 @@ react-native-storybook-loader@^1.5.0:
     glob "^7.1.1"
     yargs "^8.0.2"
 
-react-native@next:
-  version "0.45.0-rc.2"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.45.0-rc.2.tgz#e28c048403f6c13cb0d201ce0577549181558367"
+react-native@0.48.0-rc.1:
+  version "0.48.0-rc.1"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.48.0-rc.1.tgz#7ecc61fda1f57e24657c48f1fd3057bef25a8a63"
   dependencies:
     absolute-path "^0.0.0"
     art "^0.10.0"
@@ -6541,12 +6407,13 @@ react-native@next:
     babel-plugin-external-helpers "^6.18.0"
     babel-plugin-syntax-trailing-function-commas "^6.20.0"
     babel-plugin-transform-async-to-generator "6.16.0"
+    babel-plugin-transform-class-properties "^6.18.0"
     babel-plugin-transform-flow-strip-types "^6.21.0"
     babel-plugin-transform-object-rest-spread "^6.20.2"
     babel-polyfill "^6.20.0"
     babel-preset-es2015-node "^6.1.1"
-    babel-preset-fbjs "^2.1.2"
-    babel-preset-react-native "^1.9.1"
+    babel-preset-fbjs "^2.1.4"
+    babel-preset-react-native "^2.0.0"
     babel-register "^6.24.1"
     babel-runtime "^6.23.0"
     babel-traverse "^6.24.1"
@@ -6562,6 +6429,7 @@ react-native@next:
     create-react-class "^15.5.2"
     debug "^2.2.0"
     denodeify "^1.2.1"
+    envinfo "^3.0.0"
     errno ">=0.1.1 <0.2.0-0"
     event-target-shim "^1.0.5"
     fbjs "0.8.12"
@@ -6570,15 +6438,14 @@ react-native@next:
     fs-extra "^1.0.0"
     glob "^7.1.1"
     graceful-fs "^4.1.3"
-    image-size "^0.3.5"
-    inquirer "^0.12.0"
-    jest-haste-map "^20.0.4"
-    joi "^6.6.1"
+    inquirer "^3.0.6"
+    jest-haste-map "20.1.0-delta.4"
     json-stable-stringify "^1.0.1"
     json5 "^0.4.0"
     left-pad "^1.1.3"
     lodash "^4.16.6"
     merge-stream "^1.0.1"
+    metro-bundler "^0.11.0"
     mime "^1.3.4"
     mime-types "2.1.11"
     minimist "^1.2.0"
@@ -6592,7 +6459,7 @@ react-native@next:
     promise "^7.1.1"
     prop-types "^15.5.8"
     react-clone-referenced-element "^1.0.1"
-    react-devtools-core "^2.1.8"
+    react-devtools-core "^2.5.0"
     react-timer-mixin "^0.13.2"
     react-transform-hmr "^1.0.4"
     rebound "^0.0.13"
@@ -6605,8 +6472,7 @@ react-native@next:
     source-map "^0.5.6"
     stacktrace-parser "^0.1.3"
     temp "0.8.3"
-    throat "^3.0.0"
-    uglify-js "2.7.5"
+    throat "^4.1.0"
     whatwg-fetch "^1.0.0"
     wordwrap "^1.0.0"
     write-file-atomic "^1.2.0"
@@ -6752,18 +6618,18 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
-readable-stream@1.1, readable-stream@^1.0.33, readable-stream@~1.1.8, readable-stream@~1.1.9:
-  version "1.1.14"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
+"readable-stream@>=1.0.33-1 <1.1.0-0":
+  version "1.0.34"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.1"
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-"readable-stream@>=1.0.33-1 <1.1.0-0":
-  version "1.0.34"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
+readable-stream@^1.0.33, readable-stream@~1.1.8, readable-stream@~1.1.9:
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.1"
@@ -6801,14 +6667,6 @@ readdirp@^2.0.0:
     minimatch "^3.0.2"
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
-
-readline2@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/readline2/-/readline2-1.0.1.tgz#41059608ffc154757b715d9989d199ffbf372e35"
-  dependencies:
-    code-point-at "^1.0.0"
-    is-fullwidth-code-point "^1.0.0"
-    mute-stream "0.0.5"
 
 rebound@^0.0.13:
   version "0.0.13"
@@ -6928,12 +6786,6 @@ repeat-string@^1.5.2:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
 
-repeating@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/repeating/-/repeating-1.1.3.tgz#3d4114218877537494f97f77f9785fab810fa4ac"
-  dependencies:
-    is-finite "^1.0.0"
-
 repeating@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
@@ -6944,7 +6796,7 @@ replace-ext@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-0.0.1.tgz#29bbd92078a739f0bcce2b4ee41e837953522924"
 
-request@2, request@^2.55.0, request@^2.79.0, request@^2.81.0:
+request@2, request@^2.79.0, request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:
@@ -7049,21 +6901,21 @@ rndm@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/rndm/-/rndm-1.2.0.tgz#f33fe9cfb52bbfd520aa18323bc65db110a1b76c"
 
-run-async@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/run-async/-/run-async-0.1.0.tgz#c8ad4a5e110661e402a7d21b530e009f25f8e389"
-  dependencies:
-    once "^1.3.0"
-
 run-async@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
   dependencies:
     is-promise "^2.1.0"
 
-rx-lite@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
+rx-lite-aggregates@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz#753b87a89a11c95467c4ac1626c4efc4e05c67be"
+  dependencies:
+    rx-lite "*"
+
+rx-lite@*, rx-lite@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
 
 rx@2.3.24:
   version "2.3.24"
@@ -7082,6 +6934,20 @@ rxjs@^5.0.0-beta.11:
 safe-buffer@^5.0.1, safe-buffer@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
+
+sane@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/sane/-/sane-2.0.0.tgz#99cb79f21f4a53a69d4d0cd957c2db04024b8eb2"
+  dependencies:
+    anymatch "^1.3.0"
+    exec-sh "^0.2.0"
+    fb-watchman "^2.0.0"
+    minimatch "^3.0.2"
+    minimist "^1.1.1"
+    walker "~1.0.5"
+    watch "~0.10.0"
+  optionalDependencies:
+    fsevents "^1.1.1"
 
 sane@~1.4.1:
   version "1.4.1"
@@ -7106,7 +6972,7 @@ sane@~1.6.0:
     walker "~1.0.5"
     watch "~0.10.0"
 
-sax@^1.1.4, sax@^1.2.1, sax@~1.2.1:
+sax@^1.2.1, sax@~1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.2.tgz#fd8631a23bc7826bef5d871bdb87378c95647828"
 
@@ -7123,6 +6989,10 @@ schema-utils@^0.3.0:
 "semver@2 || 3 || 4 || 5", semver@5.3.0, semver@5.x, semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@~5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
+
+semver@^5.0.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
 
 semver@~5.0.1:
   version "5.0.3"
@@ -7462,6 +7332,13 @@ string-width@^2.0.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^3.0.0"
 
+string-width@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^4.0.0"
+
 string_decoder@^0.10.25, string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
@@ -7487,6 +7364,12 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
   dependencies:
     ansi-regex "^2.0.0"
+
+strip-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
+  dependencies:
+    ansi-regex "^3.0.0"
 
 strip-bom@3.0.0, strip-bom@^3.0.0:
   version "3.0.0"
@@ -7660,7 +7543,7 @@ symbol-observable@^1.0.1, symbol-observable@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
 
-"symbol-tree@>= 3.1.0 < 4.0.0", symbol-tree@^3.2.1:
+symbol-tree@^3.2.1:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
 
@@ -7680,10 +7563,6 @@ table@^4.0.1:
     lodash "^4.0.0"
     slice-ansi "0.0.4"
     string-width "^2.0.0"
-
-taffydb@2.7.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/taffydb/-/taffydb-2.7.2.tgz#7bf8106a5c1a48251b3e3bc0a0e1732489fd0dc8"
 
 tapable@^0.2.5, tapable@^0.2.7:
   version "0.2.7"
@@ -7745,6 +7624,10 @@ throat@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-3.0.0.tgz#e7c64c867cbb3845f10877642f7b60055b8ec0d6"
 
+throat@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
+
 through2@^0.6.1, through2@^0.6.3, through2@~0.6.1:
   version "0.6.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-0.6.5.tgz#41ab9c67b29d57209071410e1d7a7a968cd3ad48"
@@ -7795,19 +7678,13 @@ to-fast-properties@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.2.tgz#f3f5c0c3ba7299a7ef99427e44633257ade43320"
 
-topo@1.x.x:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/topo/-/topo-1.1.0.tgz#e9d751615d1bb87dc865db182fa1ca0a5ef536d5"
-  dependencies:
-    hoek "2.x.x"
-
-tough-cookie@^2.2.0, tough-cookie@^2.3.2, tough-cookie@~2.3.0:
+tough-cookie@^2.3.2, tough-cookie@~2.3.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.2.tgz#f081f76e4c85720e6c37a5faced737150d84072a"
   dependencies:
     punycode "^1.4.1"
 
-tr46@~0.0.1, tr46@~0.0.3:
+tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
 
@@ -8118,10 +7995,6 @@ watchpack@^1.4.0:
     chokidar "^1.7.0"
     graceful-fs "^4.1.2"
 
-webidl-conversions@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-2.0.1.tgz#3bf8258f7d318c7443c36f2e169402a1a6703506"
-
 webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
@@ -8193,12 +8066,6 @@ whatwg-fetch@>=0.10.0, whatwg-fetch@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-1.0.0.tgz#01c2ac4df40e236aaa18480e3be74bd5c8eb798e"
 
-whatwg-url-compat@~0.6.5:
-  version "0.6.5"
-  resolved "https://registry.yarnpkg.com/whatwg-url-compat/-/whatwg-url-compat-0.6.5.tgz#00898111af689bb097541cd5a45ca6c8798445bf"
-  dependencies:
-    tr46 "~0.0.1"
-
 whatwg-url@^4.3.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-4.6.0.tgz#ef98da442273be04cf9632e176f257d2395a1ae4"
@@ -8224,11 +8091,23 @@ which@1, which@^1.2.10, which@^1.2.12, which@^1.2.9:
   dependencies:
     isexe "^2.0.0"
 
+which@^1.2.14:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
+  dependencies:
+    isexe "^2.0.0"
+
 wide-align@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.2.tgz#571e0f1b0604636ebc0dfc21b0339bbe31341710"
   dependencies:
     string-width "^1.0.2"
+
+win-release@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/win-release/-/win-release-1.1.1.tgz#5fa55e02be7ca934edfc12665632e849b72e5209"
+  dependencies:
+    semver "^5.0.1"
 
 window-size@0.1.0:
   version "0.1.0"
@@ -8319,7 +8198,7 @@ xcode@0.9.3, xcode@^0.9.1:
     simple-plist "^0.2.1"
     uuid "3.0.1"
 
-"xml-name-validator@>= 2.0.1 < 3.0.0", xml-name-validator@^2.0.1:
+xml-name-validator@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3875,8 +3875,8 @@ inquirer@3.0.6:
     through "^2.3.6"
 
 inquirer@^3.0.6:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.2.2.tgz#c2aaede1507cc54d826818737742d621bef2e823"
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.2.3.tgz#1c7b1731cf77b934ec47d22c9ac5aa8fe7fbe095"
   dependencies:
     ansi-escapes "^2.0.0"
     chalk "^2.0.0"
@@ -6395,9 +6395,9 @@ react-native-storybook-loader@^1.5.0:
     glob "^7.1.1"
     yargs "^8.0.2"
 
-react-native@0.48.0-rc.1:
-  version "0.48.0-rc.1"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.48.0-rc.1.tgz#7ecc61fda1f57e24657c48f1fd3057bef25a8a63"
+react-native@0.48.0:
+  version "0.48.0"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.48.0.tgz#b2f06ee969c3145a0ad19700fb5ee90125bc0d25"
   dependencies:
     absolute-path "^0.0.0"
     art "^0.10.0"


### PR DESCRIPTION
This branch is in a state where everything should be able to run as expected, with the exception of nested scrollviews (e.g. an Artist's Artworks masonry grid). It requires a monkey-patched version of Relay with a small change re: `unstable_batchedUpdates`; I have the change locally and can help someone out with it if they would like to use this branch before it is merged. 

- [x] Upgrade RN
- [x] Upgrade RN to actual v0.48.0 now that it's no longer a release candidate
- [ ] Decide how to deal with the Relay monkey patch (on @alloy's custom branch perhaps?)
- [ ] Fix nested scrollviews (everything should run without crashing but `onScroll` callbacks will not be called; the `RCTScrollView` API has changed considerably so this might take a bit of time)
- [ ] Adapt usage of `NetInfo` to new API (the `change` event is now deprecated)

Please feel free to add to the above list. 