### PR TITLE
[Beta] Unrouted pages now go through to force

### DIFF
--- a/Example/Emission/AppDelegate.h
+++ b/Example/Emission/AppDelegate.h
@@ -3,5 +3,9 @@
 @interface AppDelegate : UIResponder <UIApplicationDelegate>
 @property (strong, nonatomic) UIWindow *window;
 @property (nonatomic, strong) NSString *emissionLoadedFromString;
+
+// TODO abstract into a switchboard?
+- (UIViewController *)viewControllerForRoute:(NSString *)route;
+
 @end
 

--- a/Example/Emission/AppDelegate.m
+++ b/Example/Emission/AppDelegate.m
@@ -274,6 +274,7 @@ randomBOOL(void)
     viewController = [[ARHomeComponentViewController alloc] initWithEmission:nil];
 
   } else {
+
     viewController = [[UnroutedViewController alloc] initWithRoute:route];
   }
 

--- a/Pod/Classes/Core/AREmission.h
+++ b/Pod/Classes/Core/AREmission.h
@@ -45,6 +45,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) ARWorksForYouModule *worksForYouModule;
 @property (nonatomic, strong, readonly) ARTakeCameraPhotoModule *cameraModule;
 
+@property (nonatomic, strong, readwrite) AREmissionConfiguration *configurationModule;
+
 + (instancetype)sharedInstance;
 + (void)setSharedInstance:(AREmission *)instance;
 

--- a/Pod/Classes/Core/AREmission.m
+++ b/Pod/Classes/Core/AREmission.m
@@ -46,9 +46,6 @@ RCT_EXPORT_MODULE(Emission);
 @end
 
 
-@interface AREmission ()
-@property (nonatomic, strong, readwrite) AREmissionConfiguration *configurationModule;
-@end
 
 @implementation AREmission
 


### PR DESCRIPTION
Adds support for showing pages in a WKWedbView - there's a slack discussion about _why_ artsy is slow [here](https://artsy.slack.com/archives/C02BAQ5K7/p1504886479000256) - same problem we see in Eigen, and this is a fresh implementation.

![2017-09-08 12_50_34](https://user-images.githubusercontent.com/49038/30222173-509e5298-9494-11e7-8684-86a9d86b8410.gif)

Only notable other change is that the config is now a readable property on AREmission externally. It's read-only, so that's fine by me.