### PR TITLE
@l2succes => Include id in conversation fragment

### DIFF
--- a/src/lib/Containers/Conversation.tsx
+++ b/src/lib/Containers/Conversation.tsx
@@ -172,6 +172,7 @@ export default createFragmentContainer(Conversation, {
   me: graphql`
     fragment Conversation_me on Me {
       conversation(id: $conversationID) {
+        id
         to {
           name
           initials


### PR DESCRIPTION
I noticed after pulling master, the mutation to mark a message as unread wasn't working, even the `id` existed in `RelayProps`, it wasn't in the container fragment. This just adds it to the fragment, which gets that all working again

trivial

Skip New Tests