### PR TITLE
[Messages] Misc UI fixes and space key remapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 
 ###### Messaging
 
+-   Moved conversation loading indicator inside list view - luc
 -   Initial message now sticks to the top of the scrollview - luc
 -   Added spinner and 'no more' message when paginating thru inbox - matt
 -   Refactored messaging-related interfaces, fixed mutations, added tests - luc + matt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ###### Dev
 
+-   Remaps space key bidding to ctrl+space so we can enter spaces fromthe simulator - luc
 -   Conditionally use different past artist show fragments for iPad vs iPhone - alloy
 -   Upgrades Relay to ‘modern’ (v1.3.0) - alloy
 -   Upgrades React Native to v0.48.0 - sarah
@@ -30,6 +31,7 @@
 
 ###### Messaging
 
+-   Fixed separator styling in the message component - luc
 -   Moved conversation loading indicator inside list view - luc
 -   Initial message now sticks to the top of the scrollview - luc
 -   Added spinner and 'no more' message when paginating thru inbox - matt

--- a/src/lib/Components/Inbox/Conversations/ConversationSnippet.tsx
+++ b/src/lib/Components/Inbox/Conversations/ConversationSnippet.tsx
@@ -33,7 +33,7 @@ const CardContent = styled(HorizontalLayout)`
 
 const TextPreview = styled(VerticalLayout)`
   margin-left: 15;
-  margin-bottom: 3;
+  margin-bottom: 15;
 `
 
 const DateHeading = styled(HorizontalLayout)`

--- a/src/lib/Components/Inbox/Conversations/Message.tsx
+++ b/src/lib/Components/Inbox/Conversations/Message.tsx
@@ -1,5 +1,6 @@
 import moment from "moment"
 import * as React from "react"
+import { View } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 
 import { BodyText, FromSignatureText, MetadataText, SmallHeadline } from "../Typography"
@@ -14,6 +15,7 @@ import styled from "styled-components/native"
 import colors from "../../../../data/colors"
 
 import SwitchBoard from "../../../NativeModules/SwitchBoard"
+import DottedLine from "../../DottedLine"
 
 const VerticalLayout = styled.View`
   flex-direction: column;
@@ -22,12 +24,15 @@ const VerticalLayout = styled.View`
 
 const HorizontalLayout = styled.View`flex-direction: row;`
 
-const Container = styled(HorizontalLayout)`
+const Container = styled(View)`
+  padding-left: 20;
+  padding-right: 20;
+`
+
+const Content = styled(HorizontalLayout)`
   align-self: stretch;
   margin-top: 15;
   margin-bottom: 10;
-  margin-left: 20;
-  margin-right: 20;
 `
 
 const Header = styled(HorizontalLayout)`
@@ -52,6 +57,11 @@ const TimeStamp = styled(MetadataText)`
   font-size: 11.5
 `
 
+const Seperator = styled(DottedLine)`
+  padding-left: 20;
+  padding-right: 20;
+`
+
 const ArtworkPreviewContainer = styled.View`margin-bottom: 10;`
 
 const ImagePreviewContainer = styled.View`margin-bottom: 10;`
@@ -66,6 +76,7 @@ interface Props extends RelayProps {
   artworkPreview?: JSX.Element
   showPreview?: JSX.Element
   firstMessage: boolean
+  index: number
   initialText: string
 }
 
@@ -118,41 +129,44 @@ export class Message extends React.Component<Props, any> {
     const fromSignature = fromName ? `${fromName} · ${fromEmail}` : fromEmail
     return (
       <Container>
-        <Avatar isUser={message.is_from_user} initials={initials} />
-        <TextContainer>
-          <Header>
-            <SenderName>
-              {senderName}
-            </SenderName>
-            {isSent &&
-              <TimeStamp>
-                {moment(message.created_at).fromNow(true)}
-              </TimeStamp>}
-          </Header>
-          {artworkPreview &&
-            <ArtworkPreviewContainer>
-              {artworkPreview}
-            </ArtworkPreviewContainer>}
+        <Content>
+          <Avatar isUser={message.is_from_user} initials={initials} />
+          <TextContainer>
+            <Header>
+              <SenderName>
+                {senderName}
+              </SenderName>
+              {isSent &&
+                <TimeStamp>
+                  {moment(message.created_at).fromNow(true)}
+                </TimeStamp>}
+            </Header>
+            {artworkPreview &&
+              <ArtworkPreviewContainer>
+                {artworkPreview}
+              </ArtworkPreviewContainer>}
 
-          {showPreview &&
-            <ArtworkPreviewContainer>
-              {showPreview}
-            </ArtworkPreviewContainer>}
+            {showPreview &&
+              <ArtworkPreviewContainer>
+                {showPreview}
+              </ArtworkPreviewContainer>}
 
-          {message.invoice &&
-            <InvoicePreviewContainer>
-              <InvoicePreview invoice={message.invoice} />
-            </InvoicePreviewContainer>}
+            {message.invoice &&
+              <InvoicePreviewContainer>
+                <InvoicePreview invoice={message.invoice} />
+              </InvoicePreviewContainer>}
 
-          {this.renderAttachmentPreviews(message.attachments)}
+            {this.renderAttachmentPreviews(message.attachments)}
 
-          {this.renderBody()}
+            {this.renderBody()}
 
-          {!message.is_from_user &&
-            <FromSignature>
-              {fromSignature}
-            </FromSignature>}
-        </TextContainer>
+            {!message.is_from_user &&
+              <FromSignature>
+                {fromSignature}
+              </FromSignature>}
+          </TextContainer>
+        </Content>
+        {this.props.index !== 0 && <Seperator />}
       </Container>
     )
   }

--- a/src/lib/Components/Inbox/Conversations/Messages.tsx
+++ b/src/lib/Components/Inbox/Conversations/Messages.tsx
@@ -140,6 +140,7 @@ export class Messages extends React.Component<Props, State> {
         }}
         refreshControl={refreshControl}
         ItemSeparatorComponent={DottedLine}
+        ListFooterComponent={<ActivityIndicator animating={this.state.fetchingMoreData} hidesWhenStopped />}
       />
     )
   }

--- a/src/lib/Components/Inbox/Conversations/Messages.tsx
+++ b/src/lib/Components/Inbox/Conversations/Messages.tsx
@@ -52,7 +52,7 @@ export class Messages extends React.Component<Props, State> {
     }
   }
 
-  renderMessage({ item }) {
+  renderMessage({ item, index }) {
     const conversationItem = this.props.conversation.items[0].item
     const conversation = this.props.conversation
     const partnerName = conversation.to.name
@@ -60,6 +60,7 @@ export class Messages extends React.Component<Props, State> {
     const initials = item.is_from_user ? conversation.from.initials : conversation.to.initials
     return (
       <Message
+        index={index}
         firstMessage={item.firstMessage}
         initialText={item}
         message={item}
@@ -105,7 +106,6 @@ export class Messages extends React.Component<Props, State> {
 
   reload() {
     const count = this.props.conversation.messages.edges.length
-
     this.setState({ reloadingData: true })
     this.props.relay.refetchConnection(count, e => {
       this.setState({ reloadingData: false })
@@ -139,7 +139,6 @@ export class Messages extends React.Component<Props, State> {
           })
         }}
         refreshControl={refreshControl}
-        ItemSeparatorComponent={DottedLine}
         ListFooterComponent={<ActivityIndicator animating={this.state.fetchingMoreData} hidesWhenStopped />}
       />
     )

--- a/src/lib/Components/Inbox/Conversations/__tests__/Message-tests.tsx
+++ b/src/lib/Components/Inbox/Conversations/__tests__/Message-tests.tsx
@@ -27,7 +27,7 @@ it("looks correct when rendered", () => {
     },
   }
   const tree = renderer
-    .create(<Message initialText="" firstMessage={false} senderName={senderName} message={props} />)
+    .create(<Message initialText="" firstMessage={false} index={0} senderName={senderName} message={props} />)
     .toJSON()
   expect(tree).toMatchSnapshot()
 })

--- a/src/lib/Components/Inbox/Conversations/__tests__/Messages-tests.tsx
+++ b/src/lib/Components/Inbox/Conversations/__tests__/Messages-tests.tsx
@@ -1,0 +1,54 @@
+import * as React from "react"
+
+import "react-native"
+import * as renderer from "react-test-renderer"
+import Messages from "../Messages"
+
+it("looks correct when rendered", () => {
+  const messages = renderer.create(<Messages conversation={props} />) as any
+  expect(messages).toMatchSnapshot()
+})
+
+const props = {
+  id: "420",
+  from: {
+    name: "Anita Garibaldi",
+    email: "anita@garibaldi.br",
+    initials: "AG",
+  },
+  to: { name: "Kimberly Klark", initials: "KK" },
+  initial_message: "Adoro! Por favor envie-me mais informações",
+  messages: {
+    edges: [
+      {
+        node: {
+          id: 222,
+          body: "Adoro! Por favor envie-me mais informações",
+          from_email_address: "anita@garibaldi.br",
+          attachments: [],
+          from: {
+            name: "Percy",
+            email: "percy@cat.com",
+          },
+        },
+      },
+    ],
+  },
+  items: [
+    {
+      title: "The Mythic Being: Sol’s Drawing #1–5",
+      item: {
+        __typename: "Artwork",
+        id: "adrian-piper-the-mythic-being-sols-drawing-number-1-5",
+        href: "/artwork/adrian-piper-the-mythic-being-sols-drawing-number-1-5",
+        title: "The Mythic Being: Sol’s Drawing #1–5",
+        date: "1974",
+        artist_names: "Adrian Piper",
+        image: {
+          url: "https://d32dm0rphc51dk.cloudfront.net/W1FkNoM9IjrND_xv_DTkeg/normalized.jpg",
+          image_url: "https://d32dm0rphc51dk.cloudfront.net/J0uofgV9e8cIxGiZwn12mg/:version.jpg",
+        },
+      },
+    },
+  ],
+}

--- a/src/lib/Components/Inbox/Conversations/__tests__/__snapshots__/ConversationSnippet-tests.tsx.snap
+++ b/src/lib/Components/Inbox/Conversations/__tests__/__snapshots__/ConversationSnippet-tests.tsx.snap
@@ -71,7 +71,7 @@ exports[`renders correctly with a show 1`] = `
           },
           Array [
             Object {
-              "marginBottom": 3,
+              "marginBottom": 15,
               "marginLeft": 15,
             },
             undefined,
@@ -332,7 +332,7 @@ exports[`renders correctly with an artwork 1`] = `
           },
           Array [
             Object {
-              "marginBottom": 3,
+              "marginBottom": 15,
               "marginLeft": 15,
             },
             undefined,

--- a/src/lib/Components/Inbox/Conversations/__tests__/__snapshots__/Conversations-tests.tsx.snap
+++ b/src/lib/Components/Inbox/Conversations/__tests__/__snapshots__/Conversations-tests.tsx.snap
@@ -119,7 +119,7 @@ exports[`looks correct when rendered 1`] = `
                 },
                 Array [
                   Object {
-                    "marginBottom": 3,
+                    "marginBottom": 15,
                     "marginLeft": 15,
                   },
                   undefined,
@@ -406,7 +406,7 @@ exports[`looks correct when rendered 1`] = `
                 },
                 Array [
                   Object {
-                    "marginBottom": 3,
+                    "marginBottom": 15,
                     "marginLeft": 15,
                   },
                   undefined,

--- a/src/lib/Components/Inbox/Conversations/__tests__/__snapshots__/Message-tests.tsx.snap
+++ b/src/lib/Components/Inbox/Conversations/__tests__/__snapshots__/Message-tests.tsx.snap
@@ -5,18 +5,10 @@ exports[`looks correct when rendered 1`] = `
   style={
     Array [
       Object {
-        "flexDirection": "row",
+        "paddingLeft": 20,
+        "paddingRight": 20,
       },
-      Array [
-        Object {
-          "alignSelf": "stretch",
-          "marginBottom": 10,
-          "marginLeft": 20,
-          "marginRight": 20,
-          "marginTop": 15,
-        },
-        undefined,
-      ],
+      undefined,
     ]
   }
 >
@@ -24,47 +16,13 @@ exports[`looks correct when rendered 1`] = `
     style={
       Array [
         Object {
-          "backgroundColor": "#e5e5e5",
-          "borderRadius": 15,
-          "height": 30,
-          "width": 30,
-        },
-        undefined,
-      ]
-    }
-  >
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      disabled={false}
-      ellipsizeMode="tail"
-      style={
-        Array [
-          Object {
-            "alignSelf": "center",
-            "color": "white",
-            "fontFamily": "Avant Garde Gothic ITCW01Dm",
-            "fontSize": 10,
-            "marginTop": 8,
-          },
-          undefined,
-        ]
-      }
-      user={true}
-    />
-  </View>
-  <View
-    style={
-      Array [
-        Object {
-          "flexBasis": 0,
-          "flexDirection": "column",
-          "flexGrow": 1,
-          "flexShrink": 1,
+          "flexDirection": "row",
         },
         Array [
           Object {
-            "marginLeft": 10,
+            "alignSelf": "stretch",
+            "marginBottom": 10,
+            "marginTop": 15,
           },
           undefined,
         ],
@@ -75,18 +33,328 @@ exports[`looks correct when rendered 1`] = `
       style={
         Array [
           Object {
-            "flexDirection": "row",
+            "backgroundColor": "#e5e5e5",
+            "borderRadius": 15,
+            "height": 30,
+            "width": 30,
+          },
+          undefined,
+        ]
+      }
+    >
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        disabled={false}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "alignSelf": "center",
+              "color": "white",
+              "fontFamily": "Avant Garde Gothic ITCW01Dm",
+              "fontSize": 10,
+              "marginTop": 8,
+            },
+            undefined,
+          ]
+        }
+        user={true}
+      />
+    </View>
+    <View
+      style={
+        Array [
+          Object {
+            "flexBasis": 0,
+            "flexDirection": "column",
+            "flexGrow": 1,
+            "flexShrink": 1,
           },
           Array [
             Object {
-              "alignSelf": "stretch",
-              "marginBottom": 10,
+              "marginLeft": 10,
             },
             undefined,
           ],
         ]
       }
     >
+      <View
+        style={
+          Array [
+            Object {
+              "flexDirection": "row",
+            },
+            Array [
+              Object {
+                "alignSelf": "stretch",
+                "marginBottom": 10,
+              },
+              undefined,
+            ],
+          ]
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          disabled={false}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "black",
+                "fontSize": 11,
+                "textAlign": "left",
+              },
+              Array [
+                Object {
+                  "fontSize": 11.5,
+                  "marginRight": 3,
+                },
+                undefined,
+              ],
+              Object {
+                "fontFamily": "Avant Garde Gothic ITCW01Dm",
+              },
+            ]
+          }
+        >
+          SARAH
+        </Text>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          disabled={false}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "color": "#cccccc",
+                "fontSize": 11,
+                "textAlign": "left",
+              },
+              Array [
+                Object {
+                  "fontSize": 11.5,
+                },
+                undefined,
+              ],
+              Object {
+                "fontFamily": "Avant Garde Gothic ITCW01Dm",
+              },
+            ]
+          }
+        >
+          A YEAR
+        </Text>
+      </View>
+      <View
+        style={
+          Array [
+            Object {
+              "marginBottom": 10,
+            },
+            undefined,
+          ]
+        }
+      >
+        <View
+          accessibilityComponentType={undefined}
+          accessibilityLabel={undefined}
+          accessibilityTraits={undefined}
+          accessible={true}
+          hasTVPreferredFocus={undefined}
+          hitSlop={undefined}
+          isTVSelectable={true}
+          nativeID={undefined}
+          onLayout={undefined}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Array [
+              Object {
+                "backgroundColor": "transparent",
+              },
+              undefined,
+            ]
+          }
+          testID={undefined}
+          tvParallaxProperties={undefined}
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "borderColor": "#e5e5e5",
+                  "borderWidth": 1,
+                  "flexBasis": 0,
+                  "flexDirection": "row",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                undefined,
+              ]
+            }
+          >
+            <Image
+              source={1}
+              style={
+                Array [
+                  Object {
+                    "marginBottom": 12,
+                    "marginLeft": 12,
+                    "marginTop": 12,
+                    "resizeMode": "contain",
+                    "width": 40,
+                  },
+                  undefined,
+                ]
+              }
+            />
+            <View
+              style={
+                Array [
+                  Object {
+                    "alignSelf": "center",
+                    "flexBasis": 0,
+                    "flexDirection": "column",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                    "marginLeft": 25,
+                  },
+                  undefined,
+                ]
+              }
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                disabled={false}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "fontFamily": "AGaramondPro-Regular",
+                      "fontSize": 14,
+                    },
+                    undefined,
+                  ]
+                }
+              >
+                Payment request
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                disabled={false}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "fontFamily": "AGaramondPro-Regular",
+                      "fontSize": 14,
+                    },
+                    undefined,
+                  ]
+                }
+              >
+                $420
+              </Text>
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "alignSelf": "center",
+                    "flexBasis": 0,
+                    "flexDirection": "column",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                    "marginLeft": 25,
+                  },
+                  undefined,
+                ]
+              }
+            >
+              <View
+                style={
+                  Array [
+                    Object {
+                      "height": 25,
+                      "width": 71,
+                    },
+                    undefined,
+                  ]
+                }
+              >
+                <View
+                  accessibilityComponentType={undefined}
+                  accessibilityLabel={undefined}
+                  accessibilityTraits={undefined}
+                  accessible={true}
+                  hasTVPreferredFocus={undefined}
+                  hitSlop={undefined}
+                  isTVSelectable={true}
+                  nativeID={undefined}
+                  onLayout={undefined}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    Array [
+                      Object {
+                        "backgroundColor": "transparent",
+                      },
+                      Object {
+                        "alignItems": "center",
+                        "backgroundColor": "rgba(0, 0, 0, 1)",
+                        "flex": 1,
+                        "justifyContent": "center",
+                      },
+                    ]
+                  }
+                  testID={undefined}
+                  tvParallaxProperties={undefined}
+                >
+                  <View>
+                    <Text
+                      accessible={true}
+                      allowFontScaling={true}
+                      disabled={false}
+                      ellipsizeMode="tail"
+                      style={
+                        Array [
+                          Object {
+                            "fontSize": 12,
+                          },
+                          Object {
+                            "color": "white",
+                            "opacity": 1,
+                          },
+                          Object {
+                            "fontFamily": "Avant Garde Gothic ITCW01Dm",
+                          },
+                        ]
+                      }
+                    >
+                      PAY
+                    </Text>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
       <Text
         accessible={true}
         allowFontScaling={true}
@@ -96,278 +364,20 @@ exports[`looks correct when rendered 1`] = `
           Array [
             Object {
               "color": "black",
-              "fontSize": 11,
+              "fontSize": 16,
               "textAlign": "left",
             },
-            Array [
-              Object {
-                "fontSize": 11.5,
-                "marginRight": 3,
-              },
-              undefined,
-            ],
+            false,
+            Object {},
             Object {
-              "fontFamily": "Avant Garde Gothic ITCW01Dm",
+              "fontFamily": "AGaramondPro-Regular",
             },
           ]
         }
       >
-        SARAH
-      </Text>
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        disabled={false}
-        ellipsizeMode="tail"
-        style={
-          Array [
-            Object {
-              "color": "#cccccc",
-              "fontSize": 11,
-              "textAlign": "left",
-            },
-            Array [
-              Object {
-                "fontSize": 11.5,
-              },
-              undefined,
-            ],
-            Object {
-              "fontFamily": "Avant Garde Gothic ITCW01Dm",
-            },
-          ]
-        }
-      >
-        A YEAR
+        Hi, I'm interested in purchasing this work. Could you please provide more information about the piece, including price?
       </Text>
     </View>
-    <View
-      style={
-        Array [
-          Object {
-            "marginBottom": 10,
-          },
-          undefined,
-        ]
-      }
-    >
-      <View
-        accessibilityComponentType={undefined}
-        accessibilityLabel={undefined}
-        accessibilityTraits={undefined}
-        accessible={true}
-        hasTVPreferredFocus={undefined}
-        hitSlop={undefined}
-        isTVSelectable={true}
-        nativeID={undefined}
-        onLayout={undefined}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
-        style={
-          Array [
-            Object {
-              "backgroundColor": "transparent",
-            },
-            undefined,
-          ]
-        }
-        testID={undefined}
-        tvParallaxProperties={undefined}
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "borderColor": "#e5e5e5",
-                "borderWidth": 1,
-                "flexBasis": 0,
-                "flexDirection": "row",
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              undefined,
-            ]
-          }
-        >
-          <Image
-            source={1}
-            style={
-              Array [
-                Object {
-                  "marginBottom": 12,
-                  "marginLeft": 12,
-                  "marginTop": 12,
-                  "resizeMode": "contain",
-                  "width": 40,
-                },
-                undefined,
-              ]
-            }
-          />
-          <View
-            style={
-              Array [
-                Object {
-                  "alignSelf": "center",
-                  "flexBasis": 0,
-                  "flexDirection": "column",
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                  "marginLeft": 25,
-                },
-                undefined,
-              ]
-            }
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              disabled={false}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "fontFamily": "AGaramondPro-Regular",
-                    "fontSize": 14,
-                  },
-                  undefined,
-                ]
-              }
-            >
-              Payment request
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              disabled={false}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "fontFamily": "AGaramondPro-Regular",
-                    "fontSize": 14,
-                  },
-                  undefined,
-                ]
-              }
-            >
-              $420
-            </Text>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "alignSelf": "center",
-                  "flexBasis": 0,
-                  "flexDirection": "column",
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                  "marginLeft": 25,
-                },
-                undefined,
-              ]
-            }
-          >
-            <View
-              style={
-                Array [
-                  Object {
-                    "height": 25,
-                    "width": 71,
-                  },
-                  undefined,
-                ]
-              }
-            >
-              <View
-                accessibilityComponentType={undefined}
-                accessibilityLabel={undefined}
-                accessibilityTraits={undefined}
-                accessible={true}
-                hasTVPreferredFocus={undefined}
-                hitSlop={undefined}
-                isTVSelectable={true}
-                nativeID={undefined}
-                onLayout={undefined}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  Array [
-                    Object {
-                      "backgroundColor": "transparent",
-                    },
-                    Object {
-                      "alignItems": "center",
-                      "backgroundColor": "rgba(0, 0, 0, 1)",
-                      "flex": 1,
-                      "justifyContent": "center",
-                    },
-                  ]
-                }
-                testID={undefined}
-                tvParallaxProperties={undefined}
-              >
-                <View>
-                  <Text
-                    accessible={true}
-                    allowFontScaling={true}
-                    disabled={false}
-                    ellipsizeMode="tail"
-                    style={
-                      Array [
-                        Object {
-                          "fontSize": 12,
-                        },
-                        Object {
-                          "color": "white",
-                          "opacity": 1,
-                        },
-                        Object {
-                          "fontFamily": "Avant Garde Gothic ITCW01Dm",
-                        },
-                      ]
-                    }
-                  >
-                    PAY
-                  </Text>
-                </View>
-              </View>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      disabled={false}
-      ellipsizeMode="tail"
-      style={
-        Array [
-          Object {
-            "color": "black",
-            "fontSize": 16,
-            "textAlign": "left",
-          },
-          false,
-          Object {},
-          Object {
-            "fontFamily": "AGaramondPro-Regular",
-          },
-        ]
-      }
-    >
-      Hi, I'm interested in purchasing this work. Could you please provide more information about the piece, including price?
-    </Text>
   </View>
 </View>
 `;

--- a/src/lib/Components/Inbox/Conversations/__tests__/__snapshots__/Messages-tests.tsx.snap
+++ b/src/lib/Components/Inbox/Conversations/__tests__/__snapshots__/Messages-tests.tsx.snap
@@ -1,0 +1,245 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`looks correct when rendered 1`] = `
+<RCTScrollView
+  ItemSeparatorComponent={[Function]}
+  data={
+    Array [
+      Object {
+        "attachments": Array [],
+        "body": "Adoro! Por favor envie-me mais informações",
+        "first_message": undefined,
+        "from": Object {
+          "email": "percy@cat.com",
+          "name": "Percy",
+        },
+        "from_email_address": "anita@garibaldi.br",
+        "id": 222,
+        "key": 0,
+      },
+    ]
+  }
+  disableVirtualization={false}
+  getItem={[Function]}
+  getItemCount={[Function]}
+  horizontal={false}
+  initialNumToRender={10}
+  inverted={true}
+  keyExtractor={[Function]}
+  maxToRenderPerBatch={10}
+  numColumns={1}
+  onContentSizeChange={[Function]}
+  onEndReached={[Function]}
+  onEndReachedThreshold={0.2}
+  onLayout={[Function]}
+  onMomentumScrollEnd={[Function]}
+  onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
+  onScrollEndDrag={[Function]}
+  onViewableItemsChanged={undefined}
+  refreshControl={
+    <RefreshControlMock
+      onRefresh={[Function]}
+      refreshing={false}
+    />
+  }
+  renderItem={[Function]}
+  scrollEventThrottle={50}
+  stickyHeaderIndices={Array []}
+  style={
+    Array [
+      Object {
+        "transform": Array [
+          Object {
+            "scaleY": -1,
+          },
+        ],
+      },
+      undefined,
+    ]
+  }
+  updateCellsBatchingPeriod={50}
+  windowSize={21}
+>
+  <RCTRefreshControl />
+  <View>
+    <View
+      onLayout={[Function]}
+      style={
+        Object {
+          "transform": Array [
+            Object {
+              "scaleY": -1,
+            },
+          ],
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "flexDirection": "row",
+            },
+            Array [
+              Object {
+                "alignSelf": "stretch",
+                "marginBottom": 10,
+                "marginLeft": 20,
+                "marginRight": 20,
+                "marginTop": 15,
+              },
+              undefined,
+            ],
+          ]
+        }
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "backgroundColor": "#e5e5e5",
+                "borderRadius": 15,
+                "height": 30,
+                "width": 30,
+              },
+              undefined,
+            ]
+          }
+        >
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            disabled={false}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "alignSelf": "center",
+                  "color": "#666666",
+                  "fontFamily": "Avant Garde Gothic ITCW01Dm",
+                  "fontSize": 10,
+                  "marginTop": 8,
+                },
+                undefined,
+              ]
+            }
+            user={undefined}
+          >
+            KK
+          </Text>
+        </View>
+        <View
+          style={
+            Array [
+              Object {
+                "flexBasis": 0,
+                "flexDirection": "column",
+                "flexGrow": 1,
+                "flexShrink": 1,
+              },
+              Array [
+                Object {
+                  "marginLeft": 10,
+                },
+                undefined,
+              ],
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "flexDirection": "row",
+                },
+                Array [
+                  Object {
+                    "alignSelf": "stretch",
+                    "marginBottom": 10,
+                  },
+                  undefined,
+                ],
+              ]
+            }
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              disabled={false}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "black",
+                    "fontSize": 11,
+                    "textAlign": "left",
+                  },
+                  Array [
+                    Object {
+                      "fontSize": 11.5,
+                      "marginRight": 3,
+                    },
+                    undefined,
+                  ],
+                  Object {
+                    "fontFamily": "Avant Garde Gothic ITCW01Dm",
+                  },
+                ]
+              }
+            >
+              KIMBERLY KLARK
+            </Text>
+          </View>
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            disabled={false}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "color": "black",
+                  "fontSize": 16,
+                  "textAlign": "left",
+                },
+                Object {
+                  "color": "#cccccc",
+                },
+                Object {},
+                Object {
+                  "fontFamily": "AGaramondPro-Regular",
+                },
+              ]
+            }
+          >
+            Adoro! Por favor envie-me mais informações
+          </Text>
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            disabled={false}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "color": "#cccccc",
+                  "fontFamily": "AGaramondPro-Regular",
+                },
+                Array [
+                  Object {
+                    "marginTop": 10,
+                  },
+                  undefined,
+                ],
+              ]
+            }
+          >
+            Percy · percy@cat.com
+          </Text>
+        </View>
+      </View>
+    </View>
+  </View>
+</RCTScrollView>
+`;

--- a/src/lib/Components/Inbox/Conversations/__tests__/__snapshots__/Messages-tests.tsx.snap
+++ b/src/lib/Components/Inbox/Conversations/__tests__/__snapshots__/Messages-tests.tsx.snap
@@ -2,7 +2,6 @@
 
 exports[`looks correct when rendered 1`] = `
 <RCTScrollView
-  ItemSeparatorComponent={[Function]}
   ListFooterComponent={
     <ActivityIndicator
       animating={false}
@@ -87,18 +86,10 @@ exports[`looks correct when rendered 1`] = `
         style={
           Array [
             Object {
-              "flexDirection": "row",
+              "paddingLeft": 20,
+              "paddingRight": 20,
             },
-            Array [
-              Object {
-                "alignSelf": "stretch",
-                "marginBottom": 10,
-                "marginLeft": 20,
-                "marginRight": 20,
-                "marginTop": 15,
-              },
-              undefined,
-            ],
+            undefined,
           ]
         }
       >
@@ -106,49 +97,13 @@ exports[`looks correct when rendered 1`] = `
           style={
             Array [
               Object {
-                "backgroundColor": "#e5e5e5",
-                "borderRadius": 15,
-                "height": 30,
-                "width": 30,
-              },
-              undefined,
-            ]
-          }
-        >
-          <Text
-            accessible={true}
-            allowFontScaling={true}
-            disabled={false}
-            ellipsizeMode="tail"
-            style={
-              Array [
-                Object {
-                  "alignSelf": "center",
-                  "color": "#666666",
-                  "fontFamily": "Avant Garde Gothic ITCW01Dm",
-                  "fontSize": 10,
-                  "marginTop": 8,
-                },
-                undefined,
-              ]
-            }
-            user={undefined}
-          >
-            KK
-          </Text>
-        </View>
-        <View
-          style={
-            Array [
-              Object {
-                "flexBasis": 0,
-                "flexDirection": "column",
-                "flexGrow": 1,
-                "flexShrink": 1,
+                "flexDirection": "row",
               },
               Array [
                 Object {
-                  "marginLeft": 10,
+                  "alignSelf": "stretch",
+                  "marginBottom": 10,
+                  "marginTop": 15,
                 },
                 undefined,
               ],
@@ -159,15 +114,12 @@ exports[`looks correct when rendered 1`] = `
             style={
               Array [
                 Object {
-                  "flexDirection": "row",
+                  "backgroundColor": "#e5e5e5",
+                  "borderRadius": 15,
+                  "height": 30,
+                  "width": 30,
                 },
-                Array [
-                  Object {
-                    "alignSelf": "stretch",
-                    "marginBottom": 10,
-                  },
-                  undefined,
-                ],
+                undefined,
               ]
             }
           >
@@ -179,72 +131,129 @@ exports[`looks correct when rendered 1`] = `
               style={
                 Array [
                   Object {
-                    "color": "black",
-                    "fontSize": 11,
-                    "textAlign": "left",
-                  },
-                  Array [
-                    Object {
-                      "fontSize": 11.5,
-                      "marginRight": 3,
-                    },
-                    undefined,
-                  ],
-                  Object {
+                    "alignSelf": "center",
+                    "color": "#666666",
                     "fontFamily": "Avant Garde Gothic ITCW01Dm",
+                    "fontSize": 10,
+                    "marginTop": 8,
                   },
+                  undefined,
                 ]
               }
+              user={undefined}
             >
-              KIMBERLY KLARK
+              KK
             </Text>
           </View>
-          <Text
-            accessible={true}
-            allowFontScaling={true}
-            disabled={false}
-            ellipsizeMode="tail"
+          <View
             style={
               Array [
                 Object {
-                  "color": "black",
-                  "fontSize": 16,
-                  "textAlign": "left",
-                },
-                Object {
-                  "color": "#cccccc",
-                },
-                Object {},
-                Object {
-                  "fontFamily": "AGaramondPro-Regular",
-                },
-              ]
-            }
-          >
-            Adoro! Por favor envie-me mais informações
-          </Text>
-          <Text
-            accessible={true}
-            allowFontScaling={true}
-            disabled={false}
-            ellipsizeMode="tail"
-            style={
-              Array [
-                Object {
-                  "color": "#cccccc",
-                  "fontFamily": "AGaramondPro-Regular",
+                  "flexBasis": 0,
+                  "flexDirection": "column",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
                 },
                 Array [
                   Object {
-                    "marginTop": 10,
+                    "marginLeft": 10,
                   },
                   undefined,
                 ],
               ]
             }
           >
-            Percy · percy@cat.com
-          </Text>
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexDirection": "row",
+                  },
+                  Array [
+                    Object {
+                      "alignSelf": "stretch",
+                      "marginBottom": 10,
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                disabled={false}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "color": "black",
+                      "fontSize": 11,
+                      "textAlign": "left",
+                    },
+                    Array [
+                      Object {
+                        "fontSize": 11.5,
+                        "marginRight": 3,
+                      },
+                      undefined,
+                    ],
+                    Object {
+                      "fontFamily": "Avant Garde Gothic ITCW01Dm",
+                    },
+                  ]
+                }
+              >
+                KIMBERLY KLARK
+              </Text>
+            </View>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              disabled={false}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "black",
+                    "fontSize": 16,
+                    "textAlign": "left",
+                  },
+                  Object {
+                    "color": "#cccccc",
+                  },
+                  Object {},
+                  Object {
+                    "fontFamily": "AGaramondPro-Regular",
+                  },
+                ]
+              }
+            >
+              Adoro! Por favor envie-me mais informações
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              disabled={false}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "#cccccc",
+                    "fontFamily": "AGaramondPro-Regular",
+                  },
+                  Array [
+                    Object {
+                      "marginTop": 10,
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+            >
+              Percy · percy@cat.com
+            </Text>
+          </View>
         </View>
       </View>
     </View>

--- a/src/lib/Components/Inbox/Conversations/__tests__/__snapshots__/Messages-tests.tsx.snap
+++ b/src/lib/Components/Inbox/Conversations/__tests__/__snapshots__/Messages-tests.tsx.snap
@@ -3,6 +3,14 @@
 exports[`looks correct when rendered 1`] = `
 <RCTScrollView
   ItemSeparatorComponent={[Function]}
+  ListFooterComponent={
+    <ActivityIndicator
+      animating={false}
+      color="#999999"
+      hidesWhenStopped={true}
+      size="small"
+    />
+  }
   data={
     Array [
       Object {
@@ -239,6 +247,25 @@ exports[`looks correct when rendered 1`] = `
           </Text>
         </View>
       </View>
+    </View>
+    <View
+      onLayout={[Function]}
+      style={
+        Object {
+          "transform": Array [
+            Object {
+              "scaleY": -1,
+            },
+          ],
+        }
+      }
+    >
+      <ActivityIndicator
+        animating={false}
+        color="#999999"
+        hidesWhenStopped={true}
+        size="small"
+      />
     </View>
   </View>
 </RCTScrollView>

--- a/src/lib/Components/Inbox/Typography/index.tsx
+++ b/src/lib/Components/Inbox/Typography/index.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import { StyleSheet, Text, TextProperties, TextStyle } from "react-native"
+import styled from "styled-components"
 
 import colors from "../../../../data/colors"
 import fonts from "../../../../data/fonts"

--- a/src/lib/Containers/Conversation.tsx
+++ b/src/lib/Containers/Conversation.tsx
@@ -5,7 +5,7 @@ import { ConnectionHandler } from "relay-runtime"
 
 import { MetadataText, SmallHeadline } from "../Components/Inbox/Typography"
 
-import { ActivityIndicator, FlatList, ImageURISource, NetInfo, View, ViewProperties } from "react-native"
+import { FlatList, ImageURISource, NetInfo, View, ViewProperties } from "react-native"
 
 import styled from "styled-components/native"
 import colors from "../../data/colors"
@@ -59,10 +59,6 @@ const DottedBorder = styled.View`
 
 const MessagesList = styled(FlatList)`
   margin-top: 10;
-`
-
-const LoadingIndicator = styled(ActivityIndicator)`
-  margin-top: 20;
 `
 
 interface Props extends RelayProps {
@@ -162,7 +158,6 @@ export class Conversation extends React.Component<Props, State> {
               </SmallHeadline>
               <PlaceholderView />
             </HeaderTextContainer>
-            <LoadingIndicator animating={this.state.fetchingData} hidesWhenStopped />
           </Header>
           {!this.state.isConnected && <ConnectivityBanner />}
           <Messages

--- a/src/lib/Containers/__tests__/__snapshots__/Conversation-tests.tsx.snap
+++ b/src/lib/Containers/__tests__/__snapshots__/Conversation-tests.tsx.snap
@@ -128,7 +128,6 @@ exports[`displays a connectivity banner when network is down 1`] = `
       </Text>
     </View>
     <RCTScrollView
-      ItemSeparatorComponent={[Function]}
       ListFooterComponent={
         <ActivityIndicator
           animating={false}
@@ -213,18 +212,10 @@ exports[`displays a connectivity banner when network is down 1`] = `
             style={
               Array [
                 Object {
-                  "flexDirection": "row",
+                  "paddingLeft": 20,
+                  "paddingRight": 20,
                 },
-                Array [
-                  Object {
-                    "alignSelf": "stretch",
-                    "marginBottom": 10,
-                    "marginLeft": 20,
-                    "marginRight": 20,
-                    "marginTop": 15,
-                  },
-                  undefined,
-                ],
+                undefined,
               ]
             }
           >
@@ -232,49 +223,13 @@ exports[`displays a connectivity banner when network is down 1`] = `
               style={
                 Array [
                   Object {
-                    "backgroundColor": "#e5e5e5",
-                    "borderRadius": 15,
-                    "height": 30,
-                    "width": 30,
-                  },
-                  undefined,
-                ]
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                disabled={false}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "alignSelf": "center",
-                      "color": "#666666",
-                      "fontFamily": "Avant Garde Gothic ITCW01Dm",
-                      "fontSize": 10,
-                      "marginTop": 8,
-                    },
-                    undefined,
-                  ]
-                }
-                user={undefined}
-              >
-                KK
-              </Text>
-            </View>
-            <View
-              style={
-                Array [
-                  Object {
-                    "flexBasis": 0,
-                    "flexDirection": "column",
-                    "flexGrow": 1,
-                    "flexShrink": 1,
+                    "flexDirection": "row",
                   },
                   Array [
                     Object {
-                      "marginLeft": 10,
+                      "alignSelf": "stretch",
+                      "marginBottom": 10,
+                      "marginTop": 15,
                     },
                     undefined,
                   ],
@@ -285,15 +240,12 @@ exports[`displays a connectivity banner when network is down 1`] = `
                 style={
                   Array [
                     Object {
-                      "flexDirection": "row",
+                      "backgroundColor": "#e5e5e5",
+                      "borderRadius": 15,
+                      "height": 30,
+                      "width": 30,
                     },
-                    Array [
-                      Object {
-                        "alignSelf": "stretch",
-                        "marginBottom": 10,
-                      },
-                      undefined,
-                    ],
+                    undefined,
                   ]
                 }
               >
@@ -305,72 +257,129 @@ exports[`displays a connectivity banner when network is down 1`] = `
                   style={
                     Array [
                       Object {
-                        "color": "black",
-                        "fontSize": 11,
-                        "textAlign": "left",
-                      },
-                      Array [
-                        Object {
-                          "fontSize": 11.5,
-                          "marginRight": 3,
-                        },
-                        undefined,
-                      ],
-                      Object {
+                        "alignSelf": "center",
+                        "color": "#666666",
                         "fontFamily": "Avant Garde Gothic ITCW01Dm",
+                        "fontSize": 10,
+                        "marginTop": 8,
                       },
+                      undefined,
                     ]
                   }
+                  user={undefined}
                 >
-                  KIMBERLY KLARK
+                  KK
                 </Text>
               </View>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                disabled={false}
-                ellipsizeMode="tail"
+              <View
                 style={
                   Array [
                     Object {
-                      "color": "black",
-                      "fontSize": 16,
-                      "textAlign": "left",
-                    },
-                    Object {
-                      "color": "#cccccc",
-                    },
-                    Object {},
-                    Object {
-                      "fontFamily": "AGaramondPro-Regular",
-                    },
-                  ]
-                }
-              >
-                Adoro! Por favor envie-me mais informações
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                disabled={false}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#cccccc",
-                      "fontFamily": "AGaramondPro-Regular",
+                      "flexBasis": 0,
+                      "flexDirection": "column",
+                      "flexGrow": 1,
+                      "flexShrink": 1,
                     },
                     Array [
                       Object {
-                        "marginTop": 10,
+                        "marginLeft": 10,
                       },
                       undefined,
                     ],
                   ]
                 }
               >
-                Percy · percy@cat.com
-              </Text>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "flexDirection": "row",
+                      },
+                      Array [
+                        Object {
+                          "alignSelf": "stretch",
+                          "marginBottom": 10,
+                        },
+                        undefined,
+                      ],
+                    ]
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    disabled={false}
+                    ellipsizeMode="tail"
+                    style={
+                      Array [
+                        Object {
+                          "color": "black",
+                          "fontSize": 11,
+                          "textAlign": "left",
+                        },
+                        Array [
+                          Object {
+                            "fontSize": 11.5,
+                            "marginRight": 3,
+                          },
+                          undefined,
+                        ],
+                        Object {
+                          "fontFamily": "Avant Garde Gothic ITCW01Dm",
+                        },
+                      ]
+                    }
+                  >
+                    KIMBERLY KLARK
+                  </Text>
+                </View>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  disabled={false}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "black",
+                        "fontSize": 16,
+                        "textAlign": "left",
+                      },
+                      Object {
+                        "color": "#cccccc",
+                      },
+                      Object {},
+                      Object {
+                        "fontFamily": "AGaramondPro-Regular",
+                      },
+                    ]
+                  }
+                >
+                  Adoro! Por favor envie-me mais informações
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  disabled={false}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#cccccc",
+                        "fontFamily": "AGaramondPro-Regular",
+                      },
+                      Array [
+                        Object {
+                          "marginTop": 10,
+                        },
+                        undefined,
+                      ],
+                    ]
+                  }
+                >
+                  Percy · percy@cat.com
+                </Text>
+              </View>
             </View>
           </View>
         </View>
@@ -569,7 +578,6 @@ exports[`looks correct when rendered 1`] = `
       </View>
     </View>
     <RCTScrollView
-      ItemSeparatorComponent={[Function]}
       ListFooterComponent={
         <ActivityIndicator
           animating={false}
@@ -654,18 +662,10 @@ exports[`looks correct when rendered 1`] = `
             style={
               Array [
                 Object {
-                  "flexDirection": "row",
+                  "paddingLeft": 20,
+                  "paddingRight": 20,
                 },
-                Array [
-                  Object {
-                    "alignSelf": "stretch",
-                    "marginBottom": 10,
-                    "marginLeft": 20,
-                    "marginRight": 20,
-                    "marginTop": 15,
-                  },
-                  undefined,
-                ],
+                undefined,
               ]
             }
           >
@@ -673,49 +673,13 @@ exports[`looks correct when rendered 1`] = `
               style={
                 Array [
                   Object {
-                    "backgroundColor": "#e5e5e5",
-                    "borderRadius": 15,
-                    "height": 30,
-                    "width": 30,
-                  },
-                  undefined,
-                ]
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                disabled={false}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "alignSelf": "center",
-                      "color": "#666666",
-                      "fontFamily": "Avant Garde Gothic ITCW01Dm",
-                      "fontSize": 10,
-                      "marginTop": 8,
-                    },
-                    undefined,
-                  ]
-                }
-                user={undefined}
-              >
-                KK
-              </Text>
-            </View>
-            <View
-              style={
-                Array [
-                  Object {
-                    "flexBasis": 0,
-                    "flexDirection": "column",
-                    "flexGrow": 1,
-                    "flexShrink": 1,
+                    "flexDirection": "row",
                   },
                   Array [
                     Object {
-                      "marginLeft": 10,
+                      "alignSelf": "stretch",
+                      "marginBottom": 10,
+                      "marginTop": 15,
                     },
                     undefined,
                   ],
@@ -726,15 +690,12 @@ exports[`looks correct when rendered 1`] = `
                 style={
                   Array [
                     Object {
-                      "flexDirection": "row",
+                      "backgroundColor": "#e5e5e5",
+                      "borderRadius": 15,
+                      "height": 30,
+                      "width": 30,
                     },
-                    Array [
-                      Object {
-                        "alignSelf": "stretch",
-                        "marginBottom": 10,
-                      },
-                      undefined,
-                    ],
+                    undefined,
                   ]
                 }
               >
@@ -746,72 +707,129 @@ exports[`looks correct when rendered 1`] = `
                   style={
                     Array [
                       Object {
-                        "color": "black",
-                        "fontSize": 11,
-                        "textAlign": "left",
-                      },
-                      Array [
-                        Object {
-                          "fontSize": 11.5,
-                          "marginRight": 3,
-                        },
-                        undefined,
-                      ],
-                      Object {
+                        "alignSelf": "center",
+                        "color": "#666666",
                         "fontFamily": "Avant Garde Gothic ITCW01Dm",
+                        "fontSize": 10,
+                        "marginTop": 8,
                       },
+                      undefined,
                     ]
                   }
+                  user={undefined}
                 >
-                  KIMBERLY KLARK
+                  KK
                 </Text>
               </View>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                disabled={false}
-                ellipsizeMode="tail"
+              <View
                 style={
                   Array [
                     Object {
-                      "color": "black",
-                      "fontSize": 16,
-                      "textAlign": "left",
-                    },
-                    Object {
-                      "color": "#cccccc",
-                    },
-                    Object {},
-                    Object {
-                      "fontFamily": "AGaramondPro-Regular",
-                    },
-                  ]
-                }
-              >
-                Adoro! Por favor envie-me mais informações
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                disabled={false}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#cccccc",
-                      "fontFamily": "AGaramondPro-Regular",
+                      "flexBasis": 0,
+                      "flexDirection": "column",
+                      "flexGrow": 1,
+                      "flexShrink": 1,
                     },
                     Array [
                       Object {
-                        "marginTop": 10,
+                        "marginLeft": 10,
                       },
                       undefined,
                     ],
                   ]
                 }
               >
-                Percy · percy@cat.com
-              </Text>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "flexDirection": "row",
+                      },
+                      Array [
+                        Object {
+                          "alignSelf": "stretch",
+                          "marginBottom": 10,
+                        },
+                        undefined,
+                      ],
+                    ]
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    disabled={false}
+                    ellipsizeMode="tail"
+                    style={
+                      Array [
+                        Object {
+                          "color": "black",
+                          "fontSize": 11,
+                          "textAlign": "left",
+                        },
+                        Array [
+                          Object {
+                            "fontSize": 11.5,
+                            "marginRight": 3,
+                          },
+                          undefined,
+                        ],
+                        Object {
+                          "fontFamily": "Avant Garde Gothic ITCW01Dm",
+                        },
+                      ]
+                    }
+                  >
+                    KIMBERLY KLARK
+                  </Text>
+                </View>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  disabled={false}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "black",
+                        "fontSize": 16,
+                        "textAlign": "left",
+                      },
+                      Object {
+                        "color": "#cccccc",
+                      },
+                      Object {},
+                      Object {
+                        "fontFamily": "AGaramondPro-Regular",
+                      },
+                    ]
+                  }
+                >
+                  Adoro! Por favor envie-me mais informações
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  disabled={false}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#cccccc",
+                        "fontFamily": "AGaramondPro-Regular",
+                      },
+                      Array [
+                        Object {
+                          "marginTop": 10,
+                        },
+                        undefined,
+                      ],
+                    ]
+                  }
+                >
+                  Percy · percy@cat.com
+                </Text>
+              </View>
             </View>
           </View>
         </View>
@@ -1010,7 +1028,6 @@ exports[`looks correct when rendered 2`] = `
       </View>
     </View>
     <RCTScrollView
-      ItemSeparatorComponent={[Function]}
       ListFooterComponent={
         <ActivityIndicator
           animating={false}
@@ -1095,18 +1112,10 @@ exports[`looks correct when rendered 2`] = `
             style={
               Array [
                 Object {
-                  "flexDirection": "row",
+                  "paddingLeft": 20,
+                  "paddingRight": 20,
                 },
-                Array [
-                  Object {
-                    "alignSelf": "stretch",
-                    "marginBottom": 10,
-                    "marginLeft": 20,
-                    "marginRight": 20,
-                    "marginTop": 15,
-                  },
-                  undefined,
-                ],
+                undefined,
               ]
             }
           >
@@ -1114,49 +1123,13 @@ exports[`looks correct when rendered 2`] = `
               style={
                 Array [
                   Object {
-                    "backgroundColor": "#e5e5e5",
-                    "borderRadius": 15,
-                    "height": 30,
-                    "width": 30,
-                  },
-                  undefined,
-                ]
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                disabled={false}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "alignSelf": "center",
-                      "color": "#666666",
-                      "fontFamily": "Avant Garde Gothic ITCW01Dm",
-                      "fontSize": 10,
-                      "marginTop": 8,
-                    },
-                    undefined,
-                  ]
-                }
-                user={undefined}
-              >
-                KK
-              </Text>
-            </View>
-            <View
-              style={
-                Array [
-                  Object {
-                    "flexBasis": 0,
-                    "flexDirection": "column",
-                    "flexGrow": 1,
-                    "flexShrink": 1,
+                    "flexDirection": "row",
                   },
                   Array [
                     Object {
-                      "marginLeft": 10,
+                      "alignSelf": "stretch",
+                      "marginBottom": 10,
+                      "marginTop": 15,
                     },
                     undefined,
                   ],
@@ -1167,15 +1140,12 @@ exports[`looks correct when rendered 2`] = `
                 style={
                   Array [
                     Object {
-                      "flexDirection": "row",
+                      "backgroundColor": "#e5e5e5",
+                      "borderRadius": 15,
+                      "height": 30,
+                      "width": 30,
                     },
-                    Array [
-                      Object {
-                        "alignSelf": "stretch",
-                        "marginBottom": 10,
-                      },
-                      undefined,
-                    ],
+                    undefined,
                   ]
                 }
               >
@@ -1187,72 +1157,129 @@ exports[`looks correct when rendered 2`] = `
                   style={
                     Array [
                       Object {
-                        "color": "black",
-                        "fontSize": 11,
-                        "textAlign": "left",
-                      },
-                      Array [
-                        Object {
-                          "fontSize": 11.5,
-                          "marginRight": 3,
-                        },
-                        undefined,
-                      ],
-                      Object {
+                        "alignSelf": "center",
+                        "color": "#666666",
                         "fontFamily": "Avant Garde Gothic ITCW01Dm",
+                        "fontSize": 10,
+                        "marginTop": 8,
                       },
+                      undefined,
                     ]
                   }
+                  user={undefined}
                 >
-                  KIMBERLY KLARK
+                  KK
                 </Text>
               </View>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                disabled={false}
-                ellipsizeMode="tail"
+              <View
                 style={
                   Array [
                     Object {
-                      "color": "black",
-                      "fontSize": 16,
-                      "textAlign": "left",
-                    },
-                    Object {
-                      "color": "#cccccc",
-                    },
-                    Object {},
-                    Object {
-                      "fontFamily": "AGaramondPro-Regular",
-                    },
-                  ]
-                }
-              >
-                Adoro! Por favor envie-me mais informações
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                disabled={false}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#cccccc",
-                      "fontFamily": "AGaramondPro-Regular",
+                      "flexBasis": 0,
+                      "flexDirection": "column",
+                      "flexGrow": 1,
+                      "flexShrink": 1,
                     },
                     Array [
                       Object {
-                        "marginTop": 10,
+                        "marginLeft": 10,
                       },
                       undefined,
                     ],
                   ]
                 }
               >
-                Percy · percy@cat.com
-              </Text>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "flexDirection": "row",
+                      },
+                      Array [
+                        Object {
+                          "alignSelf": "stretch",
+                          "marginBottom": 10,
+                        },
+                        undefined,
+                      ],
+                    ]
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    disabled={false}
+                    ellipsizeMode="tail"
+                    style={
+                      Array [
+                        Object {
+                          "color": "black",
+                          "fontSize": 11,
+                          "textAlign": "left",
+                        },
+                        Array [
+                          Object {
+                            "fontSize": 11.5,
+                            "marginRight": 3,
+                          },
+                          undefined,
+                        ],
+                        Object {
+                          "fontFamily": "Avant Garde Gothic ITCW01Dm",
+                        },
+                      ]
+                    }
+                  >
+                    KIMBERLY KLARK
+                  </Text>
+                </View>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  disabled={false}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "black",
+                        "fontSize": 16,
+                        "textAlign": "left",
+                      },
+                      Object {
+                        "color": "#cccccc",
+                      },
+                      Object {},
+                      Object {
+                        "fontFamily": "AGaramondPro-Regular",
+                      },
+                    ]
+                  }
+                >
+                  Adoro! Por favor envie-me mais informações
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  disabled={false}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#cccccc",
+                        "fontFamily": "AGaramondPro-Regular",
+                      },
+                      Array [
+                        Object {
+                          "marginTop": 10,
+                        },
+                        undefined,
+                      ],
+                    ]
+                  }
+                >
+                  Percy · percy@cat.com
+                </Text>
+              </View>
             </View>
           </View>
         </View>

--- a/src/lib/Containers/__tests__/__snapshots__/Conversation-tests.tsx.snap
+++ b/src/lib/Containers/__tests__/__snapshots__/Conversation-tests.tsx.snap
@@ -92,20 +92,6 @@ exports[`displays a connectivity banner when network is down 1`] = `
         </Text>
         <View />
       </View>
-      <ActivityIndicator
-        animating={false}
-        color="#999999"
-        hidesWhenStopped={true}
-        size="small"
-        style={
-          Array [
-            Object {
-              "marginTop": 20,
-            },
-            undefined,
-          ]
-        }
-      />
     </View>
     <View
       style={
@@ -143,6 +129,14 @@ exports[`displays a connectivity banner when network is down 1`] = `
     </View>
     <RCTScrollView
       ItemSeparatorComponent={[Function]}
+      ListFooterComponent={
+        <ActivityIndicator
+          animating={false}
+          color="#999999"
+          hidesWhenStopped={true}
+          size="small"
+        />
+      }
       data={
         Array [
           Object {
@@ -379,6 +373,25 @@ exports[`displays a connectivity banner when network is down 1`] = `
               </Text>
             </View>
           </View>
+        </View>
+        <View
+          onLayout={[Function]}
+          style={
+            Object {
+              "transform": Array [
+                Object {
+                  "scaleY": -1,
+                },
+              ],
+            }
+          }
+        >
+          <ActivityIndicator
+            animating={false}
+            color="#999999"
+            hidesWhenStopped={true}
+            size="small"
+          />
         </View>
       </View>
     </RCTScrollView>
@@ -554,23 +567,17 @@ exports[`looks correct when rendered 1`] = `
         </Text>
         <View />
       </View>
-      <ActivityIndicator
-        animating={false}
-        color="#999999"
-        hidesWhenStopped={true}
-        size="small"
-        style={
-          Array [
-            Object {
-              "marginTop": 20,
-            },
-            undefined,
-          ]
-        }
-      />
     </View>
     <RCTScrollView
       ItemSeparatorComponent={[Function]}
+      ListFooterComponent={
+        <ActivityIndicator
+          animating={false}
+          color="#999999"
+          hidesWhenStopped={true}
+          size="small"
+        />
+      }
       data={
         Array [
           Object {
@@ -808,6 +815,25 @@ exports[`looks correct when rendered 1`] = `
             </View>
           </View>
         </View>
+        <View
+          onLayout={[Function]}
+          style={
+            Object {
+              "transform": Array [
+                Object {
+                  "scaleY": -1,
+                },
+              ],
+            }
+          }
+        >
+          <ActivityIndicator
+            animating={false}
+            color="#999999"
+            hidesWhenStopped={true}
+            size="small"
+          />
+        </View>
       </View>
     </RCTScrollView>
   </View>
@@ -982,23 +1008,17 @@ exports[`looks correct when rendered 2`] = `
         </Text>
         <View />
       </View>
-      <ActivityIndicator
-        animating={false}
-        color="#999999"
-        hidesWhenStopped={true}
-        size="small"
-        style={
-          Array [
-            Object {
-              "marginTop": 20,
-            },
-            undefined,
-          ]
-        }
-      />
     </View>
     <RCTScrollView
       ItemSeparatorComponent={[Function]}
+      ListFooterComponent={
+        <ActivityIndicator
+          animating={false}
+          color="#999999"
+          hidesWhenStopped={true}
+          size="small"
+        />
+      }
       data={
         Array [
           Object {
@@ -1235,6 +1255,25 @@ exports[`looks correct when rendered 2`] = `
               </Text>
             </View>
           </View>
+        </View>
+        <View
+          onLayout={[Function]}
+          style={
+            Object {
+              "transform": Array [
+                Object {
+                  "scaleY": -1,
+                },
+              ],
+            }
+          }
+        >
+          <ActivityIndicator
+            animating={false}
+            color="#999999"
+            hidesWhenStopped={true}
+            size="small"
+          />
         </View>
       </View>
     </RCTScrollView>

--- a/src/lib/Containers/__tests__/__snapshots__/Inbox-tests.tsx.snap
+++ b/src/lib/Containers/__tests__/__snapshots__/Inbox-tests.tsx.snap
@@ -653,7 +653,7 @@ exports[`renders correctly 1`] = `
                     },
                     Array [
                       Object {
-                        "marginBottom": 3,
+                        "marginBottom": 15,
                         "marginLeft": 15,
                       },
                       undefined,
@@ -940,7 +940,7 @@ exports[`renders correctly 1`] = `
                     },
                     Array [
                       Object {
-                        "marginBottom": 3,
+                        "marginBottom": 15,
                         "marginLeft": 15,
                       },
                       undefined,


### PR DESCRIPTION
Closes: https://github.com/artsy/emission/issues/753

Misc UI fixes:

- It fixes the UI layout of `ConversationSnippet` component as the rows are off by a few pixels

Before:
<img src="https://user-images.githubusercontent.com/296775/30618323-e0e56b94-9d67-11e7-9989-6cc6d2d566bd.png" width="200" />

After:
<img src="https://user-images.githubusercontent.com/296775/30618346-f686f56c-9d67-11e7-807e-da3309c077fa.png" width="200" />

- It also fixes the separator styling in the message component, we were missing the padding around it and the last row should not have a separator under it.
<img src="https://user-images.githubusercontent.com/296775/30618401-40c8a936-9d68-11e7-97c8-e4da4499c37e.png" width="200" />

- It also moves the loading indicator inside of the messages list view so that it doesn't always appear if the user is scrolling slower than the time needed to load the next page.

It also includes a re-bind of the `space` key in Emission. As of now, we aren't able to hit space as it's used as a toggle for hiding/showing the black back button in the simulator. After this PR, the binding will `ctrl+space` and `space` will return to its default binding.

This shows a loading indicator inside the list view when a user scrolls up fast.

Skip New Tests