### PR TITLE
[Dependencies] Updated react tracking to 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "react-native-parallax-scroll-view": "https://github.com/orta/react-native-parallax-scroll-view",
     "react-native-sentry": "^0.14.5",
     "react-relay": "https://github.com/alloy/relay/releases/download/v1.3.0-artsy/react-relay-1.3.0-artsy.1.tgz",
-    "react-tracking": "https://github.com/mennenia/react-tracking#artsy-reacttracking-messaging",
+    "react-tracking": "^5.0.0",
     "relay-runtime": "https://github.com/alloy/relay/releases/download/v1.3.0-artsy/relay-runtime-artsy.1.tgz",
     "remove-markdown": "0.1.0",
     "styled-components": "^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7050,9 +7050,9 @@ react-timer-mixin@^0.13.2:
   version "0.13.3"
   resolved "https://registry.yarnpkg.com/react-timer-mixin/-/react-timer-mixin-0.13.3.tgz#0da8b9f807ec07dc3e854d082c737c65605b3d22"
 
-"react-tracking@https://github.com/mennenia/react-tracking#artsy-reacttracking-messaging":
-  version "4.2.1"
-  resolved "https://github.com/mennenia/react-tracking#9f68f3cf585156e1622b3088d157ad3886b80cc9"
+react-tracking@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/react-tracking/-/react-tracking-5.0.0.tgz#bb42209a3197089d7c8eb2a1926c1b3b61f6afef"
   dependencies:
     lodash.merge "^4.6.0"
 


### PR DESCRIPTION
Release notes [here](https://github.com/NYTimes/react-tracking/releases/tag/v5.0.0)

Basically: it adds the use of `state` within the track decorators 🎉 