### PR TITLE
[Inquiry] Hide partner response rate for now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 ###### Messaging
 
+-   Temporarily removed partner response rate in inquiry - maxim
 -   Fixed payment request component collapsing and minor UI changes - luc
 -   Added support for live open auctions for active bids - sarah
 -   Fixed separator styling in the message component - luc

--- a/src/lib/Containers/Inquiry.tsx
+++ b/src/lib/Containers/Inquiry.tsx
@@ -128,7 +128,7 @@ export class Inquiry extends React.Component<RelayProps, any> {
 
   render() {
     const message = this.state.text
-    const partnerResponseRate = "2 DAY RESPONSE TIME" // currently hardcoded
+    const partnerResponseRate = " " // currently hardcoded for alignment
     const artwork = this.props.artwork
     const partnerName = this.props.artwork.partner.name
     const buttonText = this.state.sending ? "SENDING..." : "SEND"
@@ -158,7 +158,7 @@ export class Inquiry extends React.Component<RelayProps, any> {
                   {partnerName}
                 </SmallHeadline>
                 <ResponseRateLine>
-                  <ResponseIndicator />
+                  {/* <ResponseIndicator /> */}
                   <ResponseRate>
                     {partnerResponseRate}
                   </ResponseRate>

--- a/src/lib/Containers/__tests__/__snapshots__/Inquiry-tests.tsx.snap
+++ b/src/lib/Containers/__tests__/__snapshots__/Inquiry-tests.tsx.snap
@@ -156,21 +156,6 @@ exports[`renders correctly 1`] = `
                 ]
               }
             >
-              <View
-                style={
-                  Array [
-                    Object {
-                      "backgroundColor": "#f1af1b",
-                      "borderRadius": 4,
-                      "height": 8,
-                      "marginRight": 5,
-                      "marginTop": 5,
-                      "width": 8,
-                    },
-                    undefined,
-                  ]
-                }
-              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -197,7 +182,7 @@ exports[`renders correctly 1`] = `
                   ]
                 }
               >
-                2 DAY RESPONSE TIME
+                 
               </Text>
             </View>
           </View>


### PR DESCRIPTION
The response rate was hardcoded and isn't available in metaphysics (from my search). As requested during planning meetings, we'll remove it now and add this information in the next phase.

Instead of completely ripping it out (it causes alignment issues with the cancel button), I've cheekily made it an empty string... 

![simulator screen shot 27 sep 2017 14 27 31](https://user-images.githubusercontent.com/373860/30916073-5e2ee4bc-a390-11e7-9248-cbf6497d1ca9.png)
