### PR TITLE
[Crash] Fix case where node can be null and accessing last_message results in crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 
 ###### Messaging
 
+-   Fix crash of empty node in conversation list - maxim
 -   Hyperlinks in messages are now artsy purple & underlined - sarah
 -   Aligns message header with existing back button - sarah
 -   Temporarily removed partner response rate in inquiry - maxim

--- a/src/lib/Components/Inbox/Conversations/index.tsx
+++ b/src/lib/Components/Inbox/Conversations/index.tsx
@@ -74,7 +74,9 @@ export class Conversations extends React.Component<Props, State> {
     }
     const conversations = me.conversations.edges
       .filter(({ node }) => {
-        return node.last_message
+        if (node) {
+          return node.last_message
+        }
       })
       .map(edge => edge.node)
     return conversations || []

--- a/src/lib/Components/Inbox/Conversations/index.tsx
+++ b/src/lib/Components/Inbox/Conversations/index.tsx
@@ -74,9 +74,7 @@ export class Conversations extends React.Component<Props, State> {
     }
     const conversations = me.conversations.edges
       .filter(({ node }) => {
-        if (node) {
-          return node.last_message
-        }
+        return node && node.last_message
       })
       .map(edge => edge.node)
     return conversations || []


### PR DESCRIPTION
This might be the crash we've intermittently been seeing in Emission.

I came across it during the analytics work, I inquired a few times in a row, and I feel like one got sent out with an empty message body / not fully loaded message. This shouldn't at all be an issue, I just remember the inquiry screen flashing up. I could not reproduce what it is that I had submitted. 

But it ended up meaning that on Matt's test account there's this one corrupted message (lack of better explanation), that ends up in this error:

![simulator screen shot - iphone 6 - 9 1 - 2017-10-30 at 16 44 36](https://user-images.githubusercontent.com/373860/32250782-38658ec2-be64-11e7-9832-a2c24754addb.png)

And I put a quick guard up (see code changes from this PR).

Given that Emission now loads the latest in master, I noticed that it was crashing when logging in with the test account and opening the Inbox, but if you check out the analytics PR for example (where the crash fix lived originally), it works ok. 

So, I'm extracting it out for now, given that I've got Enzyme / React-tracking stuff to fix in that branch 😄 

Skip New Tests