### PR TITLE
[Crash] guard against conversations_existence_check being null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 
 ###### Messaging
 
+-   Fix crash by guarding against null `conversations_existence_check` - christina
 -   Fix crash of empty node in conversation list - maxim
 -   Hyperlinks in messages are now artsy purple & underlined - sarah
 -   Aligns message header with existing back button - sarah

--- a/src/lib/Containers/Inbox.tsx
+++ b/src/lib/Containers/Inbox.tsx
@@ -46,7 +46,8 @@ export class Inbox extends React.Component<Props, State> {
 
   render() {
     const hasBids = this.props.me.lot_standings.length > 0
-    const hasConversations = this.props.me.conversations_existence_check.edges.length > 0
+    const hasConversations =
+      this.props.me.conversations_existence_check && this.props.me.conversations_existence_check.edges.length > 0
     return hasBids || hasConversations
       ? <Container refreshControl={<RefreshControl refreshing={this.state.fetchingData} onRefresh={this.fetchData} />}>
           <ActiveBids me={this.props.me as any} />


### PR DESCRIPTION
**The error message caused by `this.props.me.conversations_existence_check` being `null`:**
![simulator screen shot - iphone 6 - 2017-11-01 at 17 11 31](https://user-images.githubusercontent.com/5201004/32298133-c3b9e7d4-bf27-11e7-8323-bd26d3c286dd.png)

**After the null check:**
![simulator screen shot - iphone 6 - 2017-11-01 at 17 10 14](https://user-images.githubusercontent.com/5201004/32298089-9ee9f20a-bf27-11e7-93af-213ee967e8bf.png)
