### PR TITLE
[Home] Fix/hack tab labels to be centered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 -   Adds Sale container to app registry - ash
 -   QA for Home: change tab colors - maxim
 -   QA Inquiry screen - maxim
+-   QA for Home: center tab labels with thin space hack - maxim
 
 ### 1.4.0-beta.5
 

--- a/src/lib/Scenes/Home/index.tsx
+++ b/src/lib/Scenes/Home/index.tsx
@@ -26,9 +26,9 @@ export default class Home extends React.Component<null, null> {
   render() {
     return (
       <ScrollableTabView renderTabBar={() => <TabBar />}>
-        {/* A thin space has been added in front of the tab label names to compensate for trailing space
-        added by the wider letter-spacing. Going forward,
-        this would ideally be dealt with through letter indentation.  */}
+        {/* FIXME:
+        A thin space has been added in front of the tab label names to compensate for trailing space added by the
+        wider letter-spacing. Going forward, this would ideally be dealt with through letter indentation. */}
         <Tab tabLabel=" Artists">
           <WorksForYouRenderer render={renderWithLoadProgress(WorksForYou)} />
         </Tab>

--- a/src/lib/Scenes/Home/index.tsx
+++ b/src/lib/Scenes/Home/index.tsx
@@ -26,13 +26,16 @@ export default class Home extends React.Component<null, null> {
   render() {
     return (
       <ScrollableTabView renderTabBar={() => <TabBar />}>
-        <Tab tabLabel="Artists">
+        {/* A thin space has been added in front of the tab label names to compensate for trailing space
+        added by the wider letter-spacing. Going forward,
+        this would ideally be dealt with through letter indentation.  */}
+        <Tab tabLabel=" Artists">
           <WorksForYouRenderer render={renderWithLoadProgress(WorksForYou)} />
         </Tab>
-        <Tab tabLabel="For You">
+        <Tab tabLabel=" For You">
           <ForYouRenderer render={renderWithLoadProgress(ForYou)} />
         </Tab>
-        <Tab tabLabel="Auctions">
+        <Tab tabLabel=" Auctions">
           <SalesRenderer render={renderWithLoadProgress(Sales)} />
         </Tab>
       </ScrollableTabView>


### PR DESCRIPTION
Weird spaces to the rescue!

Fixes #[CE650](https://github.com/artsy/collector-experience/issues/650)

Previous context to this issue [in this PR](https://github.com/artsy/emission/pull/826), including some images that measure the offset/glitch etc. 

So, when you increase letterspacing, this little gap / added spacing at the end of your text component grows also. This makes it seem off centre, but apparently is [expected behaviour](https://stackoverflow.com/questions/23044432/css-negate-additional-space-added-to-last-letter-by-letter-spacing-property). 

Ideally you would be able to indent text through styling, and this would be applied appropriately at the start of a new paragraph. Alas, this is not available in styling of RN. It seems [possible within Core Text](https://developer.apple.com/documentation/coretext/ctparagraphstyle-2ej), and it may be a style that one could expose through RN. Letter-spacing in itself is an [iOS only property](https://facebook.github.io/react-native/docs/text.html#style)

So, for the time being I’ve added a [_thin space_](https://en.wikipedia.org/wiki/Thin_space) to the beginning of each label. This is a smaller space, that happens to work out perfectly in this case. (the world of whitespace is far and wide. Did you know that Farsi has a non-breaking space that doesn’t actually take up space? If you’re curious feel free to ping me haha I used to be all about this)

Current (zoomed in)
<img width="930" alt="screen shot 2017-11-16 at 19 25 09" src="https://user-images.githubusercontent.com/373860/32912473-10d9e484-cb07-11e7-9acf-5b0d0168499f.png">

Current (overall)
![simulator screen shot - iphone 6 - 9 1 - 2017-11-16 at 19 41 34](https://user-images.githubusercontent.com/373860/32912476-11ad34e2-cb07-11e7-873d-91341299e4fa.png)

 


