### PR TITLE
[QA] Inbox for iPad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 -   Home now includes a call to action for consignments - orta
 -   QA for Home: center tab labels with thin space hack - maxim
 -   Removes ‘works by artists you follow’ rail from ForYou view - alloy
+-   QA for Inbox view: center and cap size on iPad and solid line separator - maxim
 
 ### 1.4.0-beta.5
 

--- a/src/lib/Components/Inbox/Conversations/ConversationSnippet.tsx
+++ b/src/lib/Components/Inbox/Conversations/ConversationSnippet.tsx
@@ -69,6 +69,11 @@ const ImageView = styled(OpaqueImageView)`
   border-radius: 4px;
 `
 
+const SeparatorLine = styled.View`
+  height: 1;
+  background-color: ${colors["gray-regular"]};
+`
+
 export interface Conversation {
   id: string | null
   to: {
@@ -172,7 +177,7 @@ export class ConversationSnippet extends React.Component<Props, any> {
               </P>
             </TextPreview>
           </CardContent>
-          <DottedLine />
+          <SeparatorLine />
         </Card>
       </TouchableWithoutFeedback>
     )

--- a/src/lib/Components/Inbox/Conversations/ConversationSnippet.tsx
+++ b/src/lib/Components/Inbox/Conversations/ConversationSnippet.tsx
@@ -4,13 +4,15 @@ import { createFragmentContainer, graphql } from "react-relay"
 
 import { MetadataText, PreviewText as P, SmallHeadline } from "../Typography"
 
-import { StyleSheet, TouchableWithoutFeedback, ViewStyle } from "react-native"
+import { Dimensions, StyleSheet, TouchableWithoutFeedback, ViewStyle } from "react-native"
 
 import DottedLine from "lib/Components/DottedLine"
 import OpaqueImageView from "lib/Components/OpaqueImageView"
 import colors from "lib/data/colors"
 import fonts from "lib/data/fonts"
 import styled from "styled-components/native"
+
+const isPad = Dimensions.get("window").width > 700
 
 const Card = styled.View`
   margin: 10px 20px 0;
@@ -29,6 +31,8 @@ const HorizontalLayout = styled.View`
 
 const CardContent = styled(HorizontalLayout)`
   justify-content: space-between;
+  align-self: center;
+  max-width: 708;
 `
 
 const TextPreview = styled(VerticalLayout)`
@@ -72,6 +76,7 @@ const ImageView = styled(OpaqueImageView)`
 const SeparatorLine = styled.View`
   height: 1;
   background-color: ${colors["gray-regular"]};
+  ${isPad ? "align-self: center; width: 708;" : ""};
 `
 
 export interface Conversation {

--- a/src/lib/Components/Inbox/Conversations/ConversationSnippet.tsx
+++ b/src/lib/Components/Inbox/Conversations/ConversationSnippet.tsx
@@ -8,8 +8,8 @@ import { Dimensions, StyleSheet, TouchableWithoutFeedback, ViewStyle } from "rea
 
 import DottedLine from "lib/Components/DottedLine"
 import OpaqueImageView from "lib/Components/OpaqueImageView"
-import colors from "lib/data/colors"
-import fonts from "lib/data/fonts"
+import { Colors } from "lib/data/colors"
+import { Fonts } from "lib/data/fonts"
 import styled from "styled-components/native"
 
 const isPad = Dimensions.get("window").width > 700
@@ -49,14 +49,14 @@ const UnreadIndicator = styled.View`
   height: 8;
   width: 8;
   border-radius: 4;
-  background-color: ${colors["purple-regular"]};
+  background-color: ${Colors.PurpleRegular};
   margin-left: 4;
   margin-top: 3;
   margin-bottom: 3;
 `
 
 const Subtitle = styled.Text`
-  font-family: ${fonts["garamond-regular"]};
+  font-family: ${Fonts.GaramondRegular};
   font-size: 16px;
   color: black;
   margin-top: 6;
@@ -64,7 +64,7 @@ const Subtitle = styled.Text`
 `
 
 const Title = styled(Subtitle)`
-  font-family: ${fonts["garamond-italic"]};
+  font-family: ${Fonts.GaramondItalic};
 `
 
 const ImageView = styled(OpaqueImageView)`
@@ -75,7 +75,7 @@ const ImageView = styled(OpaqueImageView)`
 
 const SeparatorLine = styled.View`
   height: 1;
-  background-color: ${colors["gray-regular"]};
+  background-color: ${Colors.GrayRegular};
   ${isPad ? "align-self: center; width: 708;" : ""};
 `
 

--- a/src/lib/Components/Inbox/Conversations/__tests__/__snapshots__/ConversationSnippet-tests.tsx.snap
+++ b/src/lib/Components/Inbox/Conversations/__tests__/__snapshots__/ConversationSnippet-tests.tsx.snap
@@ -40,7 +40,9 @@ exports[`renders correctly with a show 1`] = `
         },
         Array [
           Object {
+            "alignSelf": "center",
             "justifyContent": "space-between",
+            "maxWidth": 708,
           },
           undefined,
         ],
@@ -251,12 +253,17 @@ exports[`renders correctly with a show 1`] = `
       </Text>
     </View>
   </View>
-  <ARDottedLine
-    color={4291611852}
+  <View
     style={
-      Object {
-        "height": 2,
-      }
+      Array [
+        Object {
+          "alignSelf": "center",
+          "backgroundColor": "#e5e5e5",
+          "height": 1,
+          "width": 708,
+        },
+        undefined,
+      ]
     }
   />
 </View>
@@ -302,7 +309,9 @@ exports[`renders correctly with an artwork 1`] = `
         },
         Array [
           Object {
+            "alignSelf": "center",
             "justifyContent": "space-between",
+            "maxWidth": 708,
           },
           undefined,
         ],
@@ -558,12 +567,17 @@ exports[`renders correctly with an artwork 1`] = `
       </Text>
     </View>
   </View>
-  <ARDottedLine
-    color={4291611852}
+  <View
     style={
-      Object {
-        "height": 2,
-      }
+      Array [
+        Object {
+          "alignSelf": "center",
+          "backgroundColor": "#e5e5e5",
+          "height": 1,
+          "width": 708,
+        },
+        undefined,
+      ]
     }
   />
 </View>

--- a/src/lib/Components/Inbox/Conversations/__tests__/__snapshots__/Conversations-tests.tsx.snap
+++ b/src/lib/Components/Inbox/Conversations/__tests__/__snapshots__/Conversations-tests.tsx.snap
@@ -88,7 +88,9 @@ exports[`looks correct when rendered 1`] = `
               },
               Array [
                 Object {
+                  "alignSelf": "center",
                   "justifyContent": "space-between",
+                  "maxWidth": 708,
                 },
                 undefined,
               ],
@@ -328,12 +330,17 @@ exports[`looks correct when rendered 1`] = `
             </Text>
           </View>
         </View>
-        <ARDottedLine
-          color={4291611852}
+        <View
           style={
-            Object {
-              "height": 2,
-            }
+            Array [
+              Object {
+                "alignSelf": "center",
+                "backgroundColor": "#e5e5e5",
+                "height": 1,
+                "width": 708,
+              },
+              undefined,
+            ]
           }
         />
       </View>
@@ -376,7 +383,9 @@ exports[`looks correct when rendered 1`] = `
               },
               Array [
                 Object {
+                  "alignSelf": "center",
                   "justifyContent": "space-between",
+                  "maxWidth": 708,
                 },
                 undefined,
               ],
@@ -616,12 +625,17 @@ exports[`looks correct when rendered 1`] = `
             </Text>
           </View>
         </View>
-        <ARDottedLine
-          color={4291611852}
+        <View
           style={
-            Object {
-              "height": 2,
-            }
+            Array [
+              Object {
+                "alignSelf": "center",
+                "backgroundColor": "#e5e5e5",
+                "height": 1,
+                "width": 708,
+              },
+              undefined,
+            ]
           }
         />
       </View>

--- a/src/lib/Containers/__tests__/__snapshots__/Inbox-tests.tsx.snap
+++ b/src/lib/Containers/__tests__/__snapshots__/Inbox-tests.tsx.snap
@@ -622,7 +622,9 @@ exports[`renders correctly 1`] = `
                   },
                   Array [
                     Object {
+                      "alignSelf": "center",
                       "justifyContent": "space-between",
+                      "maxWidth": 708,
                     },
                     undefined,
                   ],
@@ -862,12 +864,17 @@ exports[`renders correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <ARDottedLine
-              color={4291611852}
+            <View
               style={
-                Object {
-                  "height": 2,
-                }
+                Array [
+                  Object {
+                    "alignSelf": "center",
+                    "backgroundColor": "#e5e5e5",
+                    "height": 1,
+                    "width": 708,
+                  },
+                  undefined,
+                ]
               }
             />
           </View>
@@ -910,7 +917,9 @@ exports[`renders correctly 1`] = `
                   },
                   Array [
                     Object {
+                      "alignSelf": "center",
                       "justifyContent": "space-between",
+                      "maxWidth": 708,
                     },
                     undefined,
                   ],
@@ -1150,12 +1159,17 @@ exports[`renders correctly 1`] = `
                 </Text>
               </View>
             </View>
-            <ARDottedLine
-              color={4291611852}
+            <View
               style={
-                Object {
-                  "height": 2,
-                }
+                Array [
+                  Object {
+                    "alignSelf": "center",
+                    "backgroundColor": "#e5e5e5",
+                    "height": 1,
+                    "width": 708,
+                  },
+                  undefined,
+                ]
               }
             />
           </View>


### PR DESCRIPTION
Fixes #[CE640](https://github.com/artsy/collector-experience/issues/640)

- max width for iPad + centered content
- replace dotted line with solid line (😥)

Also replaced colors and fonts with enums for `ConversationSnippet`. Will do this as I touch old files. 

iPhone:

![simulator screen shot - iphone 6 - 9 1 - 2017-11-17 at 14 53 10](https://user-images.githubusercontent.com/373860/32953486-3fb87a1c-cba8-11e7-91ba-b9779e977ad6.png)


iPad (pro), P/L : 

![simulator screen shot - ipad pro 12 9 inch - 2017-11-17 at 14 48 37](https://user-images.githubusercontent.com/373860/32953493-43fd90c6-cba8-11e7-9625-a31fb6442f15.png)

![simulator screen shot - ipad pro 12 9 inch - 2017-11-17 at 14 48 39](https://user-images.githubusercontent.com/373860/32953498-47a80896-cba8-11e7-9eee-e29f97969e8e.png)
