### PR TITLE
[QA] Update composer/message thread screen for iPad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Master
 
 -   Don’t require 2 taps to open a conversation attachment and keep keyboard up - alloy
+-   QA for composer/thread view: ipad and fixed iphone size attachments - maxim
 
 ### 1.4.0-beta.8
 

--- a/src/lib/Components/Inbox/Conversations/Composer.tsx
+++ b/src/lib/Components/Inbox/Conversations/Composer.tsx
@@ -24,6 +24,11 @@ const Container = styled.View`
   background-color: ${(p: ContainerProps) => (p.active ? "white" : colors["gray-light"])};
 `
 
+const StyledKeyboardAvoidingView = styled.KeyboardAvoidingView`
+  flex: 1;
+  ${isPad ? "width: 708; align-self: center;" : ""};
+`
+
 interface StyledSendButtonProps {
   disabled: boolean
 }
@@ -90,20 +95,10 @@ export default class Composer extends React.Component<Props, State> {
       paddingRight: 10,
     }
 
-    const mainViewStyle: ViewStyle = isPad
-      ? {
-          width: 708,
-          alignSelf: "center",
-          flex: 1,
-        }
-      : {
-          flex: 1,
-        }
-
     const disableSendButton = !(this.state.text && this.state.text.length) || this.props.disabled
 
     return (
-      <KeyboardAvoidingView behavior="padding" keyboardVerticalOffset={20} style={mainViewStyle}>
+      <StyledKeyboardAvoidingView behavior="padding" keyboardVerticalOffset={20}>
         {this.props.children}
         <Container active={this.state.active}>
           <TextInput
@@ -123,7 +118,7 @@ export default class Composer extends React.Component<Props, State> {
             <SendButton disabled={disableSendButton}>SEND</SendButton>
           </TouchableWithoutFeedback>
         </Container>
-      </KeyboardAvoidingView>
+      </StyledKeyboardAvoidingView>
     )
   }
 }

--- a/src/lib/Components/Inbox/Conversations/Composer.tsx
+++ b/src/lib/Components/Inbox/Conversations/Composer.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Dimensions, KeyboardAvoidingView, TextInput, TouchableWithoutFeedback } from "react-native"
+import { Dimensions, KeyboardAvoidingView, TextInput, TouchableWithoutFeedback, ViewStyle } from "react-native"
 
 import colors from "lib/data/colors"
 import fonts from "lib/data/fonts"
@@ -90,7 +90,7 @@ export default class Composer extends React.Component<Props, State> {
       paddingRight: 10,
     }
 
-    const mainViewStyle = isPad
+    const mainViewStyle: ViewStyle = isPad
       ? {
           width: 708,
           alignSelf: "center",

--- a/src/lib/Components/Inbox/Conversations/Composer.tsx
+++ b/src/lib/Components/Inbox/Conversations/Composer.tsx
@@ -1,11 +1,13 @@
 import React from "react"
-import { KeyboardAvoidingView, TextInput, TouchableWithoutFeedback } from "react-native"
+import { Dimensions, KeyboardAvoidingView, TextInput, TouchableWithoutFeedback } from "react-native"
 
 import colors from "lib/data/colors"
 import fonts from "lib/data/fonts"
 import styled from "styled-components/native"
 
 import { Schema, Track, track as _track } from "../../../utils/track"
+
+const isPad = Dimensions.get("window").width > 700
 
 interface ContainerProps {
   active: boolean
@@ -88,10 +90,20 @@ export default class Composer extends React.Component<Props, State> {
       paddingRight: 10,
     }
 
+    const mainViewStyle = isPad
+      ? {
+          width: 708,
+          alignSelf: "center",
+          flex: 1,
+        }
+      : {
+          flex: 1,
+        }
+
     const disableSendButton = !(this.state.text && this.state.text.length) || this.props.disabled
 
     return (
-      <KeyboardAvoidingView behavior="padding" keyboardVerticalOffset={20} style={{ flex: 1 }}>
+      <KeyboardAvoidingView behavior="padding" keyboardVerticalOffset={20} style={mainViewStyle}>
         {this.props.children}
         <Container active={this.state.active}>
           <TextInput

--- a/src/lib/Components/Inbox/Conversations/Message.tsx
+++ b/src/lib/Components/Inbox/Conversations/Message.tsx
@@ -67,7 +67,10 @@ const Seperator = styled(DottedLine)`
   padding-right: 20;
 `
 
-const PreviewContainer = styled.View`margin-bottom: 10;`
+const PreviewContainer = styled.View`
+  margin-bottom: 10;
+  width: 295;
+`
 
 interface Props extends RelayProps {
   senderName: string

--- a/src/lib/Components/Inbox/Conversations/Messages.tsx
+++ b/src/lib/Components/Inbox/Conversations/Messages.tsx
@@ -7,6 +7,8 @@ import Message from "./Message"
 import ArtworkPreview from "./Preview/ArtworkPreview"
 import ShowPreview from "./Preview/ShowPreview"
 
+const isPad = Dimensions.get("window").width > 700
+
 interface Props {
   conversation?: RelayProps["me"]["conversation"]
   relay?: RelayPaginationProp
@@ -101,6 +103,13 @@ export class Messages extends React.Component<Props, State> {
     })
     const refreshControl = <RefreshControl refreshing={this.state.reloadingData} onRefresh={this.reload.bind(this)} />
 
+    const messagesStyles = isPad
+      ? {
+          width: 708,
+          alignSelf: "center",
+        }
+      : {}
+
     return (
       <FlatList
         inverted={!this.state.shouldStickFirstMessageToTop}
@@ -126,6 +135,7 @@ export class Messages extends React.Component<Props, State> {
           })
         }}
         refreshControl={refreshControl}
+        style={messagesStyles}
         ListFooterComponent={<ActivityIndicator animating={this.state.fetchingMoreData} hidesWhenStopped />}
       />
     )

--- a/src/lib/Components/Inbox/Conversations/__tests__/__snapshots__/Composer-tests.tsx.snap
+++ b/src/lib/Components/Inbox/Conversations/__tests__/__snapshots__/Composer-tests.tsx.snap
@@ -6,11 +6,16 @@ exports[`looks correct when rendered 1`] = `
   onLayout={[Function]}
   style={
     Array [
-      Object {
-        "alignSelf": "center",
-        "flex": 1,
-        "width": 708,
-      },
+      Array [
+        Object {
+          "alignSelf": "center",
+          "flexBasis": 0,
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "width": 708,
+        },
+        undefined,
+      ],
       Object {
         "paddingBottom": 0,
       },
@@ -163,11 +168,6 @@ ShallowWrapper {
         </Styled(View)>,
       ],
       "keyboardVerticalOffset": 20,
-      "style": Object {
-        "alignSelf": "center",
-        "flex": 1,
-        "width": 708,
-      },
     },
     "ref": null,
     "rendered": Array [
@@ -324,11 +324,6 @@ ShallowWrapper {
           </Styled(View)>,
         ],
         "keyboardVerticalOffset": 20,
-        "style": Object {
-          "alignSelf": "center",
-          "flex": 1,
-          "width": 708,
-        },
       },
       "ref": null,
       "rendered": Array [
@@ -455,11 +450,16 @@ exports[`regarding the send button disables it when there is no text 1`] = `
   onLayout={[Function]}
   style={
     Array [
-      Object {
-        "alignSelf": "center",
-        "flex": 1,
-        "width": 708,
-      },
+      Array [
+        Object {
+          "alignSelf": "center",
+          "flexBasis": 0,
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "width": 708,
+        },
+        undefined,
+      ],
       Object {
         "paddingBottom": 0,
       },

--- a/src/lib/Components/Inbox/Conversations/__tests__/__snapshots__/Composer-tests.tsx.snap
+++ b/src/lib/Components/Inbox/Conversations/__tests__/__snapshots__/Composer-tests.tsx.snap
@@ -7,7 +7,9 @@ exports[`looks correct when rendered 1`] = `
   style={
     Array [
       Object {
+        "alignSelf": "center",
         "flex": 1,
+        "width": 708,
       },
       Object {
         "paddingBottom": 0,
@@ -162,7 +164,9 @@ ShallowWrapper {
       ],
       "keyboardVerticalOffset": 20,
       "style": Object {
+        "alignSelf": "center",
         "flex": 1,
+        "width": 708,
       },
     },
     "ref": null,
@@ -321,7 +325,9 @@ ShallowWrapper {
         ],
         "keyboardVerticalOffset": 20,
         "style": Object {
+          "alignSelf": "center",
           "flex": 1,
+          "width": 708,
         },
       },
       "ref": null,
@@ -450,7 +456,9 @@ exports[`regarding the send button disables it when there is no text 1`] = `
   style={
     Array [
       Object {
+        "alignSelf": "center",
         "flex": 1,
+        "width": 708,
       },
       Object {
         "paddingBottom": 0,

--- a/src/lib/Components/Inbox/Conversations/__tests__/__snapshots__/Message-tests.tsx.snap
+++ b/src/lib/Components/Inbox/Conversations/__tests__/__snapshots__/Message-tests.tsx.snap
@@ -158,6 +158,7 @@ exports[`looks correct when rendered 1`] = `
           Array [
             Object {
               "marginBottom": 10,
+              "width": 295,
             },
             undefined,
           ]

--- a/src/lib/Components/Inbox/Conversations/__tests__/__snapshots__/Messages-tests.tsx.snap
+++ b/src/lib/Components/Inbox/Conversations/__tests__/__snapshots__/Messages-tests.tsx.snap
@@ -64,7 +64,10 @@ exports[`looks correct when rendered 1`] = `
           },
         ],
       },
-      undefined,
+      Object {
+        "alignSelf": "center",
+        "width": 708,
+      },
     ]
   }
   updateCellsBatchingPeriod={50}


### PR DESCRIPTION
Fixes https://github.com/artsy/collector-experience/issues/639

iPhone has stayed the same:

![simulator screen shot - iphone 6 - 9 1 - 2017-11-21 at 12 22 28](https://user-images.githubusercontent.com/373860/33072946-3614544a-ceb9-11e7-9354-068cf3342990.png)

iPad Portrait:

![simulator screen shot - ipad pro 12 9 inch - 2017-11-21 at 12 32 28](https://user-images.githubusercontent.com/373860/33073003-666edd36-ceb9-11e7-958d-3b6a4cc29c00.png)

iPad Landscape:

![simulator screen shot - ipad pro 12 9 inch - 2017-11-21 at 12 23 01](https://user-images.githubusercontent.com/373860/33073015-6df2a592-ceb9-11e7-8d52-b7330ad91d85.png)


FYI:
The no-connection banner has also been shrunk to 708 max width:
(please ignore the attachments being so wide, I took this screencap before I had fixed that)
![simulator screen shot - ipad pro 12 9 inch - 2017-11-21 at 10 46 25](https://user-images.githubusercontent.com/373860/33073097-a75b2ed0-ceb9-11e7-940b-cd3ea849426b.png)
