### PR TITLE
[QA] Message attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 -   Don’t require 2 taps to open a conversation attachment and keep keyboard up - alloy
 -   QA for composer/thread view: ipad and fixed iphone size attachments - maxim
+-   QA for message attachments - maxim
 
 ### 1.4.0-beta.8
 

--- a/src/lib/Components/Inbox/Conversations/Preview/ArtworkPreview.tsx
+++ b/src/lib/Components/Inbox/Conversations/Preview/ArtworkPreview.tsx
@@ -8,13 +8,13 @@ import { PreviewText as P, Subtitle } from "../../Typography"
 import { Schema, Track, track as _track } from "../../../../utils/track"
 
 import OpaqueImageView from "lib/Components/OpaqueImageView"
-import colors from "lib/data/colors"
-import fonts from "lib/data/fonts"
+import { Colors } from "lib/data/colors"
+import { Fonts } from "lib/data/fonts"
 import styled from "styled-components/native"
 
 const Container = styled.View`
   border-width: 1;
-  border-color: ${colors["gray-regular"]};
+  border-color: ${Colors.GrayRegular};
   flex-direction: row;
 `
 
@@ -39,6 +39,8 @@ const TextContainer = styled(VerticalLayout)`
 const SerifText = styled(P)`
   font-size: 14;
 `
+
+const Date = styled.Text`font-family: ${Fonts.GaramondRegular};`
 
 const TitleAndDate = styled.View`
   margin-top: 3;
@@ -69,7 +71,7 @@ export class ArtworkPreview extends React.Component<Props, any> {
     const artwork = this.props.artwork
 
     return (
-      <TouchableHighlight underlayColor={colors["gray-light"]} onPress={() => this.attachmentSelected()}>
+      <TouchableHighlight underlayColor={Colors.GrayLight} onPress={() => this.attachmentSelected()}>
         <Container>
           <Image imageURL={artwork.image.url} />
           <TextContainer>
@@ -78,10 +80,10 @@ export class ArtworkPreview extends React.Component<Props, any> {
             </SerifText>
             <TitleAndDate>
               {/* Nested Text components are necessary for the correct behaviour on both short and long titles + dates */}
-              <Text numberOfLines={1} ellipsizeMode={"middle"} style={{ fontFamily: fonts["garamond-italic"] }}>
+              <Subtitle numberOfLines={1} ellipsizeMode={"middle"}>
                 {`${artwork.title}`}
-                <Text style={{ fontFamily: fonts["garamond-regular"] }}>{`, ${artwork.date}`}</Text>
-              </Text>
+                <Date>{`, ${artwork.date}`}</Date>
+              </Subtitle>
             </TitleAndDate>
           </TextContainer>
         </Container>

--- a/src/lib/Components/Inbox/Conversations/Preview/ArtworkPreview.tsx
+++ b/src/lib/Components/Inbox/Conversations/Preview/ArtworkPreview.tsx
@@ -26,13 +26,13 @@ const VerticalLayout = styled.View`
 const Image = styled(OpaqueImageView)`
   margin-top: 12;
   margin-left: 12;
+  margin-right: 12;
   margin-bottom: 12;
   width: 80;
   height: 55;
 `
 
 const TextContainer = styled(VerticalLayout)`
-  margin-left: 25;
   align-self: center;
 `
 

--- a/src/lib/Components/Inbox/Conversations/Preview/ArtworkPreview.tsx
+++ b/src/lib/Components/Inbox/Conversations/Preview/ArtworkPreview.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 
-import { TouchableHighlight } from "react-native"
+import { Text, TouchableHighlight } from "react-native"
 
 import { PreviewText as P, Subtitle } from "../../Typography"
 
@@ -42,19 +42,10 @@ const SerifText = styled(P)`
 
 const TitleAndDate = styled.View`
   margin-top: 3;
+  margin-right: 12;
   flex-direction: row;
+  justify-content: flex-start;
 `
-
-const Title = styled.Text`
-  font-family: ${fonts["garamond-italic"]};
-  flex: 3;
-  font-size: 14;
-`
-
-const Date = styled(SerifText)`
-  flex: 1;
-`
-
 interface Props extends RelayProps {
   onSelected?: () => void
 }
@@ -86,10 +77,11 @@ export class ArtworkPreview extends React.Component<Props, any> {
               {artwork.artist_names}
             </SerifText>
             <TitleAndDate>
-              <Title numberOfLines={1}>
-                {artwork.title}
-              </Title>
-              {!!artwork.date && <Date>{`, ${artwork.date}`}</Date>}
+              {/* Nested Text components are necessary for the correct behaviour on both short and long titles + dates */}
+              <Text numberOfLines={1} ellipsizeMode={"middle"} style={{ fontFamily: fonts["garamond-italic"] }}>
+                {`${artwork.title}`}
+                <Text style={{ fontFamily: fonts["garamond-regular"] }}>{`, ${artwork.date}`}</Text>
+              </Text>
             </TitleAndDate>
           </TextContainer>
         </Container>

--- a/src/lib/Components/Inbox/Conversations/Preview/Attachment/PDFPreview.tsx
+++ b/src/lib/Components/Inbox/Conversations/Preview/Attachment/PDFPreview.tsx
@@ -18,7 +18,6 @@ const Container = styled.View`
 const TextContainer = styled.View`
   flex: 1;
   flex-direction: column;
-  margin-left: 25;
   align-self: center;
 `
 
@@ -27,6 +26,7 @@ const Icon = styled(Image)`
   width: 40;
   margin-top: 12;
   margin-left: 12;
+  margin-right: 12;
   margin-bottom: 12;
 `
 

--- a/src/lib/Components/Inbox/Conversations/Preview/Attachment/__tests__/__snapshots__/PDFPreview-tests.tsx.snap
+++ b/src/lib/Components/Inbox/Conversations/Preview/Attachment/__tests__/__snapshots__/PDFPreview-tests.tsx.snap
@@ -60,6 +60,7 @@ exports[`renders correctly 1`] = `
             Object {
               "marginBottom": 12,
               "marginLeft": 12,
+              "marginRight": 12,
               "marginTop": 12,
               "resizeMode": "contain",
               "width": 40,
@@ -77,7 +78,6 @@ exports[`renders correctly 1`] = `
               "flexDirection": "column",
               "flexGrow": 1,
               "flexShrink": 1,
-              "marginLeft": 25,
             },
             undefined,
           ]

--- a/src/lib/Components/Inbox/Conversations/Preview/InvoicePreview.tsx
+++ b/src/lib/Components/Inbox/Conversations/Preview/InvoicePreview.tsx
@@ -20,7 +20,6 @@ const Container = styled.View`
 const TextContainer = styled.View`
   flex: 1;
   flex-direction: column;
-  margin-left: 10;
   align-self: center;
 `
 
@@ -29,6 +28,7 @@ const Icon = styled(Image)`
   width: 40;
   margin-top: 12;
   margin-left: 12;
+  margin-right: 12;
   margin-bottom: 12;
 `
 

--- a/src/lib/Components/Inbox/Conversations/Preview/ShowPreview.tsx
+++ b/src/lib/Components/Inbox/Conversations/Preview/ShowPreview.tsx
@@ -26,13 +26,13 @@ const VerticalLayout = styled.View`
 const Image = styled(OpaqueImageView)`
   margin-top: 12;
   margin-left: 12;
+  margin-right: 12;
   margin-bottom: 12;
   width: 80;
   height: 55;
 `
 
 const TextContainer = styled(VerticalLayout)`
-  margin-left: 25;
   margin-top: 25;
   align-self: center;
 `

--- a/src/lib/Components/Inbox/Conversations/Preview/__tests__/__snapshots__/ArtworkPreview-tests.tsx.snap
+++ b/src/lib/Components/Inbox/Conversations/Preview/__tests__/__snapshots__/ArtworkPreview-tests.tsx.snap
@@ -48,6 +48,7 @@ exports[`handles dateless artworks 1`] = `
             "height": 55,
             "marginBottom": 12,
             "marginLeft": 12,
+            "marginRight": 12,
             "marginTop": 12,
             "width": 80,
           },
@@ -67,7 +68,6 @@ exports[`handles dateless artworks 1`] = `
           Array [
             Object {
               "alignSelf": "center",
-              "marginLeft": 25,
             },
             undefined,
           ],
@@ -187,6 +187,7 @@ exports[`renders correctly 1`] = `
             "height": 55,
             "marginBottom": 12,
             "marginLeft": 12,
+            "marginRight": 12,
             "marginTop": 12,
             "width": 80,
           },
@@ -206,7 +207,6 @@ exports[`renders correctly 1`] = `
           Array [
             Object {
               "alignSelf": "center",
-              "marginLeft": 25,
             },
             undefined,
           ],

--- a/src/lib/Components/Inbox/Conversations/Preview/__tests__/__snapshots__/ArtworkPreview-tests.tsx.snap
+++ b/src/lib/Components/Inbox/Conversations/Preview/__tests__/__snapshots__/ArtworkPreview-tests.tsx.snap
@@ -106,6 +106,8 @@ exports[`handles dateless artworks 1`] = `
           Array [
             Object {
               "flexDirection": "row",
+              "justifyContent": "flex-start",
+              "marginRight": 12,
               "marginTop": 3,
             },
             undefined,
@@ -116,22 +118,28 @@ exports[`handles dateless artworks 1`] = `
           accessible={true}
           allowFontScaling={true}
           disabled={false}
-          ellipsizeMode="tail"
+          ellipsizeMode="middle"
           numberOfLines={1}
           style={
-            Array [
-              Object {
-                "flexBasis": 0,
-                "flexGrow": 3,
-                "flexShrink": 1,
-                "fontFamily": "AGaramondPro-Italic",
-                "fontSize": 14,
-              },
-              undefined,
-            ]
+            Object {
+              "fontFamily": "AGaramondPro-Italic",
+            }
           }
         >
           Karl and Anna Face Off (Diptych)
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            disabled={false}
+            ellipsizeMode="tail"
+            style={
+              Object {
+                "fontFamily": "AGaramondPro-Regular",
+              }
+            }
+          >
+            , 
+          </Text>
         </Text>
       </View>
     </View>
@@ -245,6 +253,8 @@ exports[`renders correctly 1`] = `
           Array [
             Object {
               "flexDirection": "row",
+              "justifyContent": "flex-start",
+              "marginRight": 12,
               "marginTop": 3,
             },
             undefined,
@@ -255,56 +265,28 @@ exports[`renders correctly 1`] = `
           accessible={true}
           allowFontScaling={true}
           disabled={false}
-          ellipsizeMode="tail"
+          ellipsizeMode="middle"
           numberOfLines={1}
           style={
-            Array [
-              Object {
-                "flexBasis": 0,
-                "flexGrow": 3,
-                "flexShrink": 1,
-                "fontFamily": "AGaramondPro-Italic",
-                "fontSize": 14,
-              },
-              undefined,
-            ]
+            Object {
+              "fontFamily": "AGaramondPro-Italic",
+            }
           }
         >
           Karl and Anna Face Off (Diptych)
-        </Text>
-        <Text
-          accessible={true}
-          allowFontScaling={true}
-          disabled={false}
-          ellipsizeMode="tail"
-          numberOfLines={1}
-          style={
-            Array [
-              Object {
-                "color": "black",
-                "fontSize": 16,
-                "textAlign": "left",
-              },
-              Array [
-                Object {
-                  "fontSize": 14,
-                },
-                Array [
-                  Object {
-                    "flexBasis": 0,
-                    "flexGrow": 1,
-                    "flexShrink": 1,
-                  },
-                  undefined,
-                ],
-              ],
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            disabled={false}
+            ellipsizeMode="tail"
+            style={
               Object {
                 "fontFamily": "AGaramondPro-Regular",
-              },
-            ]
-          }
-        >
-          , 2016
+              }
+            }
+          >
+            , 2016
+          </Text>
         </Text>
       </View>
     </View>

--- a/src/lib/Components/Inbox/Conversations/Preview/__tests__/__snapshots__/ArtworkPreview-tests.tsx.snap
+++ b/src/lib/Components/Inbox/Conversations/Preview/__tests__/__snapshots__/ArtworkPreview-tests.tsx.snap
@@ -118,12 +118,18 @@ exports[`handles dateless artworks 1`] = `
           accessible={true}
           allowFontScaling={true}
           disabled={false}
-          ellipsizeMode="middle"
-          numberOfLines={1}
+          ellipsizeMode="tail"
           style={
-            Object {
-              "fontFamily": "AGaramondPro-Italic",
-            }
+            Array [
+              Object {
+                "color": "black",
+                "fontSize": 14,
+              },
+              Object {},
+              Object {
+                "fontFamily": "AGaramondPro-Italic",
+              },
+            ]
           }
         >
           Karl and Anna Face Off (Diptych)
@@ -133,9 +139,12 @@ exports[`handles dateless artworks 1`] = `
             disabled={false}
             ellipsizeMode="tail"
             style={
-              Object {
-                "fontFamily": "AGaramondPro-Regular",
-              }
+              Array [
+                Object {
+                  "fontFamily": "AGaramondPro-Regular",
+                },
+                undefined,
+              ]
             }
           >
             , 
@@ -265,12 +274,18 @@ exports[`renders correctly 1`] = `
           accessible={true}
           allowFontScaling={true}
           disabled={false}
-          ellipsizeMode="middle"
-          numberOfLines={1}
+          ellipsizeMode="tail"
           style={
-            Object {
-              "fontFamily": "AGaramondPro-Italic",
-            }
+            Array [
+              Object {
+                "color": "black",
+                "fontSize": 14,
+              },
+              Object {},
+              Object {
+                "fontFamily": "AGaramondPro-Italic",
+              },
+            ]
           }
         >
           Karl and Anna Face Off (Diptych)
@@ -280,9 +295,12 @@ exports[`renders correctly 1`] = `
             disabled={false}
             ellipsizeMode="tail"
             style={
-              Object {
-                "fontFamily": "AGaramondPro-Regular",
-              }
+              Array [
+                Object {
+                  "fontFamily": "AGaramondPro-Regular",
+                },
+                undefined,
+              ]
             }
           >
             , 2016

--- a/src/lib/Components/Inbox/Conversations/Preview/__tests__/__snapshots__/InvoicePreview-tests.tsx.snap
+++ b/src/lib/Components/Inbox/Conversations/Preview/__tests__/__snapshots__/InvoicePreview-tests.tsx.snap
@@ -21,6 +21,7 @@ exports[`InvoicePreview renders correctly 1`] = `
         Object {
           "marginBottom": 12,
           "marginLeft": 12,
+          "marginRight": 12,
           "marginTop": 12,
           "resizeMode": "contain",
           "width": 40,
@@ -38,7 +39,6 @@ exports[`InvoicePreview renders correctly 1`] = `
           "flexDirection": "column",
           "flexGrow": 1,
           "flexShrink": 1,
-          "marginLeft": 10,
         },
         undefined,
       ]
@@ -93,7 +93,6 @@ exports[`InvoicePreview renders correctly 1`] = `
           "flexDirection": "column",
           "flexGrow": 1,
           "flexShrink": 1,
-          "marginLeft": 10,
         },
         undefined,
       ]

--- a/src/lib/Components/Inbox/Conversations/Preview/__tests__/__snapshots__/ShowPreview-tests.tsx.snap
+++ b/src/lib/Components/Inbox/Conversations/Preview/__tests__/__snapshots__/ShowPreview-tests.tsx.snap
@@ -48,6 +48,7 @@ exports[`renders correctly for a fair booth 1`] = `
             "height": 55,
             "marginBottom": 12,
             "marginLeft": 12,
+            "marginRight": 12,
             "marginTop": 12,
             "width": 80,
           },
@@ -67,7 +68,6 @@ exports[`renders correctly for a fair booth 1`] = `
           Array [
             Object {
               "alignSelf": "center",
-              "marginLeft": 25,
               "marginTop": 25,
             },
             undefined,
@@ -176,6 +176,7 @@ exports[`renders correctly for a regular show 1`] = `
             "height": 55,
             "marginBottom": 12,
             "marginLeft": 12,
+            "marginRight": 12,
             "marginTop": 12,
             "width": 80,
           },
@@ -195,7 +196,6 @@ exports[`renders correctly for a regular show 1`] = `
           Array [
             Object {
               "alignSelf": "center",
-              "marginLeft": 25,
               "marginTop": 25,
             },
             undefined,

--- a/src/lib/Components/Inbox/Conversations/__tests__/__snapshots__/Message-tests.tsx.snap
+++ b/src/lib/Components/Inbox/Conversations/__tests__/__snapshots__/Message-tests.tsx.snap
@@ -184,6 +184,7 @@ exports[`looks correct when rendered 1`] = `
                 Object {
                   "marginBottom": 12,
                   "marginLeft": 12,
+                  "marginRight": 12,
                   "marginTop": 12,
                   "resizeMode": "contain",
                   "width": 40,
@@ -201,7 +202,6 @@ exports[`looks correct when rendered 1`] = `
                   "flexDirection": "column",
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "marginLeft": 10,
                 },
                 undefined,
               ]
@@ -256,7 +256,6 @@ exports[`looks correct when rendered 1`] = `
                   "flexDirection": "column",
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "marginLeft": 10,
                 },
                 undefined,
               ]

--- a/src/lib/Containers/__tests__/__snapshots__/Inquiry-tests.tsx.snap
+++ b/src/lib/Containers/__tests__/__snapshots__/Inquiry-tests.tsx.snap
@@ -281,6 +281,7 @@ exports[`renders correctly 1`] = `
                     "height": 55,
                     "marginBottom": 12,
                     "marginLeft": 12,
+                    "marginRight": 12,
                     "marginTop": 12,
                     "width": 80,
                   },
@@ -300,7 +301,6 @@ exports[`renders correctly 1`] = `
                   Array [
                     Object {
                       "alignSelf": "center",
-                      "marginLeft": 25,
                     },
                     undefined,
                   ],

--- a/src/lib/Containers/__tests__/__snapshots__/Inquiry-tests.tsx.snap
+++ b/src/lib/Containers/__tests__/__snapshots__/Inquiry-tests.tsx.snap
@@ -351,12 +351,18 @@ exports[`renders correctly 1`] = `
                   accessible={true}
                   allowFontScaling={true}
                   disabled={false}
-                  ellipsizeMode="middle"
-                  numberOfLines={1}
+                  ellipsizeMode="tail"
                   style={
-                    Object {
-                      "fontFamily": "AGaramondPro-Italic",
-                    }
+                    Array [
+                      Object {
+                        "color": "black",
+                        "fontSize": 14,
+                      },
+                      Object {},
+                      Object {
+                        "fontFamily": "AGaramondPro-Italic",
+                      },
+                    ]
                   }
                 >
                   Karl and Anna Face Off (Diptych)
@@ -366,9 +372,12 @@ exports[`renders correctly 1`] = `
                     disabled={false}
                     ellipsizeMode="tail"
                     style={
-                      Object {
-                        "fontFamily": "AGaramondPro-Regular",
-                      }
+                      Array [
+                        Object {
+                          "fontFamily": "AGaramondPro-Regular",
+                        },
+                        undefined,
+                      ]
                     }
                   >
                     , 2016

--- a/src/lib/Containers/__tests__/__snapshots__/Inquiry-tests.tsx.snap
+++ b/src/lib/Containers/__tests__/__snapshots__/Inquiry-tests.tsx.snap
@@ -339,6 +339,8 @@ exports[`renders correctly 1`] = `
                   Array [
                     Object {
                       "flexDirection": "row",
+                      "justifyContent": "flex-start",
+                      "marginRight": 12,
                       "marginTop": 3,
                     },
                     undefined,
@@ -349,56 +351,28 @@ exports[`renders correctly 1`] = `
                   accessible={true}
                   allowFontScaling={true}
                   disabled={false}
-                  ellipsizeMode="tail"
+                  ellipsizeMode="middle"
                   numberOfLines={1}
                   style={
-                    Array [
-                      Object {
-                        "flexBasis": 0,
-                        "flexGrow": 3,
-                        "flexShrink": 1,
-                        "fontFamily": "AGaramondPro-Italic",
-                        "fontSize": 14,
-                      },
-                      undefined,
-                    ]
+                    Object {
+                      "fontFamily": "AGaramondPro-Italic",
+                    }
                   }
                 >
                   Karl and Anna Face Off (Diptych)
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  disabled={false}
-                  ellipsizeMode="tail"
-                  numberOfLines={1}
-                  style={
-                    Array [
-                      Object {
-                        "color": "black",
-                        "fontSize": 16,
-                        "textAlign": "left",
-                      },
-                      Array [
-                        Object {
-                          "fontSize": 14,
-                        },
-                        Array [
-                          Object {
-                            "flexBasis": 0,
-                            "flexGrow": 1,
-                            "flexShrink": 1,
-                          },
-                          undefined,
-                        ],
-                      ],
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    disabled={false}
+                    ellipsizeMode="tail"
+                    style={
                       Object {
                         "fontFamily": "AGaramondPro-Regular",
-                      },
-                    ]
-                  }
-                >
-                  , 2016
+                      }
+                    }
+                  >
+                    , 2016
+                  </Text>
                 </Text>
               </View>
             </View>


### PR DESCRIPTION
Fixes most of https://github.com/artsy/collector-experience/issues/636

### The weird extra pixel

So... in code, the border is `1px` everywhere. On the simulator, I'm getting the extra pixel on the top line (see screenshots below), on device it's indeed the right border. It seems like a drawing glitch or something, but there isn't much in straight up CSS that I can do. We can create a separate ticket to investigate further? 

### Margins:

Show attachment margins:
![showattachment](https://user-images.githubusercontent.com/373860/33142140-5f4ce5a8-cfad-11e7-8159-36a56704d6fd.png)

Artwork attachment margins:
![artworkattc](https://user-images.githubusercontent.com/373860/33142142-5f6c922c-cfad-11e7-8194-940b25aef1e8.png)

Invoice attachment margins:
![invoiceattch](https://user-images.githubusercontent.com/373860/33142143-5f87742a-cfad-11e7-9295-fc4fa61c8a1a.png)

### Weird spacing gap:

Short artwork title:
![simulator screen shot - iphone 6 - 9 1 - 2017-11-22 at 17 37 25](https://user-images.githubusercontent.com/373860/33142180-792313e4-cfad-11e7-8592-fdd24182e78b.png)

Long artwork title:
(please note, the truncation has slightly changed. Sorry @katarinabatina this was the only way I could make it work..) 
![simulator screen shot - iphone 6 - 9 1 - 2017-11-22 at 17 35 28](https://user-images.githubusercontent.com/373860/33142210-8acb2d02-cfad-11e7-9893-ce839574841d.png)


