### PR TITLE
[Home] QA on header text sizes and spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 -   Don’t assume a photo was selected in the consignments photo picker - alloy
 -   QA for composer/thread view: ipad and fixed iphone size attachments - maxim
 -   QA for message attachments - maxim
+-   QA for home header font sizes and margins - maxim
 
 ### 1.4.0-beta.8
 

--- a/src/lib/Components/Home/ArtistRails/ArtistRail.tsx
+++ b/src/lib/Components/Home/ArtistRails/ArtistRail.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
 
-import { Animated, Easing, ScrollView, StyleSheet, View, ViewProperties, ViewStyle } from "react-native"
+import { Animated, Easing, ScrollView, StyleSheet, TextStyle, View, ViewProperties, ViewStyle } from "react-native"
 
 import metaphysics from "../../../metaphysics"
 
@@ -162,13 +162,16 @@ class ArtistRail extends React.Component<Props, State> {
   }
 
   title() {
+    return "Artists to Follow:"
+  }
+  subtitle() {
     switch (this.props.rail.key) {
       case "TRENDING":
-        return "Artists to Follow: Trending"
+        return "Trending on Artsy"
       case "SUGGESTED":
-        return "Artists to Follow: Recommended for You"
+        return "Recommended for You"
       case "POPULAR":
-        return "Artists to Follow: Popular"
+        return "Popular on Artsy"
     }
   }
 
@@ -183,6 +186,9 @@ class ArtistRail extends React.Component<Props, State> {
           <SectionTitle>
             {this.title()}
           </SectionTitle>
+          <SectionTitle style={styles.subtitle}>
+            {this.subtitle()}
+          </SectionTitle>
         </View>
         {this.renderModuleResults()}
         <Separator />
@@ -194,6 +200,7 @@ class ArtistRail extends React.Component<Props, State> {
 interface Styles {
   cardContainer: ViewStyle
   title: ViewStyle
+  subtitle: TextStyle
 }
 
 const styles = StyleSheet.create<Styles>({
@@ -208,6 +215,10 @@ const styles = StyleSheet.create<Styles>({
     marginRight: 20,
     marginTop: 30,
     marginBottom: 10,
+  },
+  subtitle: {
+    fontSize: 20,
+    fontFamily: "AGaramondPro-Regular",
   },
 })
 

--- a/src/lib/Components/Home/ArtistRails/ArtistRail.tsx
+++ b/src/lib/Components/Home/ArtistRails/ArtistRail.tsx
@@ -204,9 +204,9 @@ const styles = StyleSheet.create<Styles>({
     minHeight: 320,
   },
   title: {
-    marginLeft: 30,
-    marginRight: 30,
-    marginTop: 40,
+    marginLeft: 20,
+    marginRight: 20,
+    marginTop: 30,
     marginBottom: 10,
   },
 })

--- a/src/lib/Components/Home/ArtistRails/ArtistRail.tsx
+++ b/src/lib/Components/Home/ArtistRails/ArtistRail.tsx
@@ -201,7 +201,7 @@ const styles = StyleSheet.create<Styles>({
     flexGrow: 1,
     flexDirection: "row",
     marginTop: 10,
-    minHeight: 330,
+    minHeight: 320,
   },
   title: {
     marginLeft: 30,

--- a/src/lib/Components/Home/SectionTitle.tsx
+++ b/src/lib/Components/Home/SectionTitle.tsx
@@ -25,6 +25,6 @@ const styles = StyleSheet.create<Styles>({
   headerText: {
     fontFamily: "AGaramondPro-Regular",
     fontSize: 30,
-    textAlign: "center",
+    textAlign: "left",
   },
 })

--- a/src/lib/Scenes/Home/Components/ForYou/Components/ArtworkCarouselHeader.tsx
+++ b/src/lib/Scenes/Home/Components/ForYou/Components/ArtworkCarouselHeader.tsx
@@ -52,10 +52,10 @@ class ArtworkCarouselHeader extends React.Component<Props & RelayPropsWorkaround
     return (
       <TouchableWithoutFeedback onPress={this.props.handleViewAll}>
         <View style={styles.container}>
-          {this.props.rail.context && this.followAnnotation()}
           <SectionTitle>
             {this.props.rail.title}
           </SectionTitle>
+          {this.props.rail.context && this.followAnnotation()}
           {this.actionButton()}
         </View>
       </TouchableWithoutFeedback>
@@ -82,7 +82,8 @@ class ArtworkCarouselHeader extends React.Component<Props & RelayPropsWorkaround
     if (this.hasAdditionalContent()) {
       return (
         <Text style={styles.viewAllButton}>
-          {" "}{"View All".toUpperCase()}{" "}
+          {""}
+          {"View All".toUpperCase()}{" "}
         </Text>
       )
     } else if (this.props.rail.key === "related_artists" || this.props.rail.key === "followed_artist") {
@@ -119,7 +120,6 @@ class ArtworkCarouselHeader extends React.Component<Props & RelayPropsWorkaround
 
 interface Styles {
   container: ViewStyle
-  title: TextStyle
   viewAllButton: TextStyle
   followButton: ViewStyle
   followAnnotation: TextStyle
@@ -127,7 +127,7 @@ interface Styles {
 
 const styles = StyleSheet.create<Styles>({
   container: {
-    marginTop: isPad ? 40 : 20,
+    marginTop: isPad ? 40 : 30,
     marginBottom: 20,
     marginLeft: 20,
     marginRight: 20,
@@ -135,27 +135,22 @@ const styles = StyleSheet.create<Styles>({
     flexDirection: "column",
     alignItems: "flex-start",
   },
-  title: {
-    marginTop: 10,
-    fontSize: isPad ? 30 : 26,
-    textAlign: "center",
-  },
   viewAllButton: {
     fontFamily: fonts["avant-garde-regular"],
     fontSize: isPad ? 14 : 12,
     color: colors["gray-medium"],
     letterSpacing: 0.5,
     padding: 0,
+    marginTop: -5,
   },
   followButton: {
-    marginTop: 10,
+    marginTop: 5,
     marginBottom: 0,
     height: 30,
     width: 90,
   },
   followAnnotation: {
-    fontStyle: "italic",
-    fontSize: 16,
+    fontSize: 20,
   },
 })
 

--- a/src/lib/Scenes/Home/Components/ForYou/Components/__tests__/__snapshots__/FairsRail-tests.tsx.snap
+++ b/src/lib/Scenes/Home/Components/ForYou/Components/__tests__/__snapshots__/FairsRail-tests.tsx.snap
@@ -35,7 +35,7 @@ exports[`looks correct when rendered 1`] = `
       style={
         Object {
           "fontFamily": "AGaramondPro-Regular",
-          "fontSize": 25,
+          "fontSize": 30,
           "textAlign": "left",
         }
       }

--- a/src/lib/Scenes/Home/Components/Sales/__tests__/__snapshots__/index-tests.tsx.snap
+++ b/src/lib/Scenes/Home/Components/Sales/__tests__/__snapshots__/index-tests.tsx.snap
@@ -161,7 +161,7 @@ exports[`looks correct when rendered 1`] = `
             Array [
               Object {
                 "fontFamily": "AGaramondPro-Regular",
-                "fontSize": 25,
+                "fontSize": 30,
                 "marginLeft": 2,
                 "textAlign": "left",
               },
@@ -680,7 +680,7 @@ exports[`looks correct when rendered 1`] = `
             Array [
               Object {
                 "fontFamily": "AGaramondPro-Regular",
-                "fontSize": 25,
+                "fontSize": 30,
                 "marginLeft": 2,
                 "textAlign": "left",
               },

--- a/src/lib/Scenes/Home/Components/Sales/index.tsx
+++ b/src/lib/Scenes/Home/Components/Sales/index.tsx
@@ -21,7 +21,7 @@ const SectionHeader = styled.View`
 
 const SectionTitle = styled.Text`
   font-family: ${fonts["garamond-regular"]};
-  font-size: 25px;
+  font-size: 30px;
   text-align: left;
   margin-left: 2px;
 `

--- a/src/lib/Scenes/Home/Components/SectionTitle.tsx
+++ b/src/lib/Scenes/Home/Components/SectionTitle.tsx
@@ -24,7 +24,7 @@ interface Styles {
 const styles = StyleSheet.create<Styles>({
   headerText: {
     fontFamily: "AGaramondPro-Regular",
-    fontSize: 25,
+    fontSize: 30,
     textAlign: "left",
   },
 })


### PR DESCRIPTION
Fixes https://github.com/artsy/collector-experience/issues/662

Afterzzz:

<img width="970" alt="screen shot 2017-11-29 at 10 53 28" src="https://user-images.githubusercontent.com/373860/33373083-3c30b310-d4f8-11e7-929b-51f9793e7121.png">

<img width="958" alt="screen shot 2017-11-29 at 10 53 36" src="https://user-images.githubusercontent.com/373860/33373082-3c165c5e-d4f8-11e7-8431-79d94104a27c.png">

Snuck in this little thing that was bugging me ^^^^^^^ View all had an additional space, causing it to _just_ not be aligned with the top bit. (Unless this was intentional? though it didn't seem like it from the design specs in the issue) cc @katarinabatina 

To specify: I moved it left, so it aligns with the headers. The little thingy in sketch was me checking whether it was misaligned or just my imagination 😄.

Skip New Tests