### PR TITLE
More crash related fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 -   QA for composer/thread view: ipad and fixed iphone size attachments - maxim
 -   QA for message attachments - maxim
 -   QA for home header font sizes and margins - maxim
+-   Don’t rely on user of the Gene VC to specify filter defaults, which could lead to a crash - alloy
 
 ### 1.4.0-beta.8
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -21,7 +21,7 @@ PODS:
     - React/RCTNetwork (= 0.48.4)
     - React/RCTText (= 0.48.4)
     - SDWebImage (< 4, >= 3.7.2)
-    - SentryReactNative (= 0.14.5)
+    - SentryReactNative (= 0.30.2)
     - Yoga (= 0.48.4.React)
   - Extraction (1.2.3):
     - Extraction/ARAnimationContinuation (= 1.2.3)
@@ -48,14 +48,14 @@ PODS:
     - Extraction/ARAnimationContinuation
   - FLKAutoLayout (1.0.0)
   - ISO8601DateFormatter (0.8)
-  - KSCrash/Core (1.15.11):
+  - KSCrash/Core (1.15.12):
     - KSCrash/Reporting/Filters/Basic
-  - KSCrash/Recording (1.15.11):
-    - KSCrash/Recording/Tools (= 1.15.11)
-  - KSCrash/Recording/Tools (1.15.11)
-  - KSCrash/Reporting/Filters/Base (1.15.11):
+  - KSCrash/Recording (1.15.12):
+    - KSCrash/Recording/Tools (= 1.15.12)
+  - KSCrash/Recording/Tools (1.15.12)
+  - KSCrash/Reporting/Filters/Base (1.15.12):
     - KSCrash/Recording
-  - KSCrash/Reporting/Filters/Basic (1.15.11):
+  - KSCrash/Reporting/Filters/Basic (1.15.12):
     - KSCrash/Recording
     - KSCrash/Reporting/Filters/Base
   - NSURL+QueryDictionary (1.2.0)
@@ -95,15 +95,16 @@ PODS:
   - SDWebImage (3.7.5):
     - SDWebImage/Core (= 3.7.5)
   - SDWebImage/Core (3.7.5)
-  - Sentry (3.1.2):
-    - Sentry/Core (= 3.1.2)
-  - Sentry/Core (3.1.2)
-  - Sentry/KSCrash (3.1.2):
-    - KSCrash/Core (~> 1.15.9)
-  - SentryReactNative (0.14.5):
+  - Sentry (3.9.1):
+    - Sentry/Core (= 3.9.1)
+    - Sentry/KSCrash (= 3.9.1)
+  - Sentry/Core (3.9.1)
+  - Sentry/KSCrash (3.9.1):
+    - KSCrash/Core (~> 1.15.12)
+  - SentryReactNative (0.30.2):
     - React
-    - Sentry (~> 3.1.2)
-    - Sentry/KSCrash (~> 3.1.2)
+    - Sentry (~> 3.9.0)
+    - Sentry/KSCrash (~> 3.9.0)
   - UIView+BooleanAnimations (1.0.2)
   - Yoga (0.48.4.React)
 
@@ -144,18 +145,18 @@ SPEC CHECKSUMS:
   Artsy+UIColors: 31c03c4146f5e6618a9b950f37dfe02dd9ac09a6
   Artsy+UIFonts: d38c82636e000b1dee31b7bec0268e1841dac17f
   Artsy-UIButtons: cdcc3ccf4d0d31ee80f45c1d11ffd2d772695b74
-  Emission: 83ad5a90162e5333d0153a547a6c061c8fc19dd0
+  Emission: 8b5632955b7fd2885dbb1585c8f5e46e4cd3e307
   Extraction: 612cf0866f74d4c0dd616677ff24146efa200958
   FLKAutoLayout: 106b14dbae09d32c6730190f4e78a959759ba4a4
   ISO8601DateFormatter: 4551b6ce4f83185425f583b0b3feb3c7b59b942c
-  KSCrash: 7bd106ca4a2247774deeeb587c740ce0207de8f3
+  KSCrash: 931b6caeebfbfe0d316007fcd209f6cb9889c624
   NSURL+QueryDictionary: bae616404e2adf6409d3d5c02a093cbf44c8a236
   ORStackView: b9507271cb41fb9e0b3eecc6414d831201e7cf7c
   React: 6d68659481a8a56e0f6b3dbecd984d5b9bb2d6c5
   SAMKeychain: 1fc9ae02f576365395758b12888c84704eebc423
   SDWebImage: 69c6303e3348fba97e03f65d65d4fbc26740f461
-  Sentry: 5a578891f177e994d89d57effc70adb97bfb29db
-  SentryReactNative: 8f251df76f03c5ee42e702f37a41803709632217
+  Sentry: e2707f9a6b498277d9620a48fcb1bd3b655c8473
+  SentryReactNative: 2298105d4a61f520c7b0e52d57bd9ace8db856c1
   UIView+BooleanAnimations: a760be9a066036e55f298b7b7350a6cb14cfcd97
   Yoga: ccefa1454b2e9825dce3b2df98088b7f0e3c2675
 

--- a/Pod/Classes/ViewControllers/ARGeneComponentViewController.m
+++ b/Pod/Classes/ViewControllers/ARGeneComponentViewController.m
@@ -4,8 +4,7 @@
 
 - (instancetype)initWithGeneID:(NSString *)geneID;
 {
-    // Use the metaphysics defaults for a nil refineSetting
-    return [self initWithGeneID:geneID refineSettings:@{ @"medium": @"*", @"price_range": @"*-*" } emission:nil];
+    return [self initWithGeneID:geneID refineSettings:@{} emission:nil];
 }
 
 - (instancetype)initWithGeneID:(NSString *)geneID refineSettings:(nonnull NSDictionary *)settings;

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "react-native-hyperlink": "0.0.11",
     "react-native-parallax-scroll-view": "https://github.com/orta/react-native-parallax-scroll-view",
     "react-native-scrollable-tab-view": "^0.8.0",
-    "react-native-sentry": "^0.14.5",
+    "react-native-sentry": "^0.30.2",
     "react-relay": "https://github.com/alloy/relay/releases/download/v1.3.0-artsy/react-relay-1.3.0-artsy.1.tgz",
     "react-tracking": "^5.0.0",
     "relay-runtime": "https://github.com/alloy/relay/releases/download/v1.3.0-artsy/relay-runtime-artsy.1.tgz",

--- a/src/lib/Components/Consignments/Screens/SelectFromPhotoLibrary.tsx
+++ b/src/lib/Components/Consignments/Screens/SelectFromPhotoLibrary.tsx
@@ -94,13 +94,9 @@ export default class SelectFromPhotoLibrary extends React.Component<Props, State
       return
     }
 
-    CameraRoll.getPhotos(fetchParams)
-      .then(data => {
-        this.appendAssets(data)
-      })
-      .catch(e => {
-        console.log(e)
-      })
+    CameraRoll.getPhotos(fetchParams).then(data => {
+      this.appendAssets(data)
+    })
   }
 
   appendAssets(data) {

--- a/src/lib/Containers/Gene.tsx
+++ b/src/lib/Containers/Gene.tsx
@@ -76,9 +76,10 @@ export class Gene extends React.Component<Props, State> {
       selectedTabIndex: 0,
       showingStickyHeader: true,
 
+      // Use the metaphysics defaults for refine settings
       sort: "-partner_updated_at",
-      selectedMedium: this.props.medium,
-      selectedPriceRange: this.props.price_range,
+      selectedMedium: this.props.medium || "*",
+      selectedPriceRange: this.props.price_range || "*-*",
     }
   }
 

--- a/src/lib/Containers/Gene.tsx
+++ b/src/lib/Containers/Gene.tsx
@@ -183,29 +183,25 @@ export class Gene extends React.Component<Props, State> {
 
     // We're returning the promise so that it's easier
     // to write tests with the resolved state
-    return Refine.triggerRefine(this, initialSettings, currentSettings)
-      .then(newSettings => {
-        if (newSettings) {
-          this.setState({
-            selectedMedium: newSettings.medium,
-            selectedPriceRange: newSettings.selectedPrice,
-            sort: newSettings.sort,
-          })
+    return Refine.triggerRefine(this, initialSettings, currentSettings).then(newSettings => {
+      if (newSettings) {
+        this.setState({
+          selectedMedium: newSettings.medium,
+          selectedPriceRange: newSettings.selectedPrice,
+          sort: newSettings.sort,
+        })
 
-          this.props.relay.refetch(
-            {
-              medium: newSettings.medium,
-              price_range: newSettings.selectedPrice,
-              sort: newSettings.sort,
-            },
-            // TODO: is this param really required?
-            null
-          )
-        }
-      })
-      .catch(error => {
-        console.warn(error)
-      })
+        this.props.relay.refetch(
+          {
+            medium: newSettings.medium,
+            price_range: newSettings.selectedPrice,
+            sort: newSettings.sort,
+          },
+          // TODO: is this param really required?
+          null
+        )
+      }
+    })
   }
 
   /** Title of the Gene */

--- a/src/lib/NativeModules/SwitchBoard.tsx
+++ b/src/lib/NativeModules/SwitchBoard.tsx
@@ -6,6 +6,7 @@ function presentNavigationViewController(component: React.Component<any, any>, r
   try {
     reactTag = findNodeHandle(component)
   } catch (err) {
+    console.error(`Unable to find tag in presentNavigationViewController: ${err.message}`)
     return
   }
 
@@ -17,6 +18,7 @@ function presentModalViewController(component: React.Component<any, any>, route:
   try {
     reactTag = findNodeHandle(component)
   } catch (err) {
+    console.error(`Unable to find tag in presentModalViewController: ${err.message}`)
     return
   }
 
@@ -33,6 +35,7 @@ function presentMediaPreviewController(
   try {
     reactTag = findNodeHandle(component)
   } catch (err) {
+    console.error(`Unable to find tag in presentMediaPreviewController: ${err.message}`)
     return
   }
 
@@ -44,7 +47,7 @@ function dismissModalViewController(component: React.Component<any, any>) {
   try {
     reactTag = findNodeHandle(component)
   } catch (err) {
-    console.log("Could not find node for ", component)
+    console.error(`Unable to find tag in dismissModalViewController: ${err.message}`)
     return
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -270,13 +270,17 @@ amdefine@>=0.0.4:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.0.tgz#fd17474700cb5cc9c2b709f0be9d23ce3c198c33"
 
-ansi-escapes@^1.0.0, ansi-escapes@^1.1.0:
+ansi-escapes@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
 
 ansi-escapes@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-2.0.0.tgz#5bae52be424878dd9783e8910e3fc2922e83c81b"
+
+ansi-escapes@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.0.0.tgz#ec3e8b4e9f8064fc02c3ac9b65f1c275bda8ef92"
 
 ansi-html@0.0.7:
   version "0.0.7"
@@ -1945,6 +1949,14 @@ chalk@^2.0.0, chalk@^2.0.1:
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
+chalk@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
+  dependencies:
+    ansi-styles "^3.1.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^4.0.0"
+
 change-case@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/change-case/-/change-case-3.0.1.tgz#ee5f5ad0415ad1ad9e8072cf49cd4cfa7660a554"
@@ -3357,7 +3369,7 @@ extend@3, extend@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.0.tgz#5a474353b9f3353ddd8176dfd37b91c83a46f1d4"
 
-external-editor@^2.0.1, external-editor@^2.0.4:
+external-editor@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.0.4.tgz#1ed9199da9cbfe2ef2f7a31b2fde8b0d12368972"
   dependencies:
@@ -3818,17 +3830,6 @@ glob-to-regexp@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
 
-glob@7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.2"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
 glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
@@ -4268,29 +4269,30 @@ inline-style-prefixer@^3.0.6:
     bowser "^1.6.0"
     css-in-js-utils "^1.0.3"
 
-inquirer@3.0.6:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.0.6.tgz#e04aaa9d05b7a3cb9b0f407d04375f0447190347"
-  dependencies:
-    ansi-escapes "^1.1.0"
-    chalk "^1.0.0"
-    cli-cursor "^2.1.0"
-    cli-width "^2.0.0"
-    external-editor "^2.0.1"
-    figures "^2.0.0"
-    lodash "^4.3.0"
-    mute-stream "0.0.7"
-    run-async "^2.2.0"
-    rx "^4.1.0"
-    string-width "^2.0.0"
-    strip-ansi "^3.0.0"
-    through "^2.3.6"
-
 inquirer@^3.0.6:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.2.3.tgz#1c7b1731cf77b934ec47d22c9ac5aa8fe7fbe095"
   dependencies:
     ansi-escapes "^2.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^2.0.4"
+    figures "^2.0.0"
+    lodash "^4.3.0"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rx-lite "^4.0.8"
+    rx-lite-aggregates "^4.0.8"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
+    through "^2.3.6"
+
+inquirer@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.3.0.tgz#9dd2f2ad765dcab1ff0443b491442a20ba227dc9"
+  dependencies:
+    ansi-escapes "^3.0.0"
     chalk "^2.0.0"
     cli-cursor "^2.1.0"
     cli-width "^2.0.0"
@@ -7033,9 +7035,9 @@ range-parser@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.0.3.tgz#6872823535c692e2c2a0103826afd82c2e0ff175"
 
-raven-js@^3.16.1:
-  version "3.16.1"
-  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.16.1.tgz#4aab8ba7c57bc261604db970c41c49137340c450"
+raven-js@^3.19.1:
+  version "3.20.1"
+  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.20.1.tgz#3170bdb35c05098ddb8548ee5be0687f9d763330"
 
 raw-body@~2.1.2:
   version "2.1.7"
@@ -7150,16 +7152,16 @@ react-native-scrollable-tab-view@^0.8.0:
     prop-types "^15.6.0"
     react-timer-mixin "^0.13.3"
 
-react-native-sentry@^0.14.5:
-  version "0.14.5"
-  resolved "https://registry.yarnpkg.com/react-native-sentry/-/react-native-sentry-0.14.5.tgz#477aeca99a4c36326a64ca575e2b3718a3fb05a6"
+react-native-sentry@^0.30.2:
+  version "0.30.2"
+  resolved "https://registry.yarnpkg.com/react-native-sentry/-/react-native-sentry-0.30.2.tgz#6e432954db24d541c2810bfb386cd7adbad4497e"
   dependencies:
-    chalk "^1.1.1"
-    glob "7.1.1"
-    inquirer "3.0.6"
-    raven-js "^3.16.1"
-    sentry-cli-binary "^1.16.0"
-    xcode "0.9.3"
+    chalk "^2.3.0"
+    glob "^7.1.1"
+    inquirer "^3.3.0"
+    raven-js "^3.19.1"
+    sentry-cli-binary "^1.21.0"
+    xcode "^1.0.0"
 
 react-native-storybook-loader@^1.6.0:
   version "1.6.0"
@@ -7776,10 +7778,6 @@ rx@2.3.24:
   version "2.3.24"
   resolved "https://registry.yarnpkg.com/rx/-/rx-2.3.24.tgz#14f950a4217d7e35daa71bbcbe58eff68ea4b2b7"
 
-rx@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/rx/-/rx-4.1.0.tgz#a5f13ff79ef3b740fe30aa803fb09f98805d4782"
-
 rxjs@^5.0.0-beta.11:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.3.1.tgz#9ecc9e722247e4f4490d30a878577a3740fd0cb7"
@@ -7879,9 +7877,9 @@ sentence-case@^2.1.0:
     no-case "^2.2.0"
     upper-case-first "^1.1.2"
 
-sentry-cli-binary@^1.16.0:
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/sentry-cli-binary/-/sentry-cli-binary-1.16.0.tgz#10fbdde9e6e86d8a864c96f8adeb97b0064ea427"
+sentry-cli-binary@^1.21.0:
+  version "1.24.1"
+  resolved "https://registry.yarnpkg.com/sentry-cli-binary/-/sentry-cli-binary-1.24.1.tgz#1ba26f49e7d2a0906b9879e6da87804f01517969"
   dependencies:
     progress "2.0.0"
 
@@ -9260,9 +9258,17 @@ ws@^3.0.0:
     safe-buffer "~5.0.1"
     ultron "~1.1.0"
 
-xcode@0.9.3, xcode@^0.9.1:
+xcode@^0.9.1:
   version "0.9.3"
   resolved "https://registry.yarnpkg.com/xcode/-/xcode-0.9.3.tgz#910a89c16aee6cc0b42ca805a6d0b4cf87211cf3"
+  dependencies:
+    pegjs "^0.10.0"
+    simple-plist "^0.2.1"
+    uuid "3.0.1"
+
+xcode@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/xcode/-/xcode-1.0.0.tgz#e1f5b1443245ded38c180796df1a10fdeda084ec"
   dependencies:
     pegjs "^0.10.0"
     simple-plist "^0.2.1"


### PR DESCRIPTION
* I’ve removed cases where `setState` is being used in a promise and we subsequently catch all errors that can come out of the promise, which can apparently [leave React in a bad state](https://github.com/facebook/react/issues/8579#issuecomment-267312367). Going forward we should either just `console.error(…)` them so they show up in Sentry or be selective about which errors we catch and rethrow all others.
* The Sentry version we were using [has a bug](https://github.com/getsentry/sentry-cocoa/pull/192). To be able to update Sentry in Eigen we need to also update the RN client.
* The Gene container was crashing when it was initialised without filter defaults, which would happen when Eigen’s switchboard would route a Gene URL that did not contain any of the required filter parameters.
  - This would crash: `https://www.artsy.net/gene/graffiti-and-street-art`
  - This would work: `https://www.artsy.net/gene/graffiti-and-street-art?medium=*&price_range=*-*`