### PR TITLE
[QA] Consignments provenance text color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 -   QA for composer/thread view: ipad and fixed iphone size attachments - maxim
 -   QA for message attachments - maxim
 -   QA for home header font sizes and margins - maxim
+-   Minor: change text colour for provenance placeholder in consignments - maxim
 
 ### 1.4.0-beta.8
 

--- a/src/lib/Components/Consignments/Components/TextArea.tsx
+++ b/src/lib/Components/Consignments/Components/TextArea.tsx
@@ -18,7 +18,7 @@ interface State {
 const Placeholder = styled.Text`
   position: absolute;
   z-index: -1;
-  color: ${colors["gray-medium"]};
+  color: ${colors["gray-semibold"]};
   font-family: "${fonts["garamond-regular"]}";
   font-size: 20;
   margin-top: 5px;

--- a/src/lib/Components/Consignments/Components/__tests__/__snapshots__/TextArea-tests.tsx.snap
+++ b/src/lib/Components/Consignments/Components/__tests__/__snapshots__/TextArea-tests.tsx.snap
@@ -71,7 +71,7 @@ exports[`shows the placeholder when text is empty 1`] = `
       style={
         Array [
           Object {
-            "color": "#cccccc",
+            "color": "#666666",
             "fontFamily": "AGaramondPro-Regular",
             "fontSize": 20,
             "marginTop": 5,

--- a/src/lib/Components/Consignments/Screens/__tests__/__snapshots__/Provenance-tests.tsx.snap
+++ b/src/lib/Components/Consignments/Screens/__tests__/__snapshots__/Provenance-tests.tsx.snap
@@ -94,7 +94,7 @@ exports[`Sets up the right view hierarchy 1`] = `
                   style={
                     Array [
                       Object {
-                        "color": "#cccccc",
+                        "color": "#666666",
                         "fontFamily": "AGaramondPro-Regular",
                         "fontSize": 20,
                         "marginTop": 5,


### PR DESCRIPTION
Fixes https://github.com/artsy/consignments/issues/94

[Can't seem to change the cursor colour though](https://facebook.github.io/react-native/docs/textinput.html) :( 

![simulator screen shot - iphone 6 - 9 1 - 2017-11-29 at 14 19 47](https://user-images.githubusercontent.com/373860/33379879-306f5928-d511-11e7-862c-bbf02b3e9d06.png)
