### PR TITLE
[Artwork] Try to pinpoint sale artwork related crash. #trivial

### DIFF
--- a/src/lib/Components/ArtworkGrids/Artwork.tsx
+++ b/src/lib/Components/ArtworkGrids/Artwork.tsx
@@ -65,7 +65,13 @@ class Artwork extends React.Component<RelayProps, any> {
     const artwork = this.props.artwork
     if (artwork.is_in_auction && artwork.sale_artwork) {
       if (artwork.sale_artwork.sale.is_open) {
-        const numberOfBids = artwork.sale_artwork.bidder_positions_count
+        let numberOfBids = null
+        try {
+          numberOfBids = artwork.sale_artwork.bidder_positions_count
+        } catch (e) {
+          console.error(`Sentry issue #274707594 triggered with props: ${JSON.stringify(this.props)}`)
+          return null
+        }
         let text = artwork.sale_artwork.opening_bid.display
         if (numberOfBids > 0) {
           text = `${artwork.sale_artwork.current_bid.display} (${numberOfBids} bid${numberOfBids === 1 ? "" : "s"})`


### PR DESCRIPTION
https://sentry.io/artsynet/eigen-staging/issues/274707594

I have no clue how it could get here after all these `if` statements, but this is the only place I could find that accesses `bidder_positions_count`. Hopefully this log will give us some data we can use to reproduce the issue.