### PR TITLE
[inbox] fix for inbox pull-to-refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 1.4.0-beta.9
 
+-   During Inbox pull-to-refresh, Conversations container force-fetches itself - sarah
 -   Accommodate selectedArtist parameter in Home container - sarah
 -   Don’t require 2 taps to open a conversation attachment and keep keyboard up - alloy
 -   Don’t assume a photo was selected in the consignments photo picker - alloy

--- a/src/lib/Components/Inbox/ActiveBids/index.tsx
+++ b/src/lib/Components/Inbox/ActiveBids/index.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { createFragmentContainer, graphql } from "react-relay"
+import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
 import styled from "styled-components/native"
 
 import { View } from "react-native"
@@ -8,7 +8,25 @@ import ActiveBid from "./ActiveBid"
 
 const Container = styled.View`margin: 20px 0 40px;`
 
-class ActiveBids extends React.Component<RelayProps, null> {
+interface Props extends RelayProps {
+  relay?: RelayRefetchProp
+}
+
+interface State {
+  fetchingData: boolean
+}
+
+class ActiveBids extends React.Component<Props, State> {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      fetchingData: false,
+    }
+
+    this.refreshActiveBids = this.refreshActiveBids.bind(this)
+  }
+
   hasContent() {
     return this.props.me.lot_standings.length > 0
   }
@@ -18,6 +36,27 @@ class ActiveBids extends React.Component<RelayProps, null> {
       return <ActiveBid key={bidData.most_recent_bid.__id} bid={bidData} />
     })
     return bids
+  }
+
+  refreshActiveBids(callback) {
+    if (this.state.fetchingData) {
+      return
+    }
+
+    this.setState({ fetchingData: true })
+
+    this.props.relay.refetch(
+      {},
+      {},
+      () => {
+        this.setState({ fetchingData: false })
+
+        if (callback) {
+          callback()
+        }
+      },
+      { force: true }
+    )
   }
 
   render() {
@@ -30,15 +69,24 @@ class ActiveBids extends React.Component<RelayProps, null> {
   }
 }
 
-export default createFragmentContainer(
+export default createRefetchContainer(
   ActiveBids,
-  graphql`
-    fragment ActiveBids_me on Me {
-      lot_standings(live: true) {
-        most_recent_bid {
-          __id
+  {
+    me: graphql`
+      fragment ActiveBids_me on Me {
+        lot_standings(live: true) {
+          most_recent_bid {
+            __id
+          }
+          ...ActiveBid_bid
         }
-        ...ActiveBid_bid
+      }
+    `,
+  },
+  graphql`
+    query ActiveBidsRefetchQuery {
+      me {
+        ...ActiveBids_me
       }
     }
   `

--- a/src/lib/Components/Inbox/Conversations/index.tsx
+++ b/src/lib/Components/Inbox/Conversations/index.tsx
@@ -66,7 +66,10 @@ export class Conversations extends React.Component<Props, State> {
     this.setState({ fetchingNextPage: true })
     this.props.relay.refetchConnection(10, () => {
       this.setState({ fetchingNextPage: false })
-      callback()
+
+      if (callback) {
+        callback()
+      }
     })
   }
 

--- a/src/lib/Components/Inbox/Conversations/index.tsx
+++ b/src/lib/Components/Inbox/Conversations/index.tsx
@@ -40,6 +40,8 @@ export class Conversations extends React.Component<Props, State> {
       dataSource,
       fetchingNextPage: false,
     }
+
+    this.refreshConversations = this.refreshConversations.bind(this)
   }
 
   componentDidMount() {
@@ -53,6 +55,18 @@ export class Conversations extends React.Component<Props, State> {
 
     this.setState({
       dataSource: this.state.dataSource.cloneWithRows(conversations),
+    })
+  }
+
+  refreshConversations(callback) {
+    if (this.state.fetchingNextPage) {
+      return
+    }
+
+    this.setState({ fetchingNextPage: true })
+    this.props.relay.refetchConnection(10, () => {
+      this.setState({ fetchingNextPage: false })
+      callback()
     })
   }
 

--- a/src/lib/Containers/Inbox.tsx
+++ b/src/lib/Containers/Inbox.tsx
@@ -19,6 +19,7 @@ const Container = styled.ScrollView`flex: 1;`
 
 export class Inbox extends React.Component<Props, State> {
   conversations: any
+  activeBids: any
 
   constructor(props) {
     super(props)
@@ -37,10 +38,9 @@ export class Inbox extends React.Component<Props, State> {
 
     this.setState({ fetchingData: true })
 
-    // Force-fetch self; this will update Active Bids but not Conversations (there will be a warning)
-    this.props.relay.refetch({}, {}, null, { force: true })
-
-    // Allow Conversations to properly force-fetch itself
+    // Allow Conversations & Active Bids to properly force-fetch themselves.
+    // The stored refs are the Relay containers; the components themselves are nested under as refs.
+    this.activeBids.refs.component.refreshActiveBids()
     this.conversations.refs.component.refreshConversations(() => {
       this.setState({ fetchingData: false })
     })
@@ -52,7 +52,7 @@ export class Inbox extends React.Component<Props, State> {
       this.props.me.conversations_existence_check && this.props.me.conversations_existence_check.edges.length > 0
     return hasBids || hasConversations
       ? <Container refreshControl={<RefreshControl refreshing={this.state.fetchingData} onRefresh={this.fetchData} />}>
-          <ActiveBids me={this.props.me as any} />
+          <ActiveBids me={this.props.me as any} ref={activeBids => (this.activeBids = activeBids)} />
           <Conversations me={this.props.me} ref={conversations => (this.conversations = conversations)} />
         </Container>
       : <ZeroStateInbox />

--- a/src/lib/Containers/Inbox.tsx
+++ b/src/lib/Containers/Inbox.tsx
@@ -18,6 +18,8 @@ interface State {
 const Container = styled.ScrollView`flex: 1;`
 
 export class Inbox extends React.Component<Props, State> {
+  conversations: any
+
   constructor(props) {
     super(props)
 
@@ -34,14 +36,9 @@ export class Inbox extends React.Component<Props, State> {
     }
 
     this.setState({ fetchingData: true })
-    this.props.relay.refetch(
-      {},
-      null,
-      () => {
-        this.setState({ fetchingData: false })
-      },
-      { force: true }
-    )
+    this.conversations._refetchConnection(10, () => {
+      this.setState({ fetchingData: false })
+    })
   }
 
   render() {
@@ -51,7 +48,7 @@ export class Inbox extends React.Component<Props, State> {
     return hasBids || hasConversations
       ? <Container refreshControl={<RefreshControl refreshing={this.state.fetchingData} onRefresh={this.fetchData} />}>
           <ActiveBids me={this.props.me as any} />
-          <Conversations me={this.props.me} />
+          <Conversations me={this.props.me} ref={conversations => (this.conversations = conversations)} />
         </Container>
       : <ZeroStateInbox />
   }

--- a/src/lib/Containers/Inbox.tsx
+++ b/src/lib/Containers/Inbox.tsx
@@ -36,7 +36,12 @@ export class Inbox extends React.Component<Props, State> {
     }
 
     this.setState({ fetchingData: true })
-    this.conversations._refetchConnection(10, () => {
+
+    // Force-fetch self; this will update Active Bids but not Conversations (there will be a warning)
+    this.props.relay.refetch({}, {}, null, { force: true })
+
+    // Allow Conversations to properly force-fetch itself
+    this.conversations.refs.component.refreshConversations(() => {
       this.setState({ fetchingData: false })
     })
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1941,15 +1941,7 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.0.1:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
-  dependencies:
-    ansi-styles "^3.1.0"
-    escape-string-regexp "^1.0.5"
-    supports-color "^4.0.0"
-
-chalk@^2.3.0:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
   dependencies:
@@ -3141,13 +3133,13 @@ escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
 
-escape-string-regexp@^1.0.0, escape-string-regexp@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz#4dbc2fe674e71949caf3fb2695ce7f2dc1d9a8d1"
-
-escape-string-regexp@^1.0.5:
+escape-string-regexp@^1.0.0, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+
+escape-string-regexp@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz#4dbc2fe674e71949caf3fb2695ce7f2dc1d9a8d1"
 
 escodegen@^1.6.1:
   version "1.8.1"


### PR DESCRIPTION
- [x] Refresh conversations
- [x] Refresh active bids

Before, when the `Inbox` tried to force fetch its child `Conversations` container, we got an error related to pagination because `Conversations` is a `PaginationContainer` and [maintains its own cursor](https://github.com/artsy/emission/blob/master/src/lib/Components/Inbox/Conversations/index.tsx#L125).

I got around this by making `refreshConversations` and `refreshActiveBids` methods that the `Inbox` can call upon pull-to-refresh. The `ActiveBids` container is now a `RefetchContainer` and can be updated with a normal force fetch.

![refresh](https://user-images.githubusercontent.com/2712962/33597572-200efb40-d9a0-11e7-9312-ed61128b7be2.gif)


Skip New Tests