### PR TITLE
[Consignments] Metadata screen QA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 -   Fixes for metaphysics changes to consignment submission - orta
 -   Implement selected state for images in consignments photo set - maxim
 -   Support sending images for Consignments in production - orta
+-   QA for consignments on metadata screen - maxim
 
 ### 1.4.0-beta.8
 

--- a/src/lib/Components/Consignments/Components/TextInput.tsx
+++ b/src/lib/Components/Consignments/Components/TextInput.tsx
@@ -25,6 +25,10 @@ export interface TextInputProps extends ViewProperties {
   preImage?: ImageURISource | ImageURISource[]
 }
 
+interface State {
+  focused: boolean
+}
+
 const Input = styled.TextInput`
   height: 40;
   background-color: black;
@@ -34,20 +38,16 @@ const Input = styled.TextInput`
   flex: 1;
 `
 
-const Separator = styled.View`
-  background-color: white;
-  height: 1;
-`
-
-const WritableInput = (props: TextInputProps) =>
-  <Input
-    autoCorrect={false}
-    clearButtonMode="while-editing"
-    keyboardAppearance="dark"
-    placeholderTextColor={Colors.GraySemibold}
-    selectionColor={Colors.GrayMedium}
-    {...props.text}
-  />
+const Separator = focused => {
+  return (
+    <View
+      style={{
+        height: 1,
+        backgroundColor: focused ? Colors.White : Colors.GraySemibold,
+      }}
+    />
+  )
+}
 
 const ReadOnlyInput = (props: TextInputProps) =>
   <Text
@@ -61,15 +61,32 @@ const ReadOnlyInput = (props: TextInputProps) =>
     {props.text.value || props.text.placeholder}
   </Text>
 
-const render = (props: TextInputProps) =>
-  <View style={[props.style, { flex: 1, maxHeight: 40 }]}>
-    <View style={{ flexDirection: "row", height: 40 }}>
-      {props.preImage && <Image source={props.preImage} style={{ marginRight: 6, marginTop: 12 }} />}
-      {props.readonly ? ReadOnlyInput(props) : WritableInput(props)}
+export default class TextInputField extends React.Component<TextInputProps, State> {
+  constructor(props) {
+    super(props)
+    this.state = { focused: false }
+  }
+  render() {
+    return (
+      <View style={[this.props.style, { flex: 1, maxHeight: 40 }]}>
+        <View style={{ flexDirection: "row", height: 40 }}>
+          {this.props.preImage && <Image source={this.props.preImage} style={{ marginRight: 6, marginTop: 12 }} />}
+          {this.props.readonly
+            ? ReadOnlyInput(this.props)
+            : <Input
+                autoCorrect={false}
+                clearButtonMode="while-editing"
+                keyboardAppearance="dark"
+                placeholderTextColor={this.state.focused ? "white" : Colors.GraySemibold}
+                selectionColor={Colors.GrayMedium}
+                onFocus={() => this.setState({ focused: true })}
+                {...this.props.text}
+              />}
 
-      {props.searching ? <ActivityIndicator animating={props.searching} /> : null}
-    </View>
-    <Separator />
-  </View>
-
-export default render
+          {this.props.searching ? <ActivityIndicator animating={this.props.searching} /> : null}
+        </View>
+        {Separator(this.state.focused)}
+      </View>
+    )
+  }
+}

--- a/src/lib/Components/Consignments/Components/TextInput.tsx
+++ b/src/lib/Components/Consignments/Components/TextInput.tsx
@@ -79,8 +79,9 @@ export default class TextInputField extends React.Component<TextInputProps, Stat
                 keyboardAppearance="dark"
                 placeholderTextColor={this.state.focused ? "white" : Colors.GraySemibold}
                 selectionColor={Colors.GrayMedium}
-                onFocus={() => this.setState({ focused: true })}
                 {...this.props.text}
+                onFocus={() => this.setState({ focused: true }, this.props.text.onFocus)}
+                onBlur={() => this.setState({ focused: false }, this.props.text.onBlur)}
               />}
 
           {this.props.searching ? <ActivityIndicator animating={this.props.searching} /> : null}

--- a/src/lib/Components/Consignments/Components/Toggle.tsx
+++ b/src/lib/Components/Consignments/Components/Toggle.tsx
@@ -64,12 +64,12 @@ interface ToggleProps {
 
 const render = (props: ToggleProps) => {
   const { selected } = props
-  const mainBGColor = selected ? "white" : "black"
-  const leftTextColor = selected ? "black" : "white"
-  const rightTextColor = selected ? "black" : "white"
+  const mainBGColor = "black"
+  const leftTextColor = "white"
+  const rightTextColor = "white"
   const dotDirection = selected ? "row-reverse" : "row"
   const dotBorder = selected ? "white" : "white"
-  const Circle = selected ? BlackCircle : WhiteCircle
+  const Circle = WhiteCircle
 
   return (
     <Background style={{ backgroundColor: mainBGColor }} onPress={props.onPress}>

--- a/src/lib/Components/Consignments/Components/__tests__/__snapshots__/BottomAlignedButton-tests.tsx.snap
+++ b/src/lib/Components/Consignments/Components/__tests__/__snapshots__/BottomAlignedButton-tests.tsx.snap
@@ -148,7 +148,9 @@ exports[`Bottom-Aligned states:  Looks right when With an Artist Search Results 
             autoFocus={false}
             clearButtonMode="while-editing"
             keyboardAppearance="dark"
+            onBlur={[Function]}
             onChangeText={undefined}
+            onFocus={[Function]}
             placeholder="Example"
             placeholderTextColor="#666666"
             returnKeyType="search"
@@ -173,13 +175,10 @@ exports[`Bottom-Aligned states:  Looks right when With an Artist Search Results 
         </View>
         <View
           style={
-            Array [
-              Object {
-                "backgroundColor": "white",
-                "height": 1,
-              },
-              undefined,
-            ]
+            Object {
+              "backgroundColor": "#666666",
+              "height": 1,
+            }
           }
         />
       </View>

--- a/src/lib/Components/Consignments/Components/__tests__/__snapshots__/SearchResults-tests.tsx.snap
+++ b/src/lib/Components/Consignments/Components/__tests__/__snapshots__/SearchResults-tests.tsx.snap
@@ -26,7 +26,9 @@ exports[`Search states:  Looks right when Found four results 1`] = `
         autoFocus={false}
         clearButtonMode="while-editing"
         keyboardAppearance="dark"
+        onBlur={[Function]}
         onChangeText={undefined}
+        onFocus={[Function]}
         placeholder="Artist/Designer Name"
         placeholderTextColor="#666666"
         returnKeyType="search"
@@ -51,13 +53,10 @@ exports[`Search states:  Looks right when Found four results 1`] = `
     </View>
     <View
       style={
-        Array [
-          Object {
-            "backgroundColor": "white",
-            "height": 1,
-          },
-          undefined,
-        ]
+        Object {
+          "backgroundColor": "#666666",
+          "height": 1,
+        }
       }
     />
   </View>
@@ -435,7 +434,9 @@ exports[`Search states:  Looks right when Found no results 1`] = `
         autoFocus={false}
         clearButtonMode="while-editing"
         keyboardAppearance="dark"
+        onBlur={[Function]}
         onChangeText={undefined}
+        onFocus={[Function]}
         placeholder="Artist/Designer Name"
         placeholderTextColor="#666666"
         returnKeyType="search"
@@ -460,13 +461,10 @@ exports[`Search states:  Looks right when Found no results 1`] = `
     </View>
     <View
       style={
-        Array [
-          Object {
-            "backgroundColor": "white",
-            "height": 1,
-          },
-          undefined,
-        ]
+        Object {
+          "backgroundColor": "#666666",
+          "height": 1,
+        }
       }
     />
   </View>
@@ -549,7 +547,9 @@ exports[`Search states:  Looks right when Found one result 1`] = `
         autoFocus={false}
         clearButtonMode="while-editing"
         keyboardAppearance="dark"
+        onBlur={[Function]}
         onChangeText={undefined}
+        onFocus={[Function]}
         placeholder="Artist/Designer Name"
         placeholderTextColor="#666666"
         returnKeyType="search"
@@ -574,13 +574,10 @@ exports[`Search states:  Looks right when Found one result 1`] = `
     </View>
     <View
       style={
-        Array [
-          Object {
-            "backgroundColor": "white",
-            "height": 1,
-          },
-          undefined,
-        ]
+        Object {
+          "backgroundColor": "#666666",
+          "height": 1,
+        }
       }
     />
   </View>
@@ -709,7 +706,9 @@ exports[`Search states:  Looks right when Found one result, and searching 1`] = 
         autoFocus={false}
         clearButtonMode="while-editing"
         keyboardAppearance="dark"
+        onBlur={[Function]}
         onChangeText={undefined}
+        onFocus={[Function]}
         placeholder="Artist/Designer Name"
         placeholderTextColor="#666666"
         returnKeyType="search"
@@ -740,13 +739,10 @@ exports[`Search states:  Looks right when Found one result, and searching 1`] = 
     </View>
     <View
       style={
-        Array [
-          Object {
-            "backgroundColor": "white",
-            "height": 1,
-          },
-          undefined,
-        ]
+        Object {
+          "backgroundColor": "#666666",
+          "height": 1,
+        }
       }
     />
   </View>
@@ -875,7 +871,9 @@ exports[`Search states:  Looks right when Found two results 1`] = `
         autoFocus={false}
         clearButtonMode="while-editing"
         keyboardAppearance="dark"
+        onBlur={[Function]}
         onChangeText={undefined}
+        onFocus={[Function]}
         placeholder="Artist/Designer Name"
         placeholderTextColor="#666666"
         returnKeyType="search"
@@ -900,13 +898,10 @@ exports[`Search states:  Looks right when Found two results 1`] = `
     </View>
     <View
       style={
-        Array [
-          Object {
-            "backgroundColor": "white",
-            "height": 1,
-          },
-          undefined,
-        ]
+        Object {
+          "backgroundColor": "#666666",
+          "height": 1,
+        }
       }
     />
   </View>
@@ -1118,7 +1113,9 @@ exports[`Search states:  Looks right when Looking for new results 1`] = `
         autoFocus={false}
         clearButtonMode="while-editing"
         keyboardAppearance="dark"
+        onBlur={[Function]}
         onChangeText={undefined}
+        onFocus={[Function]}
         placeholder="Artist/Designer Name"
         placeholderTextColor="#666666"
         returnKeyType="search"
@@ -1149,13 +1146,10 @@ exports[`Search states:  Looks right when Looking for new results 1`] = `
     </View>
     <View
       style={
-        Array [
-          Object {
-            "backgroundColor": "white",
-            "height": 1,
-          },
-          undefined,
-        ]
+        Object {
+          "backgroundColor": "#666666",
+          "height": 1,
+        }
       }
     />
   </View>
@@ -1200,7 +1194,9 @@ exports[`Search states:  Looks right when No query 1`] = `
         autoFocus={false}
         clearButtonMode="while-editing"
         keyboardAppearance="dark"
+        onBlur={[Function]}
         onChangeText={undefined}
+        onFocus={[Function]}
         placeholder="Artist/Designer Name"
         placeholderTextColor="#666666"
         returnKeyType="search"
@@ -1225,13 +1221,10 @@ exports[`Search states:  Looks right when No query 1`] = `
     </View>
     <View
       style={
-        Array [
-          Object {
-            "backgroundColor": "white",
-            "height": 1,
-          },
-          undefined,
-        ]
+        Object {
+          "backgroundColor": "#666666",
+          "height": 1,
+        }
       }
     />
   </View>

--- a/src/lib/Components/Consignments/Components/__tests__/__snapshots__/TextInput-tests.tsx.snap
+++ b/src/lib/Components/Consignments/Components/__tests__/__snapshots__/TextInput-tests.tsx.snap
@@ -24,6 +24,8 @@ exports[`does not have an activity when searching  1`] = `
       autoCorrect={false}
       clearButtonMode="while-editing"
       keyboardAppearance="dark"
+      onBlur={[Function]}
+      onFocus={[Function]}
       placeholderTextColor="#666666"
       selectionColor="#cccccc"
       style={
@@ -52,13 +54,10 @@ exports[`does not have an activity when searching  1`] = `
   </View>
   <View
     style={
-      Array [
-        Object {
-          "backgroundColor": "white",
-          "height": 1,
-        },
-        undefined,
-      ]
+      Object {
+        "backgroundColor": "#666666",
+        "height": 1,
+      }
     }
   />
 </View>
@@ -88,6 +87,8 @@ exports[`shows an activity indicator when searching  1`] = `
       autoCorrect={false}
       clearButtonMode="while-editing"
       keyboardAppearance="dark"
+      onBlur={[Function]}
+      onFocus={[Function]}
       placeholderTextColor="#666666"
       selectionColor="#cccccc"
       style={
@@ -116,13 +117,10 @@ exports[`shows an activity indicator when searching  1`] = `
   </View>
   <View
     style={
-      Array [
-        Object {
-          "backgroundColor": "white",
-          "height": 1,
-        },
-        undefined,
-      ]
+      Object {
+        "backgroundColor": "#666666",
+        "height": 1,
+      }
     }
   />
 </View>

--- a/src/lib/Components/Consignments/Components/__tests__/__snapshots__/Toggle-tests.tsx.snap
+++ b/src/lib/Components/Consignments/Components/__tests__/__snapshots__/Toggle-tests.tsx.snap
@@ -33,7 +33,7 @@ exports[`has the expected tree 1`] = `
           "width": 64,
         },
         Object {
-          "backgroundColor": "white",
+          "backgroundColor": "black",
         },
       ],
     ]
@@ -72,7 +72,7 @@ exports[`has the expected tree 1`] = `
               "width": 24,
             },
             Object {
-              "color": "black",
+              "color": "white",
             },
           ]
         }
@@ -95,7 +95,7 @@ exports[`has the expected tree 1`] = `
               "width": 24,
             },
             Object {
-              "color": "black",
+              "color": "white",
             },
           ]
         }
@@ -123,7 +123,7 @@ exports[`has the expected tree 1`] = `
           Array [
             Object {
               "backgroundColor": "black",
-              "borderColor": "black",
+              "borderColor": "white",
               "borderRadius": 12,
               "borderWidth": 1,
               "height": 24,

--- a/src/lib/Components/Consignments/Screens/Metadata.tsx
+++ b/src/lib/Components/Consignments/Screens/Metadata.tsx
@@ -132,7 +132,7 @@ export default class Metadata extends React.Component<Props, State> {
     return (
       <View style={{ flex: 1 }}>
         <ConsignmentBG>
-          <DoneButton onPress={this.doneTapped} verticalOffset={80}>
+          <DoneButton onPress={this.doneTapped}>
             <ScrollView keyboardShouldPersistTaps="handled" centerContent>
               <View style={{ padding: 10 }}>
                 <Row>

--- a/src/lib/Components/Consignments/Screens/Metadata.tsx
+++ b/src/lib/Components/Consignments/Screens/Metadata.tsx
@@ -164,19 +164,6 @@ export default class Metadata extends React.Component<Props, State> {
                   />
                 </Row>
 
-                <TouchableWithoutFeedback onPress={this.showCategorySelection}>
-                  <Row>
-                    <Text
-                      text={{
-                        placeholder: "Category",
-                        value: this.state.categoryName,
-                      }}
-                      readonly={true}
-                      style={{ margin: 10 }}
-                    />
-                  </Row>
-                </TouchableWithoutFeedback>
-
                 <Row>
                   <Text
                     text={{
@@ -239,6 +226,18 @@ export default class Metadata extends React.Component<Props, State> {
                     <Toggle selected={this.state.unit === "CM"} left="CM" right="IN" onPress={this.updateUnit} />
                   </View>
                 </Row>
+                <TouchableWithoutFeedback onPress={this.showCategorySelection}>
+                  <Row>
+                    <Text
+                      text={{
+                        placeholder: "Category",
+                        value: this.state.categoryName,
+                      }}
+                      readonly={true}
+                      style={{ margin: 10 }}
+                    />
+                  </Row>
+                </TouchableWithoutFeedback>
               </View>
             </ScrollView>
           </DoneButton>

--- a/src/lib/Components/Consignments/Screens/Metadata.tsx
+++ b/src/lib/Components/Consignments/Screens/Metadata.tsx
@@ -248,7 +248,7 @@ export default class Metadata extends React.Component<Props, State> {
         }
         {this.state.showPicker
           ? <Picker
-              style={{ height: 220, backgroundColor: "black", marginTop: 40 }}
+              style={{ height: 220, backgroundColor: "black" }}
               key="picker"
               selectedValue={this.state.category}
               onValueChange={this.changeCategoryValue}

--- a/src/lib/Components/Consignments/Screens/Metadata.tsx
+++ b/src/lib/Components/Consignments/Screens/Metadata.tsx
@@ -143,6 +143,7 @@ export default class Metadata extends React.Component<Props, State> {
                       onChangeText: this.updateTitle,
                       value: this.state.title,
                       onSubmitEditing: this.selectNextInput,
+                      returnKeyType: "next",
                     }}
                     style={{ margin: 10 }}
                   />
@@ -157,6 +158,7 @@ export default class Metadata extends React.Component<Props, State> {
                       onFocus: this.hideCategorySelection,
                       onSubmitEditing: this.selectNextInput,
                       ref: component => (this.yearInput = component),
+                      returnKeyType: "next",
                     }}
                     style={{ margin: 10 }}
                   />
@@ -184,6 +186,7 @@ export default class Metadata extends React.Component<Props, State> {
                       onFocus: this.hideCategorySelection,
                       onSubmitEditing: this.selectNextInput,
                       ref: component => (this.mediumInput = component),
+                      returnKeyType: "next",
                     }}
                     style={{ margin: 10 }}
                   />
@@ -199,6 +202,7 @@ export default class Metadata extends React.Component<Props, State> {
                       onFocus: this.hideCategorySelection,
                       onSubmitEditing: this.selectNextInput,
                       ref: component => (this.widthInput = component),
+                      returnKeyType: "next",
                     }}
                     style={{ margin: 10 }}
                   />
@@ -211,6 +215,7 @@ export default class Metadata extends React.Component<Props, State> {
                       onFocus: this.hideCategorySelection,
                       onSubmitEditing: this.selectNextInput,
                       ref: component => (this.heightInput = component),
+                      returnKeyType: "next",
                     }}
                     style={{ margin: 10 }}
                   />
@@ -225,6 +230,7 @@ export default class Metadata extends React.Component<Props, State> {
                       onFocus: this.hideCategorySelection,
                       onSubmitEditing: this.selectNextInput,
                       value: this.state.depth ? this.state.depth.toString() : "",
+                      returnKeyType: "next",
                     }}
                     style={{ margin: 10 }}
                   />

--- a/src/lib/Components/Consignments/Screens/__tests__/__snapshots__/FinalSubmissionQuestions-tests.tsx.snap
+++ b/src/lib/Components/Consignments/Screens/__tests__/__snapshots__/FinalSubmissionQuestions-tests.tsx.snap
@@ -985,7 +985,9 @@ exports[`Shows and additional 2 inputs when there's edition info 1`] = `
                     clearButtonMode="while-editing"
                     keyboardAppearance="dark"
                     keyboardType="phone-pad"
+                    onBlur={[Function]}
                     onChangeText={[Function]}
+                    onFocus={[Function]}
                     placeholder="Edition Size"
                     placeholderTextColor="#666666"
                     selectionColor="#cccccc"
@@ -1009,13 +1011,10 @@ exports[`Shows and additional 2 inputs when there's edition info 1`] = `
                 </View>
                 <View
                   style={
-                    Array [
-                      Object {
-                        "backgroundColor": "white",
-                        "height": 1,
-                      },
-                      undefined,
-                    ]
+                    Object {
+                      "backgroundColor": "#666666",
+                      "height": 1,
+                    }
                   }
                 />
               </View>
@@ -1044,7 +1043,9 @@ exports[`Shows and additional 2 inputs when there's edition info 1`] = `
                     autoCorrect={false}
                     clearButtonMode="while-editing"
                     keyboardAppearance="dark"
+                    onBlur={[Function]}
                     onChangeText={[Function]}
+                    onFocus={[Function]}
                     placeholder="Edition Number"
                     placeholderTextColor="#666666"
                     selectionColor="#cccccc"
@@ -1068,13 +1069,10 @@ exports[`Shows and additional 2 inputs when there's edition info 1`] = `
                 </View>
                 <View
                   style={
-                    Array [
-                      Object {
-                        "backgroundColor": "white",
-                        "height": 1,
-                      },
-                      undefined,
-                    ]
+                    Object {
+                      "backgroundColor": "#666666",
+                      "height": 1,
+                    }
                   }
                 />
               </View>

--- a/src/lib/Components/Consignments/Screens/__tests__/__snapshots__/FinalSubmissionQuestions-tests.tsx.snap
+++ b/src/lib/Components/Consignments/Screens/__tests__/__snapshots__/FinalSubmissionQuestions-tests.tsx.snap
@@ -841,7 +841,7 @@ exports[`Shows and additional 2 inputs when there's edition info 1`] = `
                         "width": 64,
                       },
                       Object {
-                        "backgroundColor": "white",
+                        "backgroundColor": "black",
                       },
                     ],
                   ]
@@ -880,7 +880,7 @@ exports[`Shows and additional 2 inputs when there's edition info 1`] = `
                             "width": 24,
                           },
                           Object {
-                            "color": "black",
+                            "color": "white",
                           },
                         ]
                       }
@@ -903,7 +903,7 @@ exports[`Shows and additional 2 inputs when there's edition info 1`] = `
                             "width": 24,
                           },
                           Object {
-                            "color": "black",
+                            "color": "white",
                           },
                         ]
                       }
@@ -931,7 +931,7 @@ exports[`Shows and additional 2 inputs when there's edition info 1`] = `
                         Array [
                           Object {
                             "backgroundColor": "black",
-                            "borderColor": "black",
+                            "borderColor": "white",
                             "borderRadius": 12,
                             "borderWidth": 1,
                             "height": 24,

--- a/src/lib/Components/Consignments/Screens/__tests__/__snapshots__/Location-tests.tsx.snap
+++ b/src/lib/Components/Consignments/Screens/__tests__/__snapshots__/Location-tests.tsx.snap
@@ -103,7 +103,9 @@ exports[`Sets up the right view hierarchy 1`] = `
                     autoFocus={false}
                     clearButtonMode="while-editing"
                     keyboardAppearance="dark"
+                    onBlur={[Function]}
                     onChangeText={[Function]}
+                    onFocus={[Function]}
                     placeholder="City, Country"
                     placeholderTextColor="#666666"
                     returnKeyType="search"
@@ -128,13 +130,10 @@ exports[`Sets up the right view hierarchy 1`] = `
                 </View>
                 <View
                   style={
-                    Array [
-                      Object {
-                        "backgroundColor": "white",
-                        "height": 1,
-                      },
-                      undefined,
-                    ]
+                    Object {
+                      "backgroundColor": "#666666",
+                      "height": 1,
+                    }
                   }
                 />
               </View>

--- a/src/lib/Components/Consignments/Screens/__tests__/__snapshots__/Metadata-tests.tsx.snap
+++ b/src/lib/Components/Consignments/Screens/__tests__/__snapshots__/Metadata-tests.tsx.snap
@@ -128,7 +128,7 @@ exports[`state is set up with empty consignment metadata 1`] = `
       }
     >
       <View
-        keyboardVerticalOffset={80}
+        keyboardVerticalOffset={15}
         onLayout={[Function]}
         style={
           Array [
@@ -212,6 +212,7 @@ exports[`state is set up with empty consignment metadata 1`] = `
                           onSubmitEditing={[Function]}
                           placeholder="Title"
                           placeholderTextColor="#666666"
+                          returnKeyType="next"
                           selectionColor="#cccccc"
                           style={
                             Array [
@@ -286,6 +287,7 @@ exports[`state is set up with empty consignment metadata 1`] = `
                           onSubmitEditing={[Function]}
                           placeholder="Year"
                           placeholderTextColor="#666666"
+                          returnKeyType="next"
                           selectionColor="#cccccc"
                           style={
                             Array [
@@ -304,83 +306,6 @@ exports[`state is set up with empty consignment metadata 1`] = `
                           }
                           value={undefined}
                         />
-                      </View>
-                      <View
-                        style={
-                          Array [
-                            Object {
-                              "backgroundColor": "white",
-                              "height": 1,
-                            },
-                            undefined,
-                          ]
-                        }
-                      />
-                    </View>
-                  </View>
-                  <View
-                    accessibilityComponentType={undefined}
-                    accessibilityLabel={undefined}
-                    accessibilityTraits={undefined}
-                    accessible={true}
-                    hitSlop={undefined}
-                    nativeID={undefined}
-                    onLayout={undefined}
-                    onResponderGrant={[Function]}
-                    onResponderMove={[Function]}
-                    onResponderRelease={[Function]}
-                    onResponderTerminate={[Function]}
-                    onResponderTerminationRequest={[Function]}
-                    onStartShouldSetResponder={[Function]}
-                    style={
-                      Array [
-                        undefined,
-                        Object {
-                          "alignItems": "center",
-                          "flexDirection": "row",
-                          "paddingVertical": 6,
-                        },
-                      ]
-                    }
-                    testID={undefined}
-                  >
-                    <View
-                      style={
-                        Array [
-                          Object {
-                            "margin": 10,
-                          },
-                          Object {
-                            "flex": 1,
-                            "maxHeight": 40,
-                          },
-                        ]
-                      }
-                    >
-                      <View
-                        style={
-                          Object {
-                            "flexDirection": "row",
-                            "height": 40,
-                          }
-                        }
-                      >
-                        <Text
-                          accessible={true}
-                          allowFontScaling={true}
-                          disabled={false}
-                          ellipsizeMode="tail"
-                          style={
-                            Object {
-                              "color": "#666666",
-                              "fontFamily": "AGaramondPro-Regular",
-                              "fontSize": 20,
-                              "paddingTop": 8,
-                            }
-                          }
-                        >
-                          Category
-                        </Text>
                       </View>
                       <View
                         style={
@@ -437,6 +362,7 @@ exports[`state is set up with empty consignment metadata 1`] = `
                           onSubmitEditing={[Function]}
                           placeholder="Medium"
                           placeholderTextColor="#666666"
+                          returnKeyType="next"
                           selectionColor="#cccccc"
                           style={
                             Array [
@@ -512,6 +438,7 @@ exports[`state is set up with empty consignment metadata 1`] = `
                           onSubmitEditing={[Function]}
                           placeholder="Width"
                           placeholderTextColor="#666666"
+                          returnKeyType="next"
                           selectionColor="#cccccc"
                           style={
                             Array [
@@ -574,6 +501,7 @@ exports[`state is set up with empty consignment metadata 1`] = `
                           onSubmitEditing={[Function]}
                           placeholder="Height"
                           placeholderTextColor="#666666"
+                          returnKeyType="next"
                           selectionColor="#cccccc"
                           style={
                             Array [
@@ -649,6 +577,7 @@ exports[`state is set up with empty consignment metadata 1`] = `
                           onSubmitEditing={[Function]}
                           placeholder="Depth"
                           placeholderTextColor="#666666"
+                          returnKeyType="next"
                           selectionColor="#cccccc"
                           style={
                             Array [
@@ -856,6 +785,83 @@ exports[`state is set up with empty consignment metadata 1`] = `
                           </View>
                         </View>
                       </View>
+                    </View>
+                  </View>
+                  <View
+                    accessibilityComponentType={undefined}
+                    accessibilityLabel={undefined}
+                    accessibilityTraits={undefined}
+                    accessible={true}
+                    hitSlop={undefined}
+                    nativeID={undefined}
+                    onLayout={undefined}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
+                    style={
+                      Array [
+                        undefined,
+                        Object {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "paddingVertical": 6,
+                        },
+                      ]
+                    }
+                    testID={undefined}
+                  >
+                    <View
+                      style={
+                        Array [
+                          Object {
+                            "margin": 10,
+                          },
+                          Object {
+                            "flex": 1,
+                            "maxHeight": 40,
+                          },
+                        ]
+                      }
+                    >
+                      <View
+                        style={
+                          Object {
+                            "flexDirection": "row",
+                            "height": 40,
+                          }
+                        }
+                      >
+                        <Text
+                          accessible={true}
+                          allowFontScaling={true}
+                          disabled={false}
+                          ellipsizeMode="tail"
+                          style={
+                            Object {
+                              "color": "#666666",
+                              "fontFamily": "AGaramondPro-Regular",
+                              "fontSize": 20,
+                              "paddingTop": 8,
+                            }
+                          }
+                        >
+                          Category
+                        </Text>
+                      </View>
+                      <View
+                        style={
+                          Array [
+                            Object {
+                              "backgroundColor": "white",
+                              "height": 1,
+                            },
+                            undefined,
+                          ]
+                        }
+                      />
                     </View>
                   </View>
                 </View>
@@ -966,7 +972,7 @@ exports[`state is set up with filled consignment metadata 1`] = `
       }
     >
       <View
-        keyboardVerticalOffset={80}
+        keyboardVerticalOffset={15}
         onLayout={[Function]}
         style={
           Array [
@@ -1050,6 +1056,7 @@ exports[`state is set up with filled consignment metadata 1`] = `
                           onSubmitEditing={[Function]}
                           placeholder="Title"
                           placeholderTextColor="#666666"
+                          returnKeyType="next"
                           selectionColor="#cccccc"
                           style={
                             Array [
@@ -1124,6 +1131,7 @@ exports[`state is set up with filled consignment metadata 1`] = `
                           onSubmitEditing={[Function]}
                           placeholder="Year"
                           placeholderTextColor="#666666"
+                          returnKeyType="next"
                           selectionColor="#cccccc"
                           style={
                             Array [
@@ -1142,83 +1150,6 @@ exports[`state is set up with filled consignment metadata 1`] = `
                           }
                           value="1983"
                         />
-                      </View>
-                      <View
-                        style={
-                          Array [
-                            Object {
-                              "backgroundColor": "white",
-                              "height": 1,
-                            },
-                            undefined,
-                          ]
-                        }
-                      />
-                    </View>
-                  </View>
-                  <View
-                    accessibilityComponentType={undefined}
-                    accessibilityLabel={undefined}
-                    accessibilityTraits={undefined}
-                    accessible={true}
-                    hitSlop={undefined}
-                    nativeID={undefined}
-                    onLayout={undefined}
-                    onResponderGrant={[Function]}
-                    onResponderMove={[Function]}
-                    onResponderRelease={[Function]}
-                    onResponderTerminate={[Function]}
-                    onResponderTerminationRequest={[Function]}
-                    onStartShouldSetResponder={[Function]}
-                    style={
-                      Array [
-                        undefined,
-                        Object {
-                          "alignItems": "center",
-                          "flexDirection": "row",
-                          "paddingVertical": 6,
-                        },
-                      ]
-                    }
-                    testID={undefined}
-                  >
-                    <View
-                      style={
-                        Array [
-                          Object {
-                            "margin": 10,
-                          },
-                          Object {
-                            "flex": 1,
-                            "maxHeight": 40,
-                          },
-                        ]
-                      }
-                    >
-                      <View
-                        style={
-                          Object {
-                            "flexDirection": "row",
-                            "height": 40,
-                          }
-                        }
-                      >
-                        <Text
-                          accessible={true}
-                          allowFontScaling={true}
-                          disabled={false}
-                          ellipsizeMode="tail"
-                          style={
-                            Object {
-                              "color": "white",
-                              "fontFamily": "AGaramondPro-Regular",
-                              "fontSize": 20,
-                              "paddingTop": 8,
-                            }
-                          }
-                        >
-                          Design
-                        </Text>
                       </View>
                       <View
                         style={
@@ -1275,6 +1206,7 @@ exports[`state is set up with filled consignment metadata 1`] = `
                           onSubmitEditing={[Function]}
                           placeholder="Medium"
                           placeholderTextColor="#666666"
+                          returnKeyType="next"
                           selectionColor="#cccccc"
                           style={
                             Array [
@@ -1350,6 +1282,7 @@ exports[`state is set up with filled consignment metadata 1`] = `
                           onSubmitEditing={[Function]}
                           placeholder="Width"
                           placeholderTextColor="#666666"
+                          returnKeyType="next"
                           selectionColor="#cccccc"
                           style={
                             Array [
@@ -1412,6 +1345,7 @@ exports[`state is set up with filled consignment metadata 1`] = `
                           onSubmitEditing={[Function]}
                           placeholder="Height"
                           placeholderTextColor="#666666"
+                          returnKeyType="next"
                           selectionColor="#cccccc"
                           style={
                             Array [
@@ -1487,6 +1421,7 @@ exports[`state is set up with filled consignment metadata 1`] = `
                           onSubmitEditing={[Function]}
                           placeholder="Depth"
                           placeholderTextColor="#666666"
+                          returnKeyType="next"
                           selectionColor="#cccccc"
                           style={
                             Array [
@@ -1694,6 +1629,83 @@ exports[`state is set up with filled consignment metadata 1`] = `
                           </View>
                         </View>
                       </View>
+                    </View>
+                  </View>
+                  <View
+                    accessibilityComponentType={undefined}
+                    accessibilityLabel={undefined}
+                    accessibilityTraits={undefined}
+                    accessible={true}
+                    hitSlop={undefined}
+                    nativeID={undefined}
+                    onLayout={undefined}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
+                    style={
+                      Array [
+                        undefined,
+                        Object {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "paddingVertical": 6,
+                        },
+                      ]
+                    }
+                    testID={undefined}
+                  >
+                    <View
+                      style={
+                        Array [
+                          Object {
+                            "margin": 10,
+                          },
+                          Object {
+                            "flex": 1,
+                            "maxHeight": 40,
+                          },
+                        ]
+                      }
+                    >
+                      <View
+                        style={
+                          Object {
+                            "flexDirection": "row",
+                            "height": 40,
+                          }
+                        }
+                      >
+                        <Text
+                          accessible={true}
+                          allowFontScaling={true}
+                          disabled={false}
+                          ellipsizeMode="tail"
+                          style={
+                            Object {
+                              "color": "white",
+                              "fontFamily": "AGaramondPro-Regular",
+                              "fontSize": 20,
+                              "paddingTop": 8,
+                            }
+                          }
+                        >
+                          Design
+                        </Text>
+                      </View>
+                      <View
+                        style={
+                          Array [
+                            Object {
+                              "backgroundColor": "white",
+                              "height": 1,
+                            },
+                            undefined,
+                          ]
+                        }
+                      />
                     </View>
                   </View>
                 </View>

--- a/src/lib/Components/Consignments/Screens/__tests__/__snapshots__/Metadata-tests.tsx.snap
+++ b/src/lib/Components/Consignments/Screens/__tests__/__snapshots__/Metadata-tests.tsx.snap
@@ -207,6 +207,7 @@ exports[`state is set up with empty consignment metadata 1`] = `
                           autoCorrect={false}
                           clearButtonMode="while-editing"
                           keyboardAppearance="dark"
+                          onBlur={[Function]}
                           onChangeText={[Function]}
                           onFocus={[Function]}
                           onSubmitEditing={[Function]}
@@ -234,13 +235,10 @@ exports[`state is set up with empty consignment metadata 1`] = `
                       </View>
                       <View
                         style={
-                          Array [
-                            Object {
-                              "backgroundColor": "white",
-                              "height": 1,
-                            },
-                            undefined,
-                          ]
+                          Object {
+                            "backgroundColor": "#666666",
+                            "height": 1,
+                          }
                         }
                       />
                     </View>
@@ -282,6 +280,7 @@ exports[`state is set up with empty consignment metadata 1`] = `
                           autoCorrect={false}
                           clearButtonMode="while-editing"
                           keyboardAppearance="dark"
+                          onBlur={[Function]}
                           onChangeText={[Function]}
                           onFocus={[Function]}
                           onSubmitEditing={[Function]}
@@ -309,13 +308,10 @@ exports[`state is set up with empty consignment metadata 1`] = `
                       </View>
                       <View
                         style={
-                          Array [
-                            Object {
-                              "backgroundColor": "white",
-                              "height": 1,
-                            },
-                            undefined,
-                          ]
+                          Object {
+                            "backgroundColor": "#666666",
+                            "height": 1,
+                          }
                         }
                       />
                     </View>
@@ -357,6 +353,7 @@ exports[`state is set up with empty consignment metadata 1`] = `
                           autoCorrect={false}
                           clearButtonMode="while-editing"
                           keyboardAppearance="dark"
+                          onBlur={[Function]}
                           onChangeText={[Function]}
                           onFocus={[Function]}
                           onSubmitEditing={[Function]}
@@ -384,13 +381,10 @@ exports[`state is set up with empty consignment metadata 1`] = `
                       </View>
                       <View
                         style={
-                          Array [
-                            Object {
-                              "backgroundColor": "white",
-                              "height": 1,
-                            },
-                            undefined,
-                          ]
+                          Object {
+                            "backgroundColor": "#666666",
+                            "height": 1,
+                          }
                         }
                       />
                     </View>
@@ -433,6 +427,7 @@ exports[`state is set up with empty consignment metadata 1`] = `
                           clearButtonMode="while-editing"
                           keyboardAppearance="dark"
                           keyboardType="numeric"
+                          onBlur={[Function]}
                           onChangeText={[Function]}
                           onFocus={[Function]}
                           onSubmitEditing={[Function]}
@@ -460,13 +455,10 @@ exports[`state is set up with empty consignment metadata 1`] = `
                       </View>
                       <View
                         style={
-                          Array [
-                            Object {
-                              "backgroundColor": "white",
-                              "height": 1,
-                            },
-                            undefined,
-                          ]
+                          Object {
+                            "backgroundColor": "#666666",
+                            "height": 1,
+                          }
                         }
                       />
                     </View>
@@ -496,6 +488,7 @@ exports[`state is set up with empty consignment metadata 1`] = `
                           clearButtonMode="while-editing"
                           keyboardAppearance="dark"
                           keyboardType="numeric"
+                          onBlur={[Function]}
                           onChangeText={[Function]}
                           onFocus={[Function]}
                           onSubmitEditing={[Function]}
@@ -523,13 +516,10 @@ exports[`state is set up with empty consignment metadata 1`] = `
                       </View>
                       <View
                         style={
-                          Array [
-                            Object {
-                              "backgroundColor": "white",
-                              "height": 1,
-                            },
-                            undefined,
-                          ]
+                          Object {
+                            "backgroundColor": "#666666",
+                            "height": 1,
+                          }
                         }
                       />
                     </View>
@@ -572,6 +562,7 @@ exports[`state is set up with empty consignment metadata 1`] = `
                           clearButtonMode="while-editing"
                           keyboardAppearance="dark"
                           keyboardType="numeric"
+                          onBlur={[Function]}
                           onChangeText={[Function]}
                           onFocus={[Function]}
                           onSubmitEditing={[Function]}
@@ -599,13 +590,10 @@ exports[`state is set up with empty consignment metadata 1`] = `
                       </View>
                       <View
                         style={
-                          Array [
-                            Object {
-                              "backgroundColor": "white",
-                              "height": 1,
-                            },
-                            undefined,
-                          ]
+                          Object {
+                            "backgroundColor": "#666666",
+                            "height": 1,
+                          }
                         }
                       />
                     </View>
@@ -853,13 +841,10 @@ exports[`state is set up with empty consignment metadata 1`] = `
                       </View>
                       <View
                         style={
-                          Array [
-                            Object {
-                              "backgroundColor": "white",
-                              "height": 1,
-                            },
-                            undefined,
-                          ]
+                          Object {
+                            "backgroundColor": "#666666",
+                            "height": 1,
+                          }
                         }
                       />
                     </View>
@@ -1051,6 +1036,7 @@ exports[`state is set up with filled consignment metadata 1`] = `
                           autoCorrect={false}
                           clearButtonMode="while-editing"
                           keyboardAppearance="dark"
+                          onBlur={[Function]}
                           onChangeText={[Function]}
                           onFocus={[Function]}
                           onSubmitEditing={[Function]}
@@ -1078,13 +1064,10 @@ exports[`state is set up with filled consignment metadata 1`] = `
                       </View>
                       <View
                         style={
-                          Array [
-                            Object {
-                              "backgroundColor": "white",
-                              "height": 1,
-                            },
-                            undefined,
-                          ]
+                          Object {
+                            "backgroundColor": "#666666",
+                            "height": 1,
+                          }
                         }
                       />
                     </View>
@@ -1126,6 +1109,7 @@ exports[`state is set up with filled consignment metadata 1`] = `
                           autoCorrect={false}
                           clearButtonMode="while-editing"
                           keyboardAppearance="dark"
+                          onBlur={[Function]}
                           onChangeText={[Function]}
                           onFocus={[Function]}
                           onSubmitEditing={[Function]}
@@ -1153,13 +1137,10 @@ exports[`state is set up with filled consignment metadata 1`] = `
                       </View>
                       <View
                         style={
-                          Array [
-                            Object {
-                              "backgroundColor": "white",
-                              "height": 1,
-                            },
-                            undefined,
-                          ]
+                          Object {
+                            "backgroundColor": "#666666",
+                            "height": 1,
+                          }
                         }
                       />
                     </View>
@@ -1201,6 +1182,7 @@ exports[`state is set up with filled consignment metadata 1`] = `
                           autoCorrect={false}
                           clearButtonMode="while-editing"
                           keyboardAppearance="dark"
+                          onBlur={[Function]}
                           onChangeText={[Function]}
                           onFocus={[Function]}
                           onSubmitEditing={[Function]}
@@ -1228,13 +1210,10 @@ exports[`state is set up with filled consignment metadata 1`] = `
                       </View>
                       <View
                         style={
-                          Array [
-                            Object {
-                              "backgroundColor": "white",
-                              "height": 1,
-                            },
-                            undefined,
-                          ]
+                          Object {
+                            "backgroundColor": "#666666",
+                            "height": 1,
+                          }
                         }
                       />
                     </View>
@@ -1277,6 +1256,7 @@ exports[`state is set up with filled consignment metadata 1`] = `
                           clearButtonMode="while-editing"
                           keyboardAppearance="dark"
                           keyboardType="numeric"
+                          onBlur={[Function]}
                           onChangeText={[Function]}
                           onFocus={[Function]}
                           onSubmitEditing={[Function]}
@@ -1304,13 +1284,10 @@ exports[`state is set up with filled consignment metadata 1`] = `
                       </View>
                       <View
                         style={
-                          Array [
-                            Object {
-                              "backgroundColor": "white",
-                              "height": 1,
-                            },
-                            undefined,
-                          ]
+                          Object {
+                            "backgroundColor": "#666666",
+                            "height": 1,
+                          }
                         }
                       />
                     </View>
@@ -1340,6 +1317,7 @@ exports[`state is set up with filled consignment metadata 1`] = `
                           clearButtonMode="while-editing"
                           keyboardAppearance="dark"
                           keyboardType="numeric"
+                          onBlur={[Function]}
                           onChangeText={[Function]}
                           onFocus={[Function]}
                           onSubmitEditing={[Function]}
@@ -1367,13 +1345,10 @@ exports[`state is set up with filled consignment metadata 1`] = `
                       </View>
                       <View
                         style={
-                          Array [
-                            Object {
-                              "backgroundColor": "white",
-                              "height": 1,
-                            },
-                            undefined,
-                          ]
+                          Object {
+                            "backgroundColor": "#666666",
+                            "height": 1,
+                          }
                         }
                       />
                     </View>
@@ -1416,6 +1391,7 @@ exports[`state is set up with filled consignment metadata 1`] = `
                           clearButtonMode="while-editing"
                           keyboardAppearance="dark"
                           keyboardType="numeric"
+                          onBlur={[Function]}
                           onChangeText={[Function]}
                           onFocus={[Function]}
                           onSubmitEditing={[Function]}
@@ -1443,13 +1419,10 @@ exports[`state is set up with filled consignment metadata 1`] = `
                       </View>
                       <View
                         style={
-                          Array [
-                            Object {
-                              "backgroundColor": "white",
-                              "height": 1,
-                            },
-                            undefined,
-                          ]
+                          Object {
+                            "backgroundColor": "#666666",
+                            "height": 1,
+                          }
                         }
                       />
                     </View>
@@ -1697,13 +1670,10 @@ exports[`state is set up with filled consignment metadata 1`] = `
                       </View>
                       <View
                         style={
-                          Array [
-                            Object {
-                              "backgroundColor": "white",
-                              "height": 1,
-                            },
-                            undefined,
-                          ]
+                          Object {
+                            "backgroundColor": "#666666",
+                            "height": 1,
+                          }
                         }
                       />
                     </View>


### PR DESCRIPTION
fixes https://github.com/artsy/emission/issues/850 and https://github.com/artsy/consignments/issues/97

Done:
- return key is now 'next'
- move order of fields so 'category' is last
- toggle now stays black
- done button doesn't float
- placeholders light up on focus (and dim _on blur_)
- updated some margins around the picker

![simulator screen shot - iphone 6 - 9 1 - 2017-12-01 at 18 50 10](https://user-images.githubusercontent.com/373860/33498221-7896807e-d6c8-11e7-8866-1a81a5d4c3eb.png)

![simulator screen shot - ipad pro 12 9 inch - 2017-12-01 at 18 43 24](https://user-images.githubusercontent.com/373860/33498186-59bfab4e-d6c8-11e7-901f-5bb04509ea67.png)
