### PR TITLE
[Inbox => Bugfix] Active Bids component retrieving incorrect data

### DIFF
--- a/src/lib/Components/Inbox/ActiveBids/ActiveBid.tsx
+++ b/src/lib/Components/Inbox/ActiveBids/ActiveBid.tsx
@@ -1,14 +1,11 @@
-import React from "react"
-import { createFragmentContainer, graphql } from "react-relay"
-import styled from "styled-components/native"
-
-import { TouchableWithoutFeedback } from "react-native"
-
-import { BodyText, MetadataText } from "../Typography"
-
 import OpaqueImageView from "lib/Components/OpaqueImageView"
 import colors from "lib/data/colors"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
+import React from "react"
+import { TouchableWithoutFeedback } from "react-native"
+import { createFragmentContainer, graphql } from "react-relay"
+import styled from "styled-components/native"
+import { BodyText, MetadataText } from "../Typography"
 
 const Container = styled.View`
   margin: 17px 20px 0;
@@ -86,7 +83,7 @@ class ActiveBid extends React.Component<RelayProps, State> {
       status = "live_auction"
     } else {
       const leadingBidder = bid.is_leading_bidder
-      const reserveNotMet = bid.active_bid.sale_artwork.reserve_status === "reserve_not_met"
+      const reserveNotMet = bid.most_recent_bid.sale_artwork.reserve_status === "reserve_not_met"
 
       if (leadingBidder) {
         status = reserveNotMet ? "reserve" : "winning"
@@ -111,12 +108,12 @@ class ActiveBid extends React.Component<RelayProps, State> {
   handleTap() {
     const bid = this.props.bid
     // push user into live auction if it's open; otherwise go to artwork
-    const href = this.state.status === "live_auction" ? bid.sale.href : bid.active_bid.sale_artwork.artwork.href
+    const href = this.state.status === "live_auction" ? bid.sale.href : bid.most_recent_bid.sale_artwork.artwork.href
     SwitchBoard.presentNavigationViewController(this, href)
   }
 
   render() {
-    const bid = this.props.bid.active_bid
+    const bid = this.props.bid.most_recent_bid
     const imageURL = bid.sale_artwork.artwork.image.url
     const lotNumber = bid.sale_artwork.lot_number
     const artistName = bid.sale_artwork.artwork.artist_names
@@ -159,7 +156,8 @@ export default createFragmentContainer(
         href
         is_live_open
       }
-      active_bid {
+      most_recent_bid {
+        __id
         max_bid {
           display
         }
@@ -186,7 +184,7 @@ interface RelayProps {
       href: string | null
       is_live_open: boolean | null
     } | null
-    active_bid: {
+    most_recent_bid: {
       max_bid: {
         display: string | null
       } | null

--- a/src/lib/Components/Inbox/ActiveBids/__stories__/ActiveBids.story.tsx
+++ b/src/lib/Components/Inbox/ActiveBids/__stories__/ActiveBids.story.tsx
@@ -1,0 +1,27 @@
+import { storiesOf } from "@storybook/react-native"
+import createEnvironment from "lib/relay/createEnvironment"
+import { InboxRenderer } from "lib/relay/QueryRenderers"
+import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
+import React from "react"
+import { Text, View } from "react-native"
+import { graphql, QueryRenderer, QueryRendererProps } from "react-relay"
+import ActiveBids from "../index"
+
+function ActiveBidsRenderer({ render }) {
+  return (
+    <QueryRenderer
+      environment={createEnvironment()}
+      query={graphql`
+        query ActiveBidsQuery {
+          me {
+            ...ActiveBids_me
+          }
+        }
+      `}
+      variables={{}}
+      render={render}
+    />
+  )
+}
+
+storiesOf("Inbox/Active Bids").add("List", () => <ActiveBidsRenderer render={renderWithLoadProgress(ActiveBids)} />)

--- a/src/lib/Components/Inbox/ActiveBids/__tests__/ActiveBid-tests.tsx
+++ b/src/lib/Components/Inbox/ActiveBids/__tests__/ActiveBid-tests.tsx
@@ -24,7 +24,7 @@ const bid = (isLive?: boolean, isOpen?: boolean) => {
       is_live_open: isOpen,
       href: "/to-the-auction",
     },
-    active_bid: {
+    most_recent_bid: {
       id: "594933e6275b244305851e9c",
       display_max_bid_amount_dollars: "$10,000",
       max_bid: {

--- a/src/lib/Components/Inbox/ActiveBids/index.tsx
+++ b/src/lib/Components/Inbox/ActiveBids/index.tsx
@@ -15,7 +15,7 @@ class ActiveBids extends React.Component<RelayProps, null> {
 
   renderRows() {
     const bids = this.props.me.lot_standings.map(bidData => {
-      return <ActiveBid key={bidData.active_bid.__id} bid={bidData} />
+      return <ActiveBid key={bidData.most_recent_bid.__id} bid={bidData} />
     })
     return bids
   }
@@ -34,8 +34,8 @@ export default createFragmentContainer(
   ActiveBids,
   graphql`
     fragment ActiveBids_me on Me {
-      lot_standings(active_positions: true) {
-        active_bid {
+      lot_standings(live: true) {
+        most_recent_bid {
           __id
         }
         ...ActiveBid_bid
@@ -47,7 +47,7 @@ export default createFragmentContainer(
 interface RelayProps {
   me: {
     lot_standings: Array<{
-      active_bid: {
+      most_recent_bid: {
         __id: string
       } | null
     } | null> | null

--- a/src/lib/Containers/Inbox.tsx
+++ b/src/lib/Containers/Inbox.tsx
@@ -73,8 +73,8 @@ export default createRefetchContainer(
   {
     me: graphql`
       fragment Inbox_me on Me {
-        lot_standings(active_positions: true) {
-          active_bid {
+        lot_standings(live: true) {
+          most_recent_bid {
             __id
           }
         }

--- a/src/lib/Containers/__tests__/Inbox-tests.tsx
+++ b/src/lib/Containers/__tests__/Inbox-tests.tsx
@@ -84,7 +84,7 @@ const meProps = (withBids: boolean = true, withMessages: boolean = true) => {
   const lotStandings = withBids
     ? [
         {
-          active_bid: {
+          most_recent_bid: {
             __id: "594934048b3b8174796e285a",
             id: "594934048b3b8174796e285a",
             display_max_bid_amount_dollars: "$1,100",
@@ -114,7 +114,7 @@ const meProps = (withBids: boolean = true, withMessages: boolean = true) => {
           },
         },
         {
-          active_bid: {
+          most_recent_bid: {
             __id: "594933e6275b244305851e9c",
             id: "594933e6275b244305851e9c",
             display_max_bid_amount_dollars: "$10,000",
@@ -144,7 +144,7 @@ const meProps = (withBids: boolean = true, withMessages: boolean = true) => {
           },
         },
         {
-          active_bid: {
+          most_recent_bid: {
             __id: "594932d0275b244305851e99",
             id: "594932d0275b244305851e99",
             display_max_bid_amount_dollars: "$5,000",

--- a/storybook/storyLoader.js
+++ b/storybook/storyLoader.js
@@ -14,6 +14,7 @@ function loadStories() {
   require('../src/lib/Components/Consignments/__stories__/Search.story.tsx');
   require('../src/lib/Components/Consignments/__stories__/Style.story.tsx');
   require('../src/lib/Components/Consignments/__stories__/Todo.story.tsx');
+  require('../src/lib/Components/Inbox/ActiveBids/__stories__/ActiveBids.story');
   require('../src/lib/Components/Inbox/Conversations/Preview/__stories__/InvoicePreview.story.tsx');
   require('../src/lib/Components/Inbox/Conversations/__stories__/ArtworkPreview.story.tsx');
   require('../src/lib/Components/Inbox/Conversations/__stories__/Avatar.story.tsx');
@@ -32,7 +33,6 @@ function loadStories() {
   require('../src/lib/Scenes/Home/Components/Sales/Components/__stories__/Sales.Components.story.tsx');
   require('../src/lib/Scenes/Home/__stories__/Home.story.tsx');
   require('../src/lib/Scenes/Settings/__stories__/Settings.story.tsx');
-  
 }
 
 const stories = [
@@ -45,6 +45,7 @@ const stories = [
   '../src/lib/Components/Consignments/__stories__/Search.story.tsx',
   '../src/lib/Components/Consignments/__stories__/Style.story.tsx',
   '../src/lib/Components/Consignments/__stories__/Todo.story.tsx',
+  '../src/lib/Components/Inbox/ActiveBids/__stories__/ActiveBids.story',
   '../src/lib/Components/Inbox/Conversations/Preview/__stories__/InvoicePreview.story.tsx',
   '../src/lib/Components/Inbox/Conversations/__stories__/ArtworkPreview.story.tsx',
   '../src/lib/Components/Inbox/Conversations/__stories__/Avatar.story.tsx',
@@ -63,7 +64,7 @@ const stories = [
   '../src/lib/Scenes/Home/Components/Sales/Components/__stories__/Sales.Components.story.tsx',
   '../src/lib/Scenes/Home/__stories__/Home.story.tsx',
   '../src/lib/Scenes/Settings/__stories__/Settings.story.tsx',
-  
+
 ];
 
 module.exports = {


### PR DESCRIPTION
Fixes https://github.com/artsy/emission/issues/864
Fixes https://github.com/artsy/collector-experience/issues/658

Skip New Tests
#trivial

We needed to update the query to reflect more accurate data: 

```
most_recent_bid {
  __id
}
```

Also added a storybook entry under `Inbox/ActiveBids`. 

<img width="419" alt="screen shot 2017-12-01 at 12 54 33 pm" src="https://user-images.githubusercontent.com/236943/33504281-c27a7a24-d69b-11e7-9cbc-b9a215ccc360.png">

