### PR TITLE
[Polish] Adds support for sending Artwork sets through to Eigen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 // Please add your own contribution below inside the Master section
 // These docs are aimed at developers, but are shown inside collector GMV's channel
 
+### Master
+
+-   Allow passing a set of Artworks and an index to load to Eigen when clicking on
+    a Artwork within a grid - orta
+
 ### 1.4.0-beta.9
 
 -   Accommodate selectedArtist parameter in Home container - sarah

--- a/Example/Emission/AppDelegate.m
+++ b/Example/Emission/AppDelegate.m
@@ -159,8 +159,14 @@ randomBOOL(void)
       NSLog(@"Route push - %@", route);
       return;
     }
-    [fromViewController.navigationController pushViewController:[self viewControllerForRoute:route]
-                                                       animated:YES];
+    [fromViewController.navigationController pushViewController:[self viewControllerForRoute:route] animated:YES];
+  };
+
+  // Ignore the set attributes for now inside Emission, just load the artwork as a singleton
+  emission.switchBoardModule.presentArtworkSet = ^(UIViewController * _Nonnull fromViewController, NSArray<NSString *> * _Nonnull artworkIDs, NSNumber * _Nonnull index) {
+    NSString *artworkID = artworkIDs[index.integerValue];
+    NSString *route = [NSString stringWithFormat:@"/artwork/%@", artworkID];
+    [fromViewController.navigationController pushViewController:[self viewControllerForRoute:route] animated:YES];
   };
 
   emission.switchBoardModule.presentModalViewController = ^(UIViewController * _Nonnull fromViewController,

--- a/Pod/Classes/Core/ARSwitchBoardModule.h
+++ b/Pod/Classes/Core/ARSwitchBoardModule.h
@@ -3,8 +3,10 @@
 
 // Invoked on the main thread.
 typedef void(^ARSwitchBoardPresentViewController)(UIViewController * _Nonnull fromViewController, NSString * _Nonnull route);
+typedef void(^ARSwitchBoardHandleArtworkSet)(UIViewController * _Nonnull fromViewController, NSArray<NSString *> * _Nonnull artworkIDs, NSNumber * _Nonnull index);
 
 @interface ARSwitchBoardModule : NSObject <RCTBridgeModule>
 @property (nonatomic, copy, nullable, readwrite) ARSwitchBoardPresentViewController presentNavigationViewController;
 @property (nonatomic, copy, nullable, readwrite) ARSwitchBoardPresentViewController presentModalViewController;
+@property (nonatomic, copy, nullable, readwrite) ARSwitchBoardHandleArtworkSet presentArtworkSet;
 @end

--- a/Pod/Classes/Core/ARSwitchBoardModule.m
+++ b/Pod/Classes/Core/ARSwitchBoardModule.m
@@ -15,6 +15,20 @@ typedef void(^ARSwitchBoardPresentInternalViewController)(UIViewController * _No
 
 RCT_EXPORT_MODULE();
 
+RCT_EXPORT_METHOD(presentArtworksSet:(nonnull NSNumber *)reactTag artworkIDs:(nonnull NSArray<NSString *> *)artworkIDs initialIndex:(nonnull NSNumber *)index)
+{
+    UIView *originatingView = [self.bridge.uiManager viewForReactTag:reactTag];
+    UIView *rootView = originatingView;
+    while (rootView.superview && ![rootView isKindOfClass:RCTRootView.class]) {
+        rootView = rootView.superview;
+    }
+    UIViewController *viewController = rootView.reactViewController;
+    NSParameterAssert(viewController);
+
+    self.presentArtworkSet(viewController, artworkIDs, index);
+}
+
+
 RCT_EXPORT_METHOD(presentNavigationViewController:(nonnull NSNumber *)reactTag route:(nonnull NSString *)route)
 {
   [self invokeCallback:self.presentNavigationViewController reactTag:reactTag route:route];

--- a/src/lib/Components/ArtworkGrids/Artwork.tsx
+++ b/src/lib/Components/ArtworkGrids/Artwork.tsx
@@ -8,9 +8,21 @@ import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import ImageView from "../OpaqueImageView"
 import SerifText from "../Text/Serif"
 
-class Artwork extends React.Component<RelayProps, any> {
+interface Props extends RelayProps {
+  // Passes the Artwork ID back up to another component
+  // ideally, this would be used to send an array of Artworks
+  // through to Eigen where this item is the default selected one.
+  //
+  // If it's not provided, then it will push just the one artwork
+  // to the switchboard.
+  onPress?: (artworkID: string) => void
+}
+
+class Artwork extends React.Component<Props, any> {
   handleTap() {
-    SwitchBoard.presentNavigationViewController(this, this.props.artwork.href)
+    this.props.onPress && this.props.artwork.id
+      ? this.props.onPress(this.props.artwork.id)
+      : SwitchBoard.presentNavigationViewController(this, this.props.artwork.href)
   }
 
   render() {
@@ -122,6 +134,7 @@ export default createFragmentContainer(
       date
       sale_message
       is_in_auction
+      id
       sale_artwork {
         opening_bid {
           display
@@ -151,6 +164,7 @@ export default createFragmentContainer(
 
 interface RelayProps {
   artwork: {
+    id: string
     title: string | null
     date: string | null
     sale_message: string | null

--- a/src/lib/Components/ArtworkGrids/GenericGrid.tsx
+++ b/src/lib/Components/ArtworkGrids/GenericGrid.tsx
@@ -1,7 +1,8 @@
 import React from "react"
+import { LayoutChangeEvent, StyleSheet, View, ViewStyle } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 
-import { LayoutChangeEvent, StyleSheet, View, ViewStyle } from "react-native"
+import SwitchBoard from "lib/NativeModules/SwitchBoard"
 
 import Artwork from "./Artwork"
 
@@ -31,6 +32,12 @@ class GenericArtworksGrid extends React.Component<Props, State> {
     }
 
     this.onLayout = this.onLayout.bind(this)
+  }
+
+  tappedOnArtwork = (artworkID: string) => {
+    const allArtworkIDs = this.props.artworks.map(a => a.id)
+    const index = allArtworkIDs.indexOf(artworkID)
+    SwitchBoard.presentArtworkSet(this, allArtworkIDs, index)
   }
 
   layoutState(currentLayout): State {
@@ -102,7 +109,9 @@ class GenericArtworksGrid extends React.Component<Props, State> {
       const artworks = sectionedArtworks[i]
       for (let j = 0; j < artworks.length; j++) {
         const artwork = artworks[j]
-        artworkComponents.push(<Artwork artwork={artwork} key={artwork.__id + i + j} />)
+        artworkComponents.push(
+          <Artwork artwork={artwork} key={artwork.__id + i + j} onPress={this.tappedOnArtwork.bind(this)} />
+        )
         if (j < artworks.length - 1) {
           artworkComponents.push(<View style={spacerStyle} key={"spacer-" + j} accessibilityLabel="Spacer View" />)
         }
@@ -152,6 +161,7 @@ const GenericGrid = createFragmentContainer(
   graphql`
     fragment GenericGrid_artworks on Artwork @relay(plural: true) {
       __id
+      id
       image {
         aspect_ratio
       }
@@ -165,6 +175,7 @@ export default GenericGrid
 interface RelayProps {
   artworks: Array<{
     __id: string
+    id: string
     image: {
       aspect_ratio: number | null
     } | null

--- a/src/lib/Components/ArtworkGrids/InfiniteScrollGrid.tsx
+++ b/src/lib/Components/ArtworkGrids/InfiniteScrollGrid.tsx
@@ -7,15 +7,15 @@
 // 4. Update height of grid to encompass all items.
 
 import React from "react"
+import { Dimensions, LayoutChangeEvent, ScrollView, StyleSheet, View, ViewStyle } from "react-native"
 import { RelayPaginationProp } from "react-relay"
 
 import { get } from "lodash"
 
-import { Dimensions, LayoutChangeEvent, ScrollView, StyleSheet, View, ViewStyle } from "react-native"
-
 import Spinner from "../Spinner"
 import Artwork from "./Artwork"
 
+import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { isCloseToBottom } from "lib/utils/isCloseToBottom"
 import { ArtistRelayProps } from "./RelayConnections/ArtistForSaleArtworksGrid"
 import { GeneRelayProps } from "./RelayConnections/GeneArtworksGrid"
@@ -33,6 +33,7 @@ export const PageSize = 10
 
 interface Artwork {
   __id: string
+  id: string
   image: {
     aspect_ratio: number | null
   } | null
@@ -169,6 +170,13 @@ class InfiniteScrollArtworksGrid extends React.Component<Props, State> {
     // tslint:enable:no-console
   }
 
+  tappedOnArtwork = (artworkID: string) => {
+    const artworks = this.artworksConnection() ? this.artworksConnection().edges : []
+    const allArtworkIDs = artworks.map(a => a.node.id)
+    const index = allArtworkIDs.indexOf(artworkID)
+    SwitchBoard.presentArtworkSet(this, allArtworkIDs, index)
+  }
+
   onLayout = (event: LayoutChangeEvent) => {
     const layout = event.nativeEvent.layout
     if (layout.width > 0) {
@@ -235,7 +243,13 @@ class InfiniteScrollArtworksGrid extends React.Component<Props, State> {
       const artworkComponents: JSX.Element[] = []
       for (let j = 0; j < sectionedArtworks[i].length; j++) {
         const artwork = sectionedArtworks[i][j]
-        artworkComponents.push(<Artwork artwork={artwork as any} key={"artwork-" + j + "-" + artwork.__id} />)
+        artworkComponents.push(
+          <Artwork
+            artwork={artwork as any}
+            key={"artwork-" + j + "-" + artwork.__id}
+            onPress={this.tappedOnArtwork.bind(this)}
+          />
+        )
         // Setting a marginBottom on the artwork component didn’t work, so using a spacer view instead.
         if (j < artworks.length - 1) {
           artworkComponents.push(

--- a/src/lib/Components/ArtworkGrids/RelayConnections/ArtistForSaleArtworksGrid.tsx
+++ b/src/lib/Components/ArtworkGrids/RelayConnections/ArtistForSaleArtworksGrid.tsx
@@ -30,6 +30,7 @@ const ArtistForSaleArtworksGrid = createPaginationContainer(
           }
           edges {
             node {
+              id
               __id
               image {
                 aspect_ratio
@@ -88,6 +89,7 @@ export interface ArtistRelayProps {
       edges: Array<{
         node: {
           __id: string
+          id: string
           image: {
             aspect_ratio: number | null
           } | null

--- a/src/lib/Components/ArtworkGrids/RelayConnections/ArtistNotForSaleArtworksGrid.tsx
+++ b/src/lib/Components/ArtworkGrids/RelayConnections/ArtistNotForSaleArtworksGrid.tsx
@@ -30,6 +30,7 @@ const ArtistNotForSaleArtworksGrid = createPaginationContainer(
           }
           edges {
             node {
+              id
               __id
               image {
                 aspect_ratio
@@ -88,6 +89,7 @@ export interface ArtistRelayProps {
       edges: Array<{
         node: {
           __id: string
+          id: string
           image: {
             aspect_ratio: number | null
           } | null

--- a/src/lib/Components/ArtworkGrids/RelayConnections/GeneArtworksGrid.tsx
+++ b/src/lib/Components/ArtworkGrids/RelayConnections/GeneArtworksGrid.tsx
@@ -34,6 +34,7 @@ const GeneArtworksGrid = createPaginationContainer(
           }
           edges {
             node {
+              id
               __id
               image {
                 aspect_ratio
@@ -95,6 +96,7 @@ export interface GeneRelayProps {
       edges: Array<{
         node: {
           __id: string
+          id: string
           image: {
             aspect_ratio: number | null
           } | null

--- a/src/lib/Components/ArtworkGrids/RelayConnections/SaleArtworksGrid.tsx
+++ b/src/lib/Components/ArtworkGrids/RelayConnections/SaleArtworksGrid.tsx
@@ -23,6 +23,7 @@ const SaleArtworksGrid = createPaginationContainer(
           edges {
             node {
               artwork {
+                id
                 __id
                 image {
                   aspect_ratio

--- a/src/lib/Components/ArtworkGrids/__tests__/Artwork-tests.tsx
+++ b/src/lib/Components/ArtworkGrids/__tests__/Artwork-tests.tsx
@@ -72,6 +72,7 @@ const artworkProps = (saleArtwork = null) => {
     partner: {
       name: "Gallery 1261",
     },
+    id: "mikael-olson-some-kind-of-dinosaur",
     href: "/artwork/mikael-olson-some-kind-of-dinosaur",
   }
 }

--- a/src/lib/NativeModules/SwitchBoard.tsx
+++ b/src/lib/NativeModules/SwitchBoard.tsx
@@ -54,9 +54,22 @@ function dismissModalViewController(component: React.Component<any, any>) {
   ARSwitchBoardModule.dismissModalViewController(reactTag)
 }
 
+function presentArtworkSet(component: React.Component<any, any>, artworkIDs: string[], index: number) {
+  let reactTag
+  try {
+    reactTag = findNodeHandle(component)
+  } catch (err) {
+    console.error(`Unable to find tag in presentArtworkSet: ${err.message}`)
+    return
+  }
+
+  ARSwitchBoardModule.presentArtworksSet(reactTag, artworkIDs, index)
+}
+
 export default {
   presentNavigationViewController,
   presentMediaPreviewController,
   presentModalViewController,
   dismissModalViewController,
+  presentArtworkSet,
 }

--- a/storybook/storyLoader.js
+++ b/storybook/storyLoader.js
@@ -14,7 +14,7 @@ function loadStories() {
   require('../src/lib/Components/Consignments/__stories__/Search.story.tsx');
   require('../src/lib/Components/Consignments/__stories__/Style.story.tsx');
   require('../src/lib/Components/Consignments/__stories__/Todo.story.tsx');
-  require('../src/lib/Components/Inbox/ActiveBids/__stories__/ActiveBids.story');
+  require('../src/lib/Components/Inbox/ActiveBids/__stories__/ActiveBids.story.tsx');
   require('../src/lib/Components/Inbox/Conversations/Preview/__stories__/InvoicePreview.story.tsx');
   require('../src/lib/Components/Inbox/Conversations/__stories__/ArtworkPreview.story.tsx');
   require('../src/lib/Components/Inbox/Conversations/__stories__/Avatar.story.tsx');
@@ -33,6 +33,7 @@ function loadStories() {
   require('../src/lib/Scenes/Home/Components/Sales/Components/__stories__/Sales.Components.story.tsx');
   require('../src/lib/Scenes/Home/__stories__/Home.story.tsx');
   require('../src/lib/Scenes/Settings/__stories__/Settings.story.tsx');
+  
 }
 
 const stories = [
@@ -45,7 +46,7 @@ const stories = [
   '../src/lib/Components/Consignments/__stories__/Search.story.tsx',
   '../src/lib/Components/Consignments/__stories__/Style.story.tsx',
   '../src/lib/Components/Consignments/__stories__/Todo.story.tsx',
-  '../src/lib/Components/Inbox/ActiveBids/__stories__/ActiveBids.story',
+  '../src/lib/Components/Inbox/ActiveBids/__stories__/ActiveBids.story.tsx',
   '../src/lib/Components/Inbox/Conversations/Preview/__stories__/InvoicePreview.story.tsx',
   '../src/lib/Components/Inbox/Conversations/__stories__/ArtworkPreview.story.tsx',
   '../src/lib/Components/Inbox/Conversations/__stories__/Avatar.story.tsx',
@@ -64,7 +65,7 @@ const stories = [
   '../src/lib/Scenes/Home/Components/Sales/Components/__stories__/Sales.Components.story.tsx',
   '../src/lib/Scenes/Home/__stories__/Home.story.tsx',
   '../src/lib/Scenes/Settings/__stories__/Settings.story.tsx',
-
+  
 ];
 
 module.exports = {


### PR DESCRIPTION
In Eigen the ArtworkVC is a special case against routed VC in two ways:

1. It can be wrapped in a Fair
2. It can accept multiple artworks and paginate between them

In moving to Emission, we lost the ability to do number 2. This brings it back. This adds a new API to the Emission switchboard for routing artworks specifically when you click one within a set like via `GenericGrid` or `InfiniteScrollGrid`. 

This will need work in Eigen when Emission is updated, but it'll be a trivial one liner. Just pass these options to [this function](https://github.com/artsy/eigen/blob/master/Artsy/App/ARSwitchBoard+Eigen.h#L37).

I swear I made an issue for this, but I can't find it anymore. Been annoying me for years :P

Skip New Tests