### PR TITLE
[ImageView] Get rid of `skipGemini` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 -   Change inquiry status bar background to white - maxim
 -   Move pagination from home/sale index to LotsByfollowedArtists, misc QA - chris
 -   Only load a single Works For You page at a time - alloy
+-   Get rid of image view flag that would skip on-the-fly resizing - alloy
 
 ### 1.4.0-beta.9
 

--- a/src/lib/Components/OpaqueImageView.tsx
+++ b/src/lib/Components/OpaqueImageView.tsx
@@ -25,8 +25,6 @@ interface Props {
   /** Any additional styling for the imageview */
   style?: any
 
-  skipGemini?: boolean
-
   /**
    * An aspect ratio created with: width / height.
    *
@@ -82,9 +80,6 @@ export default class OpaqueImageView extends React.Component<Props, State> {
 
   imageURL() {
     const imageURL = this.props.imageURL
-    if (this.props.skipGemini) {
-      return imageURL
-    }
     if (imageURL) {
       // Either scale or crop, based on if an aspect ratio is available.
       const type = this.state.aspectRatio ? "fit" : "fill"

--- a/src/lib/Scenes/Home/Components/Sales/Components/SaleListItem.tsx
+++ b/src/lib/Scenes/Home/Components/Sales/Components/SaleListItem.tsx
@@ -87,8 +87,8 @@ export class SaleListItem extends React.Component<RelayProps, null> {
 
   render() {
     const item = this.props.sale
+    const image = item.cover_image
     const timestamp = (item.live_start_at ? liveDate(item) : timedDate(item)).toUpperCase()
-    const imageURL = (item.cover_image || { cropped: { url: "" } }).cropped.url
     const containerWidth = this.containerWidth
 
     const Container = styled.View`
@@ -100,7 +100,7 @@ export class SaleListItem extends React.Component<RelayProps, null> {
     return (
       <TouchableWithoutFeedback onPress={this.handleTap}>
         <Container>
-          <Image imageURL={imageURL} />
+          <Image imageURL={image && image.url} />
           <Content>
             <Header>
               <Title numberOfLines={2}>
@@ -137,9 +137,8 @@ export default createFragmentContainer(SaleListItem, {
       registration_ends_at
       live_start_at
       cover_image {
-        cropped(width: 158, height: 196, version: "medium") {
-          url
-        }
+        url(version: "large")
+        aspect_ratio
       }
     }
   `,
@@ -158,9 +157,7 @@ interface RelayProps {
     registration_ends_at: string | null
     live_start_at: string | null
     cover_image: {
-      cropped: {
-        url: string | null
-      } | null
+      url: string | null
     }
   } | null
 }

--- a/src/lib/Scenes/Home/Components/Sales/Components/SaleListItem.tsx
+++ b/src/lib/Scenes/Home/Components/Sales/Components/SaleListItem.tsx
@@ -100,7 +100,7 @@ export class SaleListItem extends React.Component<RelayProps, null> {
     return (
       <TouchableWithoutFeedback onPress={this.handleTap}>
         <Container>
-          <Image imageURL={imageURL} skipGemini={true} />
+          <Image imageURL={imageURL} />
           <Content>
             <Header>
               <Title numberOfLines={2}>

--- a/src/lib/Scenes/Home/Components/Sales/Components/__tests__/SaleListItem-tests.tsx
+++ b/src/lib/Scenes/Home/Components/Sales/Components/__tests__/SaleListItem-tests.tsx
@@ -22,9 +22,6 @@ const props = {
   live_start_at: moment().add(5, "hour").toISOString(),
   live_url_if_open: null,
   cover_image: {
-    cropped: {
-      url:
-        "https://d7hftxdivxxvm.cloudfront.net/?resize_to=fill&width=158&height=196&q…A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FeeqLfwMMAYA8XOmeYEb7Rg%2Fsource.jpg",
-    },
+    url: "https://d32dm0rphc51dk.cloudfront.net/eeqLfwMMAYA8XOmeYEb7Rg/source.jpg",
   },
 }

--- a/src/lib/Scenes/Home/Components/Sales/Components/__tests__/__snapshots__/SaleListItem-tests.tsx.snap
+++ b/src/lib/Scenes/Home/Components/Sales/Components/__tests__/__snapshots__/SaleListItem-tests.tsx.snap
@@ -32,7 +32,6 @@ exports[`renders correctly 1`] = `
 >
   <AROpaqueImageView
     imageURL="https://d7hftxdivxxvm.cloudfront.net/?resize_to=fill&width=158&height=196&q…A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FeeqLfwMMAYA8XOmeYEb7Rg%2Fsource.jpg"
-    skipGemini={true}
     style={
       Array [
         Object {

--- a/src/lib/Scenes/Home/Components/Sales/Components/__tests__/__snapshots__/SaleListItem-tests.tsx.snap
+++ b/src/lib/Scenes/Home/Components/Sales/Components/__tests__/__snapshots__/SaleListItem-tests.tsx.snap
@@ -31,7 +31,7 @@ exports[`renders correctly 1`] = `
   testID={undefined}
 >
   <AROpaqueImageView
-    imageURL="https://d7hftxdivxxvm.cloudfront.net/?resize_to=fill&width=158&height=196&q…A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FeeqLfwMMAYA8XOmeYEb7Rg%2Fsource.jpg"
+    imageURL="https://d32dm0rphc51dk.cloudfront.net/eeqLfwMMAYA8XOmeYEb7Rg/source.jpg"
     style={
       Array [
         Object {

--- a/src/lib/Scenes/Home/Components/Sales/__tests__/__snapshots__/index-tests.tsx.snap
+++ b/src/lib/Scenes/Home/Components/Sales/__tests__/__snapshots__/index-tests.tsx.snap
@@ -19,11 +19,10 @@ exports[`looks correct when rendered 1`] = `
             "data": Array [
               Object {
                 "cover_image": Object {
-                  "cropped": Object {
-                    "url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=fill&width=158&height=196&q…A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FWV-7BYlETayN8MGkNjOGXw%2Fsource.jpg",
-                  },
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/WV-7BYlETayN8MGkNjOGXw/source.jpg",
                 },
                 "end_at": null,
+                "href": "/auction/wright-noma",
                 "id": "wright-noma",
                 "is_live_open": true,
                 "is_open": true,
@@ -34,11 +33,10 @@ exports[`looks correct when rendered 1`] = `
               },
               Object {
                 "cover_image": Object {
-                  "cropped": Object {
-                    "url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=fill&width=158&height=196&q…A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FeeqLfwMMAYA8XOmeYEb7Rg%2Fsource.jpg",
-                  },
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/eeqLfwMMAYA8XOmeYEb7Rg/source.jpg",
                 },
                 "end_at": null,
+                "href": "/auction/freemans-modern-and-contemporary-works-of-art",
                 "id": "freemans-modern-and-contemporary-works-of-art",
                 "is_live_open": false,
                 "is_open": true,
@@ -79,11 +77,10 @@ exports[`looks correct when rendered 1`] = `
               "sales": Array [
                 Object {
                   "cover_image": Object {
-                    "cropped": Object {
-                      "url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=fill&width=158&height=196&q…A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FWV-7BYlETayN8MGkNjOGXw%2Fsource.jpg",
-                    },
+                    "url": "https://d32dm0rphc51dk.cloudfront.net/WV-7BYlETayN8MGkNjOGXw/source.jpg",
                   },
                   "end_at": null,
+                  "href": "/auction/wright-noma",
                   "id": "wright-noma",
                   "is_live_open": true,
                   "is_open": true,
@@ -94,11 +91,10 @@ exports[`looks correct when rendered 1`] = `
                 },
                 Object {
                   "cover_image": Object {
-                    "cropped": Object {
-                      "url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=fill&width=158&height=196&q…A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FeeqLfwMMAYA8XOmeYEb7Rg%2Fsource.jpg",
-                    },
+                    "url": "https://d32dm0rphc51dk.cloudfront.net/eeqLfwMMAYA8XOmeYEb7Rg/source.jpg",
                   },
                   "end_at": null,
+                  "href": "/auction/freemans-modern-and-contemporary-works-of-art",
                   "id": "freemans-modern-and-contemporary-works-of-art",
                   "is_live_open": false,
                   "is_open": true,
@@ -141,11 +137,10 @@ exports[`looks correct when rendered 1`] = `
             "data": Array [
               Object {
                 "cover_image": Object {
-                  "cropped": Object {
-                    "url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=fill&width=158&height=196&q…A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FWV-7BYlETayN8MGkNjOGXw%2Fsource.jpg",
-                  },
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/WV-7BYlETayN8MGkNjOGXw/source.jpg",
                 },
                 "end_at": null,
+                "href": "/auction/wright-noma",
                 "id": "wright-noma",
                 "is_live_open": true,
                 "is_open": true,
@@ -156,11 +151,10 @@ exports[`looks correct when rendered 1`] = `
               },
               Object {
                 "cover_image": Object {
-                  "cropped": Object {
-                    "url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=fill&width=158&height=196&q…A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FeeqLfwMMAYA8XOmeYEb7Rg%2Fsource.jpg",
-                  },
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/eeqLfwMMAYA8XOmeYEb7Rg/source.jpg",
                 },
                 "end_at": null,
+                "href": "/auction/freemans-modern-and-contemporary-works-of-art",
                 "id": "freemans-modern-and-contemporary-works-of-art",
                 "is_live_open": false,
                 "is_open": true,
@@ -201,11 +195,10 @@ exports[`looks correct when rendered 1`] = `
               "sales": Array [
                 Object {
                   "cover_image": Object {
-                    "cropped": Object {
-                      "url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=fill&width=158&height=196&q…A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FWV-7BYlETayN8MGkNjOGXw%2Fsource.jpg",
-                    },
+                    "url": "https://d32dm0rphc51dk.cloudfront.net/WV-7BYlETayN8MGkNjOGXw/source.jpg",
                   },
                   "end_at": null,
+                  "href": "/auction/wright-noma",
                   "id": "wright-noma",
                   "is_live_open": true,
                   "is_open": true,
@@ -216,11 +209,10 @@ exports[`looks correct when rendered 1`] = `
                 },
                 Object {
                   "cover_image": Object {
-                    "cropped": Object {
-                      "url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=fill&width=158&height=196&q…A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FeeqLfwMMAYA8XOmeYEb7Rg%2Fsource.jpg",
-                    },
+                    "url": "https://d32dm0rphc51dk.cloudfront.net/eeqLfwMMAYA8XOmeYEb7Rg/source.jpg",
                   },
                   "end_at": null,
+                  "href": "/auction/freemans-modern-and-contemporary-works-of-art",
                   "id": "freemans-modern-and-contemporary-works-of-art",
                   "is_live_open": false,
                   "is_open": true,
@@ -298,11 +290,10 @@ exports[`looks correct when rendered 1`] = `
             Array [
               Object {
                 "cover_image": Object {
-                  "cropped": Object {
-                    "url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=fill&width=158&height=196&q…A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FWV-7BYlETayN8MGkNjOGXw%2Fsource.jpg",
-                  },
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/WV-7BYlETayN8MGkNjOGXw/source.jpg",
                 },
                 "end_at": null,
+                "href": "/auction/wright-noma",
                 "id": "wright-noma",
                 "is_live_open": true,
                 "is_open": true,
@@ -313,11 +304,10 @@ exports[`looks correct when rendered 1`] = `
               },
               Object {
                 "cover_image": Object {
-                  "cropped": Object {
-                    "url": "https://d7hftxdivxxvm.cloudfront.net/?resize_to=fill&width=158&height=196&q…A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FeeqLfwMMAYA8XOmeYEb7Rg%2Fsource.jpg",
-                  },
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/eeqLfwMMAYA8XOmeYEb7Rg/source.jpg",
                 },
                 "end_at": null,
+                "href": "/auction/freemans-modern-and-contemporary-works-of-art",
                 "id": "freemans-modern-and-contemporary-works-of-art",
                 "is_live_open": false,
                 "is_open": true,
@@ -394,7 +384,7 @@ exports[`looks correct when rendered 1`] = `
                 testID={undefined}
               >
                 <AROpaqueImageView
-                  imageURL="https://d7hftxdivxxvm.cloudfront.net/?resize_to=fill&width=158&height=196&q…A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FWV-7BYlETayN8MGkNjOGXw%2Fsource.jpg"
+                  imageURL="https://d32dm0rphc51dk.cloudfront.net/WV-7BYlETayN8MGkNjOGXw/source.jpg"
                   style={
                     Array [
                       Object {
@@ -579,7 +569,7 @@ exports[`looks correct when rendered 1`] = `
                 testID={undefined}
               >
                 <AROpaqueImageView
-                  imageURL="https://d7hftxdivxxvm.cloudfront.net/?resize_to=fill&width=158&height=196&q…A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FeeqLfwMMAYA8XOmeYEb7Rg%2Fsource.jpg"
+                  imageURL="https://d32dm0rphc51dk.cloudfront.net/eeqLfwMMAYA8XOmeYEb7Rg/source.jpg"
                   style={
                     Array [
                       Object {

--- a/src/lib/Scenes/Home/Components/Sales/__tests__/__snapshots__/index-tests.tsx.snap
+++ b/src/lib/Scenes/Home/Components/Sales/__tests__/__snapshots__/index-tests.tsx.snap
@@ -395,7 +395,6 @@ exports[`looks correct when rendered 1`] = `
               >
                 <AROpaqueImageView
                   imageURL="https://d7hftxdivxxvm.cloudfront.net/?resize_to=fill&width=158&height=196&q…A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FWV-7BYlETayN8MGkNjOGXw%2Fsource.jpg"
-                  skipGemini={true}
                   style={
                     Array [
                       Object {
@@ -581,7 +580,6 @@ exports[`looks correct when rendered 1`] = `
               >
                 <AROpaqueImageView
                   imageURL="https://d7hftxdivxxvm.cloudfront.net/?resize_to=fill&width=158&height=196&q…A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FeeqLfwMMAYA8XOmeYEb7Rg%2Fsource.jpg"
-                  skipGemini={true}
                   style={
                     Array [
                       Object {

--- a/src/lib/Scenes/Home/Components/Sales/__tests__/index-tests.tsx
+++ b/src/lib/Scenes/Home/Components/Sales/__tests__/index-tests.tsx
@@ -5,7 +5,7 @@ import * as renderer from "react-test-renderer"
 import Sales from "../index"
 
 it("looks correct when rendered", () => {
-  const auctions = renderer.create(<Sales {...props as any} />)
+  const auctions = renderer.create(<Sales {...props} />)
   expect(auctions).toMatchSnapshot()
 })
 
@@ -19,6 +19,7 @@ const props = {
     sales: [
       {
         id: "wright-noma",
+        href: "/auction/wright-noma",
         name: "Wright: noma",
         is_open: true,
         is_live_open: true,
@@ -27,14 +28,12 @@ const props = {
         registration_ends_at: "2017-11-01T13:00:00+00:00",
         live_start_at: "2017-11-02T13:00:00+00:00",
         cover_image: {
-          cropped: {
-            url:
-              "https://d7hftxdivxxvm.cloudfront.net/?resize_to=fill&width=158&height=196&q…A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FWV-7BYlETayN8MGkNjOGXw%2Fsource.jpg",
-          },
+          url: "https://d32dm0rphc51dk.cloudfront.net/WV-7BYlETayN8MGkNjOGXw/source.jpg",
         },
       },
       {
         id: "freemans-modern-and-contemporary-works-of-art",
+        href: "/auction/freemans-modern-and-contemporary-works-of-art",
         name: "Freeman's: Modern & Contemporary Works of Art",
         is_open: true,
         is_live_open: false,
@@ -43,10 +42,7 @@ const props = {
         registration_ends_at: "2017-11-01T17:00:00+00:00",
         live_start_at: "2017-11-02T17:00:00+00:00",
         cover_image: {
-          cropped: {
-            url:
-              "https://d7hftxdivxxvm.cloudfront.net/?resize_to=fill&width=158&height=196&q…A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FeeqLfwMMAYA8XOmeYEb7Rg%2Fsource.jpg",
-          },
+          url: "https://d32dm0rphc51dk.cloudfront.net/eeqLfwMMAYA8XOmeYEb7Rg/source.jpg",
         },
       },
     ],


### PR DESCRIPTION
A flag called `skipGemini` was [added to the image component](https://github.com/artsy/emission/pull/630), which was seemingly only done to work around a problem with [Gemini not being able to read images from `https` sources](https://artsy.slack.com/archives/C04DU9H0L/p1498517025120402). However, the issue was [apparently](https://artsy.slack.com/archives/C0GNAB0US/p1498763267827192) resolved with [this PR](https://github.com/artsy/gemini/pull/242).

The flag was never removed and got used in new auction related code https://github.com/artsy/emission/commit/5dde988d4af49dc8e150e845c3aac8779a5a8407#diff-741b505d177ba9a6e497cd077987ab45R47

Skip New Tests