### PR TITLE
[Cleanup] Enable noUnusedLocals/Parameters and remove all refs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -65,5 +65,8 @@
   "stylelint.additionalDocumentSelectors": ["typescript", "typescriptreact"],
   "todohighlight.exclude": ["node_modules/**", ".vscode/**", "externals/**"],
   "tslint.autoFixOnSave": true,
-  "typescript.format.enable": false
+  "typescript.format.enable": false,
+  "[json]": {
+    "editor.formatOnSave": false
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 -   QA on Inbox and Active Bids spacing - maxim
 -   iPad support for Active Bids - maxim
 -   Get rid of image view flag that would skip on-the-fly resizing - alloy
+-   Add noUnusedLocals / noUnusedParameters to tslint config; clean up refs in app -chris
 
 ### 1.4.0-beta.9
 

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
       ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
     },
     "testRegex": "/__tests__/.*-tests.(ts|tsx|js)$",
-    "testPathIgnorePatterns": ["\\.snap$", "<rootDir>/node_modules/"],
+    "testPathIgnorePatterns": ["\\.snap$", "<rootDir>/build", "<rootDir>/node_modules/"],
     "setupFiles": ["./src/setupJest.ts"],
     "cacheDirectory": ".jest/cache"
   },

--- a/src/lib/AppRegistry.tsx
+++ b/src/lib/AppRegistry.tsx
@@ -1,7 +1,5 @@
-import * as _ from "lodash"
 import React from "react"
-import { AppRegistry, View, ViewProperties } from "react-native"
-import { TrackingInfo } from "react-tracking"
+import { AppRegistry, View } from "react-native"
 
 import Consignments from "./Components/Consignments"
 import Containers from "./Containers/index"
@@ -12,24 +10,18 @@ import {
   InboxRenderer,
   InquiryRenderer,
   MyProfileRenderer,
-  RenderCallback,
-  SaleRenderer,
   WorksForYouRenderer,
 } from "./relay/QueryRenderers"
 import FavoritesScene from "./Scenes/Favorites"
 import HomeScene from "./Scenes/Home"
 import renderWithLoadProgress from "./utils/renderWithLoadProgress"
-import { Schema, screenTrack as track, Track } from "./utils/track"
-
-// Analytics wrapper for all of our top level React components
-function AddTrack(pageName: string) {
-  return component => component
-}
+import { Schema, screenTrack as track } from "./utils/track"
 
 interface ArtistProps {
   artistID: string
   isPad: boolean
 }
+
 const Artist: React.SFC<ArtistProps> = track<ArtistProps>(props => {
   return {
     context_screen: Schema.PageNames.ArtistPage,
@@ -38,7 +30,7 @@ const Artist: React.SFC<ArtistProps> = track<ArtistProps>(props => {
   }
 })(props => <ArtistRenderer {...props} render={renderWithLoadProgress(Containers.Artist, props)} />)
 
-const Inbox: React.SFC<{}> = track<{}>(props => {
+const Inbox: React.SFC<{}> = track<{}>(() => {
   return { context_screen: Schema.PageNames.InboxPage, context_screen_owner_type: null }
 })(props => <InboxRenderer {...props} render={renderWithLoadProgress(Containers.Inbox, props)} />)
 
@@ -52,10 +44,11 @@ const Gene: React.SFC<GeneProps> = ({ geneID, refineSettings: { medium, price_ra
   return <GeneRenderer {...initialProps} render={renderWithLoadProgress(Containers.Gene, initialProps)} />
 }
 
-const Sale: React.SFC<{ saleID: string }> = ({ saleID }) => {
-  const initialProps = { saleID }
-  return <SaleRenderer {...initialProps} render={renderWithLoadProgress(Containers.Sale, initialProps)} />
-}
+// FIXME: This isn't being used
+// const Sale: React.SFC<{ saleID: string }> = ({ saleID }) => {
+//   const initialProps = { saleID }
+//   return <SaleRenderer {...initialProps} render={renderWithLoadProgress(Containers.Sale, initialProps)} />
+// }
 
 // TODO: This was required to trigger the 1px wake-up hack (in case the scrollview goes blank)
 //

--- a/src/lib/Components/Artist/Articles/Article.tsx
+++ b/src/lib/Components/Artist/Articles/Article.tsx
@@ -7,20 +7,7 @@ import fonts from "lib/data/fonts"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import ImageView from "../../OpaqueImageView"
 
-interface Props extends ViewProperties {
-  article: {
-    href: string
-    author: {
-      name
-    }
-    thumbnail_image: {
-      url
-    }
-    thumbnail_title: string
-  }
-}
-
-class Article extends React.Component<Props, {}> {
+class Article extends React.Component<RelayProps & ViewProperties> {
   handleTap() {
     SwitchBoard.presentNavigationViewController(this, this.props.article.href)
   }

--- a/src/lib/Components/Artist/Articles/index.tsx
+++ b/src/lib/Components/Artist/Articles/index.tsx
@@ -1,15 +1,11 @@
-import React from "react"
+import React, { Component } from "react"
 import { ScrollView, StyleSheet, View, ViewProperties } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 
 import SerifText from "../../Text/Serif"
 import Article from "./Article"
 
-interface Props extends ViewProperties {
-  articles: any[]
-}
-
-class Articles extends React.Component<Props, {}> {
+class Articles extends Component<RelayProps & ViewProperties> {
   render() {
     const articles = this.props.articles
     return (
@@ -21,7 +17,7 @@ class Articles extends React.Component<Props, {}> {
           scrollsToTop={false}
           style={{ overflow: "visible", marginBottom: 40 }}
         >
-          {articles.map(article => <Article key={article.__id} article={article} style={styles.article} />)}
+          {articles.map(article => <Article key={article.__id} article={article as any} style={styles.article} />)}
         </ScrollView>
       </View>
     )

--- a/src/lib/Components/Artist/Artworks/index.tsx
+++ b/src/lib/Components/Artist/Artworks/index.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { Component } from "react"
 import { StyleSheet, View, ViewProperties } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 
@@ -19,33 +19,22 @@ interface RenderSectionParams {
   mapPropsToArtworksConnection: (Props) => any
 }
 
-interface Props extends ViewProperties {
-  artist: {
-    counts: {
-      for_sale_artworks: number
-      artworks: number
-    }
-    not_for_sale_artworks: any[]
-    for_sale_artworks: any[]
-  }
-  relay: any
+interface Props extends RelayProps, ViewProperties {
+  relay?: RelayProps
 }
 
 interface State {
   completedForSaleWorks: boolean
 }
 
-class Artworks extends React.Component<Props, State> {
-  constructor(props) {
-    super(props)
-    this.state = {
-      completedForSaleWorks: false,
-    }
+class Artworks extends Component<Props, State> {
+  state = {
+    completedForSaleWorks: false,
   }
 
   render() {
     const forSaleCount = this.props.artist.counts.for_sale_artworks
-    const otherCount = this.props.artist.counts.artworks - forSaleCount
+    const otherCount = (this.props.artist.counts.artworks as number) - (forSaleCount as number)
     if (forSaleCount === 0) {
       return this.renderSection({
         title: "Works",
@@ -75,7 +64,7 @@ class Artworks extends React.Component<Props, State> {
         <View style={styles.section}>
           {this.renderSection({
             title: "Works for Sale",
-            count: forSaleCount,
+            count: forSaleCount as number,
             filter: "IS_FOR_SALE",
             onComplete: () => this.setState({ completedForSaleWorks: true }),
             Component: ArtistForSaleArtworksGrid,
@@ -144,7 +133,5 @@ interface RelayProps {
       artworks: boolean | number | string | null
       for_sale_artworks: boolean | number | string | null
     } | null
-    for_sale_artworks: Array<boolean | number | string | null> | null
-    not_for_sale_artworks: Array<boolean | number | string | null> | null
   }
 }

--- a/src/lib/Components/Artist/Biography.tsx
+++ b/src/lib/Components/Artist/Biography.tsx
@@ -9,11 +9,7 @@ import SerifText from "../Text/Serif"
 
 const sideMargin = Dimensions.get("window").width > 700 ? 50 : 0
 
-interface Props extends ViewProperties {
-  artist: any
-}
-
-class Biography extends React.Component<Props, any> {
+class Biography extends React.Component<RelayProps & ViewProperties> {
   render() {
     const artist = this.props.artist
     if (!artist.blurb && !artist.bio) {

--- a/src/lib/Components/Artist/Header.tsx
+++ b/src/lib/Components/Artist/Header.tsx
@@ -7,8 +7,6 @@ import { createFragmentContainer, graphql } from "react-relay"
 import { Dimensions, NativeModules, StyleSheet, TextStyle, View, ViewStyle } from "react-native"
 const { ARTemporaryAPIModule } = NativeModules
 
-import Events from "lib/NativeModules/Events"
-
 import colors from "lib/data/colors"
 import InvertedButton from "../Buttons/InvertedButton"
 import Headline from "../Text/Headline"
@@ -49,6 +47,10 @@ class Header extends React.Component<Props, State> {
 
   componentDidMount() {
     NativeModules.ARTemporaryAPIModule.followStatusForArtist(this.props.artist._id, (error, following) => {
+      if (error) {
+        // FIXME: Handle error
+        console.error("Artist/Header.tsx", error.message)
+      }
       this.setState({ following })
     })
   }

--- a/src/lib/Components/Artist/Shows/Metadata.tsx
+++ b/src/lib/Components/Artist/Shows/Metadata.tsx
@@ -7,23 +7,7 @@ import SerifText from "lib/Components/Text/Serif"
 import colors from "lib/data/colors"
 import fonts from "lib/data/fonts"
 
-interface Props extends ViewProperties {
-  show: {
-    name: string
-    kind: string
-    exhibition_period: string
-    location?: {
-      city: string
-    }
-    status_update?: string
-    status: string
-    partner?: {
-      name: string
-    }
-  }
-}
-
-class Metadata extends React.Component<Props, any> {
+class Metadata extends React.Component<RelayProps & ViewProperties> {
   render() {
     const partnerName = this.props.show.partner && this.props.show.partner.name
     return (

--- a/src/lib/Components/Artist/Shows/Show.tsx
+++ b/src/lib/Components/Artist/Shows/Show.tsx
@@ -6,13 +6,7 @@ import SwitchBoard from "../../../NativeModules/SwitchBoard"
 import OpaqueImageView from "../../OpaqueImageView"
 import Metadata from "./Metadata"
 
-interface Props extends ViewProperties {
-  show: {
-    href: string
-    cover_image: {
-      url: string
-    }
-  }
+interface Props extends RelayProps, ViewProperties {
   styles?: {
     container?: any
     image?: any
@@ -20,7 +14,7 @@ interface Props extends ViewProperties {
   }
 }
 
-class Show extends React.Component<Props, {}> {
+class Show extends React.Component<Props> {
   handleTap() {
     SwitchBoard.presentNavigationViewController(this, this.props.show.href)
   }

--- a/src/lib/Components/Artist/Shows/SmallList.tsx
+++ b/src/lib/Components/Artist/Shows/SmallList.tsx
@@ -6,15 +6,11 @@ import Show from "./Show"
 
 import colors from "lib/data/colors"
 
-interface Props extends ViewProperties {
-  shows: any[]
-}
-
 interface State {
   dataSource: ListViewDataSource
 }
 
-class SmallList extends React.Component<Props, State> {
+class SmallList extends React.Component<RelayProps & ViewProperties, State> {
   constructor(props) {
     super(props)
     this.state = {

--- a/src/lib/Components/Artist/Shows/VariableSizeShowsList.tsx
+++ b/src/lib/Components/Artist/Shows/VariableSizeShowsList.tsx
@@ -1,13 +1,12 @@
-import React from "react"
+import React, { Component } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 
 import { LayoutChangeEvent, StyleSheet, View, ViewProperties, ViewStyle } from "react-native"
 
 import Show from "./Show"
 
-interface Props extends ViewProperties {
+interface Props extends RelayProps, ViewProperties {
   showSize: "medium" | "large"
-  shows: any[]
 }
 
 interface State {
@@ -15,14 +14,10 @@ interface State {
   height: number
 }
 
-class ShowsList extends React.Component<Props, State> {
-  constructor(props) {
-    super(props)
-
-    this.state = {
-      width: 1,
-      height: 1,
-    }
+class ShowsList extends Component<Props, State> {
+  state = {
+    width: 1,
+    height: 1,
   }
 
   imageDimensions(layout) {

--- a/src/lib/Components/Artist/Shows/index.tsx
+++ b/src/lib/Components/Artist/Shows/index.tsx
@@ -1,16 +1,13 @@
 import React from "react"
+import { StyleSheet, TextStyle, View, ViewStyle } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
-
-import { Dimensions, StyleSheet, TextStyle, View, ViewProperties, ViewStyle } from "react-native"
 
 import Separator from "../../Separator"
 import SerifText from "../../Text/Serif"
 import SmallList from "./SmallList"
 import VariableSizeShowsList from "./VariableSizeShowsList"
 
-const windowDimensions = Dimensions.get("window")
-
-class Shows extends React.Component<RelayProps, any> {
+class Shows extends React.Component<RelayProps> {
   render() {
     return (
       <View style={styles.container}>
@@ -98,6 +95,8 @@ interface RelayProps {
     current_shows: Array<boolean | number | string | null> | null
     upcoming_shows: Array<boolean | number | string | null> | null
     past_small_shows: Array<boolean | number | string | null> | null
-    past_large_shows: Array<boolean | number | string | null> | null
+    past_large_shows: Array<{
+      __id: string | null
+    }> | null
   }
 }

--- a/src/lib/Components/Artist/__stories__/ArtistHeader.story.tsx
+++ b/src/lib/Components/Artist/__stories__/ArtistHeader.story.tsx
@@ -1,8 +1,6 @@
 import { storiesOf } from "@storybook/react-native"
 import React from "react"
 import { View } from "react-native"
-import { Environment, Network, RecordSource, Store } from "relay-runtime"
-// import StubContainer from "react-storybooks-relay-container"
 
 import Header from "../Header"
 

--- a/src/lib/Components/Artist/__tests__/Artworks-tests.tsx
+++ b/src/lib/Components/Artist/__tests__/Artworks-tests.tsx
@@ -12,6 +12,6 @@ it("renders properly", () => {
       for_sale_artworks: 2,
     },
   }
-  const artworks = renderer.create(<Artworks artist={artist} />).toJSON()
+  const artworks = renderer.create(<Artworks artist={artist as any} />).toJSON()
   expect(artworks).toMatchSnapshot()
 })

--- a/src/lib/Components/ArtworkGrids/InfiniteScrollGrid.tsx
+++ b/src/lib/Components/ArtworkGrids/InfiniteScrollGrid.tsx
@@ -10,8 +10,6 @@ import React from "react"
 import { Dimensions, LayoutChangeEvent, ScrollView, StyleSheet, View, ViewStyle } from "react-native"
 import { RelayPaginationProp } from "react-relay"
 
-import { get } from "lodash"
-
 import Spinner from "../Spinner"
 import Artwork from "./Artwork"
 
@@ -20,7 +18,7 @@ import { isCloseToBottom } from "lib/utils/isCloseToBottom"
 import { ArtistRelayProps } from "./RelayConnections/ArtistForSaleArtworksGrid"
 import { GeneRelayProps } from "./RelayConnections/GeneArtworksGrid"
 
-export const PageSize = 10
+import { PAGE_SIZE } from "lib/data/constants"
 
 /**
  * TODO:
@@ -110,8 +108,6 @@ class InfiniteScrollArtworksGrid extends React.Component<Props, State> {
     fetchingNextPage: false,
   }
 
-  private sentEndForContentLength: null | number = null
-
   artworksConnection(): ArtworksConnection {
     return this.props.mapPropsToArtworksConnection(this.props)
   }
@@ -121,7 +117,11 @@ class InfiniteScrollArtworksGrid extends React.Component<Props, State> {
       return
     }
     this.setState({ fetchingNextPage: true })
-    this.props.relay.loadMore(PageSize, error => {
+    this.props.relay.loadMore(PAGE_SIZE, error => {
+      if (error) {
+        // FIXME: Handle error
+        console.error("InfiniteScrollGrid.tsx", error.message)
+      }
       this.setState({ fetchingNextPage: false })
       if (!this.artworksConnection().pageInfo.hasNextPage && this.props.onComplete) {
         this.props.onComplete()

--- a/src/lib/Components/ArtworkGrids/RelayConnections/ArtistForSaleArtworksGrid.tsx
+++ b/src/lib/Components/ArtworkGrids/RelayConnections/ArtistForSaleArtworksGrid.tsx
@@ -1,5 +1,5 @@
 import { createPaginationContainer, graphql } from "react-relay"
-import InfiniteScrollArtworksGrid, { PageSize } from "../InfiniteScrollGrid"
+import InfiniteScrollArtworksGrid from "../InfiniteScrollGrid"
 
 import Artwork from "../Artwork"
 // tslint:disable-next-line:no-unused-expression

--- a/src/lib/Components/ArtworkGrids/RelayConnections/ArtistNotForSaleArtworksGrid.tsx
+++ b/src/lib/Components/ArtworkGrids/RelayConnections/ArtistNotForSaleArtworksGrid.tsx
@@ -1,5 +1,5 @@
 import { createPaginationContainer, graphql } from "react-relay"
-import InfiniteScrollArtworksGrid, { PageSize } from "../InfiniteScrollGrid"
+import InfiniteScrollArtworksGrid from "../InfiniteScrollGrid"
 
 import Artwork from "../Artwork"
 // tslint:disable-next-line:no-unused-expression

--- a/src/lib/Components/ArtworkGrids/RelayConnections/GeneArtworksGrid.tsx
+++ b/src/lib/Components/ArtworkGrids/RelayConnections/GeneArtworksGrid.tsx
@@ -1,5 +1,5 @@
 import { createPaginationContainer, graphql } from "react-relay"
-import InfiniteScrollArtworksGrid, { PageSize } from "../InfiniteScrollGrid"
+import InfiniteScrollArtworksGrid from "../InfiniteScrollGrid"
 
 import Artwork from "../Artwork"
 // tslint:disable-next-line:no-unused-expression

--- a/src/lib/Components/ArtworkGrids/RelayConnections/SaleArtworksGrid.tsx
+++ b/src/lib/Components/ArtworkGrids/RelayConnections/SaleArtworksGrid.tsx
@@ -1,5 +1,5 @@
 import { createPaginationContainer, graphql } from "react-relay"
-import InfiniteScrollArtworksGrid, { PageSize, Props as GridProps } from "../InfiniteScrollGrid"
+import InfiniteScrollArtworksGrid, { Props as GridProps } from "../InfiniteScrollGrid"
 
 import Artwork from "../Artwork"
 // tslint:disable-next-line:no-unused-expression

--- a/src/lib/Components/Buttons/Button.tsx
+++ b/src/lib/Components/Buttons/Button.tsx
@@ -1,7 +1,6 @@
 import React from "react"
-import { Animated, StyleSheet, TouchableWithoutFeedback, View, ViewProperties } from "react-native"
+import { Animated, StyleSheet, TouchableWithoutFeedback, View } from "react-native"
 
-import colors from "lib/data/colors"
 import Headline from "../Text/Headline"
 
 import { ButtonProps } from "./"
@@ -61,7 +60,7 @@ export default class Button extends React.Component<Props, State> {
     }
   }
 
-  componentDidUpdate(prevProps: any, prevState: any) {
+  componentDidUpdate(_prevProps: any, prevState: any) {
     if (this.state.displayState !== prevState.displayState) {
       // Don't animate in when it's the initial press down
       const showHighlight =

--- a/src/lib/Components/Buttons/DarkNavigationButton.tsx
+++ b/src/lib/Components/Buttons/DarkNavigationButton.tsx
@@ -1,11 +1,10 @@
 import React from "react"
-import { Image, TouchableWithoutFeedback, View } from "react-native"
+import { Image, TouchableWithoutFeedback } from "react-native"
 import styled from "styled-components/native"
 
 import { Colors } from "lib/data/colors"
 import { Fonts } from "lib/data/fonts"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
-import Separator from "../Separator"
 
 interface Props extends React.Props<DarkNavigationButton> {
   href?: string

--- a/src/lib/Components/Buttons/FlatWhite.tsx
+++ b/src/lib/Components/Buttons/FlatWhite.tsx
@@ -40,7 +40,7 @@ export default class WhiteButton extends React.Component<Props, State> {
     }
   }
 
-  componentDidUpdate(prevProps: any, prevState: any) {
+  componentDidUpdate(prevProps: any) {
     if (this.props.selected !== prevProps.selected) {
       const duration = AnimationDuration
       Animated.parallel([

--- a/src/lib/Components/Buttons/InvertedButton.tsx
+++ b/src/lib/Components/Buttons/InvertedButton.tsx
@@ -37,7 +37,7 @@ export default class InvertedButton extends React.Component<InvertedButtonProps,
     }
   }
 
-  componentDidUpdate(prevProps: any, prevState: any) {
+  componentDidUpdate(prevProps: any) {
     if (this.props.selected !== prevProps.selected) {
       const duration = AnimationDuration
       Animated.parallel([

--- a/src/lib/Components/ConnectivityBanner.tsx
+++ b/src/lib/Components/ConnectivityBanner.tsx
@@ -1,6 +1,4 @@
 import React from "react"
-import * as Relay from "react-relay"
-
 import styled from "styled-components/native"
 
 import colors from "lib/data/colors"

--- a/src/lib/Components/Consignments/Components/ArtworkConsignmentTodo.tsx
+++ b/src/lib/Components/Consignments/Components/ArtworkConsignmentTodo.tsx
@@ -1,14 +1,6 @@
 import React from "react"
-import {
-  ButtonProperties,
-  Image,
-  StyleProp,
-  TouchableHighlight,
-  TouchableHighlightProperties,
-  ViewStyle,
-} from "react-native"
+import { Image, StyleProp, TouchableHighlight, TouchableHighlightProperties, ViewStyle } from "react-native"
 
-import colors from "lib/data/colors"
 import fonts from "lib/data/fonts"
 import styled from "styled-components/native"
 

--- a/src/lib/Components/Consignments/Components/ConsignmentBG.tsx
+++ b/src/lib/Components/Consignments/Components/ConsignmentBG.tsx
@@ -1,12 +1,10 @@
 import React from "react"
-import { Image, LayoutChangeEvent, View, ViewProperties, ViewStyle } from "react-native"
+import { ViewProperties } from "react-native"
 
 import styled from "styled-components/native"
 
 import SwitchBoard from "../../../NativeModules/SwitchBoard"
 import CloseButton from "../Components/CloseButton"
-
-import PropTypes from "prop-types"
 
 // Full screen black
 const BG = styled.View`

--- a/src/lib/Components/Consignments/Components/FormElements.tsx
+++ b/src/lib/Components/Consignments/Components/FormElements.tsx
@@ -1,9 +1,8 @@
 import React from "react"
 
-import { ScrollView, TextProperties, View, ViewProperties, ViewStyle } from "react-native"
+import { ScrollView, View, ViewProperties } from "react-native"
 import { ButtonProps, WhiteButton } from "../../Buttons"
 import { BodyText, LargeHeadline } from "../Typography/index"
-import Text from "./TextInput"
 
 /** A re-usable full-screen form with a scrollview */
 export const Form: React.SFC<{ title?: string }> = props =>

--- a/src/lib/Components/Consignments/Components/ImageSelection.tsx
+++ b/src/lib/Components/Consignments/Components/ImageSelection.tsx
@@ -1,32 +1,16 @@
 import React from "react"
 import {
-  ButtonProperties,
   Dimensions,
-  FlatList,
   Image,
   ListView,
   ListViewDataSource,
-  ScrollView,
   StyleSheet,
-  Text,
   TouchableHighlight,
   TouchableOpacity,
   View,
 } from "react-native"
 
-import { chunk, filter } from "lodash"
-
-import colors from "lib/data/colors"
-import fonts from "lib/data/fonts"
 import styled from "styled-components/native"
-
-import { ConsignmentSetup } from "../index"
-
-const Photo = styled.TouchableHighlight`
-  color: white;
-  font-family: "${fonts["avant-garde-regular"]}";
-  flex: 1;
-`
 
 const ImageBG = styled.View`
   border-color: white;
@@ -144,7 +128,7 @@ export default class ImageSelection extends React.Component<Props, State> {
   }
 
   onPressItem = (id: string) => {
-    this.setState(state => {
+    this.setState(_state => {
       const selected = this.state.selected
       const selectedAlready = selected.has(id)
       if (selectedAlready) {
@@ -158,7 +142,6 @@ export default class ImageSelection extends React.Component<Props, State> {
       }
 
       // This is probably inefficient, but it works.
-      const ds = new ListView.DataSource({ rowHasChanged: (r1, r2) => r1 !== r2 })
       const dataSource = this.dataSourceFromData(this.props.data, isPad)
       return { dataSource }
     })

--- a/src/lib/Components/Consignments/Components/SearchResults.tsx
+++ b/src/lib/Components/Consignments/Components/SearchResults.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { ActivityIndicator, ScrollView, TouchableHighlight, View } from "react-native"
+import { ScrollView, View } from "react-native"
 
 import colors from "lib/data/colors"
 import fonts from "lib/data/fonts"

--- a/src/lib/Components/Consignments/Components/TextArea.tsx
+++ b/src/lib/Components/Consignments/Components/TextArea.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { ActivityIndicator, Text, TextInput, TextInputProperties, View, ViewProperties } from "react-native"
+import { TextInputProperties, View, ViewProperties } from "react-native"
 
 import colors from "lib/data/colors"
 import fonts from "lib/data/fonts"

--- a/src/lib/Components/Consignments/Components/TextInput.tsx
+++ b/src/lib/Components/Consignments/Components/TextInput.tsx
@@ -1,14 +1,5 @@
 import React from "react"
-import {
-  ActivityIndicator,
-  Image,
-  ImageURISource,
-  Text,
-  TextInput,
-  TextInputProperties,
-  View,
-  ViewProperties,
-} from "react-native"
+import { ActivityIndicator, Image, ImageURISource, Text, TextInputProperties, View, ViewProperties } from "react-native"
 
 import { Colors } from "lib/data/colors"
 import { Fonts } from "lib/data/fonts"

--- a/src/lib/Components/Consignments/Components/Toggle.tsx
+++ b/src/lib/Components/Consignments/Components/Toggle.tsx
@@ -30,15 +30,6 @@ const TextBackground = styled.View`
   margin-right: 8;
 `
 
-const BlackCircle = styled.View`
-  width: 24;
-  height: 24;
-  border-radius: 12;
-  background-color: black;
-  border-color: black;
-  border-width: 1;
-`
-
 const WhiteCircle = styled.View`
   width: 24;
   height: 24;

--- a/src/lib/Components/Consignments/Components/__tests__/ArtworkConsignmentTodo-tests.tsx
+++ b/src/lib/Components/Consignments/Components/__tests__/ArtworkConsignmentTodo-tests.tsx
@@ -1,12 +1,5 @@
-import React from "react"
-// import ReactTestUtils from "react-dom/test-utils"
-import * as renderer from "react-test-renderer"
-import * as shallow from "react-test-renderer/shallow"
-
 import * as TODOStories from "../../__stories__/Todo.story"
 import storyRunner from "./Runner"
-
-import TODO from "../ArtworkConsignmentTodo"
 
 storyRunner("TODO states:", TODOStories)
 

--- a/src/lib/Components/Consignments/Components/__tests__/FormElements-tests.tsx
+++ b/src/lib/Components/Consignments/Components/__tests__/FormElements-tests.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import "react-native"
 import * as renderer from "react-test-renderer"
 
-import { Form, Label, Row } from "../FormElements"
+import { Row } from "../FormElements"
 
 describe("Row", () => {
   it("row passes style props, and other props into the view", () => {

--- a/src/lib/Components/Consignments/Screens/Artist.tsx
+++ b/src/lib/Components/Consignments/Screens/Artist.tsx
@@ -6,8 +6,7 @@ import ArtistSearch from "../Components/SearchResults"
 
 import { ConsignmentSetup, SearchResult } from "../index"
 
-import { debounce } from "lodash"
-import { Dimensions, NavigatorIOS, Route, ScrollView, View, ViewProperties } from "react-native"
+import { Dimensions, NavigatorIOS, Route, View, ViewProperties } from "react-native"
 import metaphysics from "../../../metaphysics"
 
 interface ArtistSearchResponse {

--- a/src/lib/Components/Consignments/Screens/FinalSubmissionQuestions.tsx
+++ b/src/lib/Components/Consignments/Screens/FinalSubmissionQuestions.tsx
@@ -1,21 +1,14 @@
 import React from "react"
 
-import { LayoutAnimation, NavigatorIOS, Route, ScrollView, View, ViewProperties } from "react-native"
+import { LayoutAnimation, NavigatorIOS, Route, View, ViewProperties } from "react-native"
 import { WhiteButton } from "../../Buttons"
 import ConsignmentBG from "../Components/ConsignmentBG"
-import { BodyText, LargeHeadline, Subtitle } from "../Typography"
 
 import { Schema, screenTrack } from "lib/utils/track"
-import { ConsignmentSetup, SearchResult } from "../"
-import Spinner from "../../Spinner"
-import TODO from "../Components/ArtworkConsignmentTodo"
+import { ConsignmentSetup } from "../"
 import { Form, Label, Row } from "../Components/FormElements"
 import Text from "../Components/TextInput"
 import Toggle from "../Components/Toggle"
-import Artist from "./Artist"
-import Provenance from "./Provenance"
-import SelectFromPhotoLibrary from "./SelectFromPhotoLibrary"
-import Welcome from "./Welcome"
 
 interface Props extends ViewProperties {
   navigator: NavigatorIOS
@@ -23,8 +16,6 @@ interface Props extends ViewProperties {
   setup: ConsignmentSetup
   submitFinalSubmission: (setup: ConsignmentSetup) => void
 }
-
-const Loader = (p, c) => <Spinner style={{ flex: 1 }} />
 
 @screenTrack<Props>(props => ({
   context_screen: Schema.PageNames.ConsignmentsSubmission,

--- a/src/lib/Components/Consignments/Screens/Location.tsx
+++ b/src/lib/Components/Consignments/Screens/Location.tsx
@@ -6,9 +6,7 @@ import Search from "../Components/SearchResults"
 
 import { ConsignmentSetup, SearchResult } from "../index"
 
-import { debounce } from "lodash"
-import { NavigatorIOS, Route, ScrollView, View, ViewProperties } from "react-native"
-import metaphysics from "../../../metaphysics"
+import { NavigatorIOS, Route, View, ViewProperties } from "react-native"
 
 import { stringify } from "qs"
 

--- a/src/lib/Components/Consignments/Screens/Metadata.tsx
+++ b/src/lib/Components/Consignments/Screens/Metadata.tsx
@@ -1,32 +1,23 @@
 import React from "react"
 
-import { Fonts } from "lib/data/fonts"
 import {
   Keyboard,
   LayoutAnimation,
-  NativeMethodsMixinStatic,
   NavigatorIOS,
   Picker,
   Route,
   ScrollView,
-  TextInput,
-  TouchableHighlight,
   TouchableWithoutFeedback,
   View,
   ViewProperties,
 } from "react-native"
-import { ConsignmentMetadata, SearchResult } from "../"
-import TODO from "../Components/ArtworkConsignmentTodo"
+
+import { ConsignmentMetadata } from "../"
 import ConsignmentBG from "../Components/ConsignmentBG"
 import DoneButton from "../Components/DoneButton"
-import { Form, Label, Row } from "../Components/FormElements"
+import { Label, Row } from "../Components/FormElements"
 import Text from "../Components/TextInput"
 import Toggle from "../Components/Toggle"
-import { BodyText, LargeHeadline, Subtitle } from "../Typography"
-import Artist from "./Artist"
-import Provenance from "./Provenance"
-import SelectFromPhotoLibrary from "./SelectFromPhotoLibrary"
-import Welcome from "./Welcome"
 
 interface Props extends ViewProperties {
   navigator: NavigatorIOS
@@ -112,7 +103,7 @@ export default class Metadata extends React.Component<Props, State> {
   }
 
   hideCategorySelection = () => this.animateStateChange({ showPicker: false })
-  changeCategoryValue = (value, index) => {
+  changeCategoryValue = (_value, index) => {
     this.setState({
       categoryName: categoryOptions[index].name,
       category: categoryOptions[index].value,

--- a/src/lib/Components/Consignments/Screens/Overview.tsx
+++ b/src/lib/Components/Consignments/Screens/Overview.tsx
@@ -1,16 +1,6 @@
 import { Schema, screenTrack, Track, track as _track } from "lib/utils/track"
 import React from "react"
-import {
-  AsyncStorage,
-  Dimensions,
-  Image,
-  NavigatorIOS,
-  Route,
-  ScrollView,
-  TouchableHighlight,
-  View,
-  ViewProperties,
-} from "react-native"
+import { AsyncStorage, Dimensions, NavigatorIOS, Route, ScrollView, View, ViewProperties } from "react-native"
 
 import { ConsignmentMetadata, ConsignmentSetup, SearchResult } from "../"
 import SwitchBoard from "../../../NativeModules/SwitchBoard"
@@ -27,7 +17,6 @@ import Location from "./Location"
 import Metadata from "./Metadata"
 import Provenance from "./Provenance"
 import SelectFromPhotoLibrary from "./SelectFromPhotoLibrary"
-import Welcome from "./Welcome"
 
 const consignmentsStateKey = "ConsignmentsStoredState"
 
@@ -61,7 +50,7 @@ export default class Info extends React.Component<Props, State> {
 
   saveStateToLocalStorage = () => AsyncStorage.setItem(consignmentsStateKey, JSON.stringify(this.state))
   restoreFromLocalStorage = () =>
-    AsyncStorage.getItem(consignmentsStateKey, (err, result) => {
+    AsyncStorage.getItem(consignmentsStateKey, (_err, result) => {
       const results = (result && JSON.parse(result)) || {}
       this.setState({ ...results, hasLoaded: true })
     })
@@ -126,7 +115,7 @@ export default class Info extends React.Component<Props, State> {
     }
   }
 
-  @track((props, state) => ({
+  @track((_props, state) => ({
     action_type: Schema.ActionTypes.Success,
     action_name: Schema.ActionNames.ConsignmentDraftCreated,
     owner_id: state.submission_id,
@@ -146,7 +135,7 @@ export default class Info extends React.Component<Props, State> {
     })
   }
 
-  @track((props, state) => ({
+  @track((_props, state) => ({
     action_type: Schema.ActionTypes.Success,
     action_name: Schema.ActionNames.ConsignmentSubmitted,
     owner_id: state.submission_id,
@@ -190,7 +179,6 @@ export default class Info extends React.Component<Props, State> {
     )
 
     const isPad = Dimensions.get("window").width > 700
-    const isPadHorizontal = Dimensions.get("window").height > 700
 
     return (
       <ConsignmentBG showCloseButton>

--- a/src/lib/Components/Consignments/Screens/Provenance.tsx
+++ b/src/lib/Components/Consignments/Screens/Provenance.tsx
@@ -4,7 +4,7 @@ import ConsignmentBG from "../Components/ConsignmentBG"
 import DoneButton from "../Components/DoneButton"
 
 import { NavigatorIOS, Route, View, ViewProperties } from "react-native"
-import TextArea, { TextAreaProps } from "../Components/TextArea"
+import TextArea from "../Components/TextArea"
 import { ConsignmentSetup } from "../index"
 
 interface Props extends ConsignmentSetup, ViewProperties {

--- a/src/lib/Components/Consignments/Screens/SelectFromPhotoLibrary.tsx
+++ b/src/lib/Components/Consignments/Screens/SelectFromPhotoLibrary.tsx
@@ -1,11 +1,6 @@
 import React from "react"
 
-import * as _ from "lodash"
-
-import { WhiteButton } from "../../Buttons"
 import DoneButton from "../Components/BottomAlignedButton"
-
-import Circle from "../Components/CircleImage"
 import ConsignmentBG from "../Components/ConsignmentBG"
 
 import ImageSelection, { ImageData } from "../Components/ImageSelection"
@@ -13,17 +8,7 @@ import { BodyText as P } from "../Typography"
 
 import triggerCamera from "../../../NativeModules/triggerCamera"
 
-import {
-  CameraRoll,
-  Dimensions,
-  GetPhotosParamType,
-  GetPhotosReturnType,
-  NavigatorIOS,
-  Route,
-  ScrollView,
-  View,
-  ViewProperties,
-} from "react-native"
+import { CameraRoll, Dimensions, NavigatorIOS, Route, ScrollView, View, ViewProperties } from "react-native"
 import { ConsignmentSetup } from "../index"
 
 interface Props extends ViewProperties {
@@ -101,10 +86,12 @@ export default class SelectFromPhotoLibrary extends React.Component<Props, State
 
   appendAssets(data) {
     const assets = data.edges
-    const nextState = {
-      loadingMore: false,
-      noMorePhotos: !data.page_info.has_next_page,
-    }
+
+    // TODO: Reenable when used
+    // const nextState = {
+    //   loadingMore: false,
+    //   noMorePhotos: !data.page_info.has_next_page,
+    // }
 
     if (assets.length === 0) {
       this.setState({
@@ -151,7 +138,7 @@ export default class SelectFromPhotoLibrary extends React.Component<Props, State
     })
   }
 
-  onNewSelectionState = (state: Set<string>) => this.setState({ selection: this.state.selection })
+  onNewSelectionState = (_state: Set<string>) => this.setState({ selection: this.state.selection })
 
   render() {
     return (

--- a/src/lib/Components/Consignments/Screens/Welcome.tsx
+++ b/src/lib/Components/Consignments/Screens/Welcome.tsx
@@ -1,19 +1,10 @@
 import React from "react"
-import {
-  Dimensions,
-  NavigatorIOS,
-  Route,
-  ScrollView,
-  Text,
-  TouchableHighlight,
-  View,
-  ViewProperties,
-} from "react-native"
+import { Dimensions, NavigatorIOS, Route, ScrollView, Text, View, ViewProperties } from "react-native"
 
 import { Router } from "lib/utils/router"
 import SwitchBoard from "../../../NativeModules/SwitchBoard"
 
-import { Schema, screenTrack, Track } from "lib/utils/track"
+import { Schema, screenTrack } from "lib/utils/track"
 import Circle from "../Components/CircleImage"
 import ConsignmentBG from "../Components/ConsignmentBG"
 import { Button } from "../Components/FormElements"
@@ -43,7 +34,6 @@ export default class Welcome extends React.Component<Props, null> {
 
   render() {
     const isPad = Dimensions.get("window").width > 700
-    const isPadHorizontal = Dimensions.get("window").height > 700
 
     const TOS = () =>
       <Text style={{ textDecorationStyle: "solid", textDecorationLine: "underline" }} onPress={this.TOSTapped}>

--- a/src/lib/Components/Consignments/Screens/__tests__/Overview-local-storage-tests.tsx
+++ b/src/lib/Components/Consignments/Screens/__tests__/Overview-local-storage-tests.tsx
@@ -1,4 +1,3 @@
-import React from "react"
 import { AsyncStorage } from "react-native"
 
 import Overview from "../Overview"
@@ -17,12 +16,14 @@ beforeEach(() => {
 const key = "ConsignmentsStoredState"
 
 it("restores when no props are provided", () => {
-  const overview = new Overview({ setup: null })
+  // tslint:disable-next-line
+  new Overview({ setup: null })
   expect(AsyncStorage.getItem).toBeCalledWith(key, expect.anything())
 })
 
 it("does not restore setup props are provided", () => {
-  const overview = new Overview({ setup: {} })
+  // tslint:disable-next-line
+  new Overview({ setup: {} })
   expect(AsyncStorage.getItem).not.toBeCalled()
 })
 

--- a/src/lib/Components/Consignments/Screens/__tests__/Overview-tests.tsx
+++ b/src/lib/Components/Consignments/Screens/__tests__/Overview-tests.tsx
@@ -9,7 +9,6 @@ import Overview from "../Overview"
 
 import Provenance from "../Provenance"
 import SelectFromPhotoLibrary from "../SelectFromPhotoLibrary"
-import Welcome from "../Welcome"
 
 const nav = {} as any
 const route = {} as any

--- a/src/lib/Components/Consignments/Submission/__tests__/create-tests.ts
+++ b/src/lib/Components/Consignments/Submission/__tests__/create-tests.ts
@@ -21,7 +21,7 @@ it("makes a graphQL request to metaphysics", async () => {
     })
   )
 
-  const response = await create(withPhotos)
+  await create(withPhotos)
   const query = mockphysics.mock.calls[0][0].query
 
   expect(query).toContain("mutation")

--- a/src/lib/Components/Consignments/Submission/__tests__/geminiUploadToS3-tests.ts
+++ b/src/lib/Components/Consignments/Submission/__tests__/geminiUploadToS3-tests.ts
@@ -9,7 +9,7 @@ beforeEach(mockphysics.mockReset)
 it("getGeminiCredentialsForEnvironment makes a graphQL request to metaphysics", async () => {
   mockphysics.mockImplementationOnce(() => Promise.resolve())
 
-  const response = await getGeminiCredentialsForEnvironment({
+  await getGeminiCredentialsForEnvironment({
     name: "thing",
     acl: "private",
   })
@@ -22,7 +22,7 @@ it("getGeminiCredentialsForEnvironment makes a graphQL request to metaphysics", 
 it("createGeminiAssetWithS3Credentials makes a graphQL request to metaphysics", async () => {
   mockphysics.mockImplementationOnce(() => Promise.resolve())
 
-  const response = await createGeminiAssetWithS3Credentials({
+  await createGeminiAssetWithS3Credentials({
     source_key: "source",
     template_key: "template",
     source_bucket: "bucket",

--- a/src/lib/Components/Consignments/Submission/__tests__/update-tests.ts
+++ b/src/lib/Components/Consignments/Submission/__tests__/update-tests.ts
@@ -21,7 +21,7 @@ it("makes a graphQL request to metaphysics", async () => {
     })
   )
 
-  const response = await update(withLocation, "123")
+  await update(withLocation, "123")
   const query = mockphysics.mock.calls[0][0].query
 
   expect(query).toContain("mutation")

--- a/src/lib/Components/Consignments/Submission/__tests__/uploadPhotoToGemini-tests.ts
+++ b/src/lib/Components/Consignments/Submission/__tests__/uploadPhotoToGemini-tests.ts
@@ -8,21 +8,14 @@ jest.mock("../geminiUploadToS3", () => ({
   uploadFileToS3: jest.fn(),
 }))
 
-import {
-  createGeminiAssetWithS3Credentials,
-  GeminiCredsResponse,
-  getGeminiCredentialsForEnvironment,
-  uploadFileToS3,
-} from "../geminiUploadToS3"
-
-import { addAssetToConsignment, uploadImageAndPassToGemini } from "../uploadPhotoToGemini"
+import { addAssetToConsignment } from "../uploadPhotoToGemini"
 
 beforeEach(jest.resetAllMocks)
 
 it("addAssetToConsignment makes a graphQL request to metaphysics", async () => {
   mockphysics.mockImplementationOnce(() => Promise.resolve())
 
-  const response = await addAssetToConsignment({
+  await addAssetToConsignment({
     asset_type: "asset",
     gemini_token: "g-token",
     submission_id: "123",

--- a/src/lib/Components/Consignments/Submission/create.ts
+++ b/src/lib/Components/Consignments/Submission/create.ts
@@ -1,7 +1,6 @@
 import { metaphysics } from "../../../metaphysics"
 import { ConsignmentSetup } from "../index"
 import { consignmentSetupToMutationInput } from "./consignmentSetupToSubmission"
-import { objectToGraphQLInput } from "./objectToGraphQL"
 import { CreateSubmissionResponse } from "./types"
 
 /**

--- a/src/lib/Components/Consignments/Submission/geminiUploadToS3.ts
+++ b/src/lib/Components/Consignments/Submission/geminiUploadToS3.ts
@@ -1,4 +1,3 @@
-import queryString from "query-string"
 import { metaphysics } from "../../../metaphysics"
 import objectToGraphQL from "./objectToGraphQL"
 import { GeminiEntryCreationResonse } from "./uploadPhotoToGemini"
@@ -96,11 +95,10 @@ export const uploadFileToS3 = async (file: string, req: GeminiCredsInput, res: G
     const geminiKey = asset.policy_document.conditions.gemini_key
     const bucket = asset.policy_document.conditions.bucket
     const uploadURL = `https://${bucket}.s3.amazonaws.com`
-    const filename = file.split(/\//g).pop()
 
     const data = {
       "Content-Type": "image/jpg",
-      key: geminiKey + "/${filename}",
+      key: geminiKey + "/${filename}", // NOTE: This form (which _looks_ like ES6 interpolation) is required by AWS
       AWSAccessKeyId: asset.credentials,
       acl: req.acl,
       success_action_status: asset.policy_document.conditions.success_action_status,

--- a/src/lib/Components/Consignments/Submission/update.ts
+++ b/src/lib/Components/Consignments/Submission/update.ts
@@ -1,7 +1,6 @@
 import { metaphysics } from "../../../metaphysics"
 import { ConsignmentSetup } from "../index"
 import { consignmentSetupToMutationInput } from "./consignmentSetupToSubmission"
-import { objectToGraphQLInput } from "./objectToGraphQL"
 import { UpdateSubmissionResponse } from "./types"
 
 /**
@@ -9,7 +8,7 @@ import { UpdateSubmissionResponse } from "./types"
  * @param submission A submission object
  * @param id This ID isn't used, but is added to force a non-null ID in the submission
  */
-const updateASubmission = async (submission: ConsignmentSetup, id: string) => {
+const updateASubmission = async (submission: ConsignmentSetup, _id: string) => {
   const input = consignmentSetupToMutationInput(submission)
   const query = `mutation {
     updateConsignmentSubmission(input:${input}) {

--- a/src/lib/Components/Consignments/Submission/uploadPhotoToGemini.ts
+++ b/src/lib/Components/Consignments/Submission/uploadPhotoToGemini.ts
@@ -1,4 +1,3 @@
-import queryString from "query-string"
 import { metaphysics } from "../../../metaphysics"
 import {
   createGeminiAssetWithS3Credentials,

--- a/src/lib/Components/Consignments/__stories__/BottomAligned.story.tsx
+++ b/src/lib/Components/Consignments/__stories__/BottomAligned.story.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Text, View } from "react-native"
+import { Text } from "react-native"
 
 import BottomAlignedButton, { BottomAlignedProps } from "../Components/BottomAlignedButton"
 import Search from "../Components/SearchResults"

--- a/src/lib/Components/Consignments/__stories__/ImageSelection.story.tsx
+++ b/src/lib/Components/Consignments/__stories__/ImageSelection.story.tsx
@@ -3,9 +3,6 @@ import React from "react"
 import ImageSelection from "../Components/ImageSelection"
 import { Wrapper } from "./"
 
-const nav = {} as any
-const route = {} as any
-
 const uri1 = "https://d32dm0rphc51dk.cloudfront.net/Vq62IJMLbG1TuUjs-2fZCg/large.jpg"
 const uri2 = "https://d32dm0rphc51dk.cloudfront.net/WAlGHmjlxTn3USMllNt4rA/large.jpg"
 const uri3 = "https://d32dm0rphc51dk.cloudfront.net/8BuMWBuUOBtKVBsGRUoDKw/large.jpg"

--- a/src/lib/Components/Consignments/__stories__/Search.story.tsx
+++ b/src/lib/Components/Consignments/__stories__/Search.story.tsx
@@ -1,6 +1,3 @@
-import React from "react"
-import { View } from "react-native"
-
 import { camelCase } from "lodash"
 
 import Search, { SearchQueryProps } from "../Components/SearchResults"

--- a/src/lib/Components/Consignments/__stories__/Todo.story.tsx
+++ b/src/lib/Components/Consignments/__stories__/Todo.story.tsx
@@ -1,10 +1,7 @@
-import { storiesOf } from "@storybook/react-native"
-import React from "react"
-
 import { metadata, withArtist, withLocation, withMetadata, withOnePhoto, withPhotos } from "./consignmentSetups"
 
 import TODO from "../Components/ArtworkConsignmentTodo"
-import { ConsignmentMetadata, ConsignmentSetup } from "../index"
+import { ConsignmentSetup } from "../index"
 
 export const name = "Consignments/TODO Component"
 export const component = TODO

--- a/src/lib/Components/DottedLine.tsx
+++ b/src/lib/Components/DottedLine.tsx
@@ -1,6 +1,5 @@
-import * as PropTypes from "prop-types"
 import React from "react"
-import { ColorPropType, processColor, requireNativeComponent, View } from "react-native"
+import { ColorPropType, processColor, requireNativeComponent } from "react-native"
 
 import colors from "lib/data/colors"
 

--- a/src/lib/Components/Gene/About.tsx
+++ b/src/lib/Components/Gene/About.tsx
@@ -8,7 +8,7 @@ import Biography from "./Biography"
 import RelatedArtists from "../RelatedArtists"
 import Separator from "../Separator"
 
-class About extends React.Component<RelayPropsWorkaround, any> {
+class About extends React.Component<RelayProps> {
   render() {
     return (
       <View>
@@ -59,10 +59,5 @@ export default createFragmentContainer(
 interface RelayProps {
   gene: {
     trending_artists: Array<boolean | number | string | null> | null
-  }
-}
-interface RelayPropsWorkaround {
-  gene: {
-    trending_artists: any[]
   }
 }

--- a/src/lib/Components/Gene/Header.tsx
+++ b/src/lib/Components/Gene/Header.tsx
@@ -25,6 +25,10 @@ class Header extends React.Component<HeaderProps, HeaderState> {
 
   componentDidMount() {
     NativeModules.ARTemporaryAPIModule.followStatusForGene(this.props.gene._id, (error, following) => {
+      if (error) {
+        // FIXME: Handle error
+        console.error("Gene/Header.tsx", error.message)
+      }
       this.setState({ following })
     })
   }

--- a/src/lib/Components/Gene/__tests__/About-tests.tsx
+++ b/src/lib/Components/Gene/__tests__/About-tests.tsx
@@ -42,6 +42,6 @@ it("shows trending artists correctly", () => {
     ],
   }
 
-  const about = renderer.create(<About gene={gene} />).toJSON()
+  const about = renderer.create(<About gene={gene as any} />).toJSON()
   expect(about).toMatchSnapshot()
 })

--- a/src/lib/Components/Home/ArtistRails/ArtistCard.tsx
+++ b/src/lib/Components/Home/ArtistRails/ArtistCard.tsx
@@ -53,7 +53,7 @@ export class ArtistCard extends React.Component<Props, State> {
   handleFollowChange = () => {
     this.setState({ processingChange: true })
 
-    ARTemporaryAPIModule.setFollowArtistStatus(true, this.props.artist._id, (error, following) => {
+    ARTemporaryAPIModule.setFollowArtistStatus(true, this.props.artist._id, (error, _following) => {
       if (error) {
         console.warn(error)
         this.setState({ processingChange: false })

--- a/src/lib/Components/Home/ArtistRails/ArtistRail.tsx
+++ b/src/lib/Components/Home/ArtistRails/ArtistRail.tsx
@@ -41,7 +41,11 @@ class ArtistRail extends React.Component<Props, State> {
     if (this.props.relay) {
       this.props.relay.refetch({ __id: this.props.rail.__id, fetchContent: true }, null, error => {
         if (error) {
-          this.setState({ loadFailed: true })
+          console.error("ArtistRail.tsx", error.message)
+
+          this.setState({
+            loadFailed: true,
+          })
         }
       })
     }
@@ -65,7 +69,7 @@ class ArtistRail extends React.Component<Props, State> {
   }
 
   followedArtistAnimation(followedArtist) {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve, _reject) => {
       const { opacity, translateY } = followedArtist._animatedValues
       const duration = Animation.duration.followedArtist
       const easing = Animation.easing
@@ -77,7 +81,7 @@ class ArtistRail extends React.Component<Props, State> {
   }
 
   suggestedArtistAnimation(suggestedArtist: SuggestedArtist) {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve, _reject) => {
       const { opacity, translateY } = suggestedArtist._animatedValues
       const duration = Animation.duration.suggestedArtist
       const easing = Animation.easing

--- a/src/lib/Components/Home/ArtworkRails/ArtworkRail.tsx
+++ b/src/lib/Components/Home/ArtworkRails/ArtworkRail.tsx
@@ -67,6 +67,10 @@ export class ArtworkRail extends React.Component<Props & RelayPropsWorkaround, S
   componentDidMount() {
     if (this.props.relay) {
       this.props.relay.refetch({ __id: this.props.rail.__id, fetchContent: true }, null, error => {
+        if (error) {
+          console.error("ArtworkRail.tsx", error.message)
+        }
+
         this.setState({
           didPerformFetch: true,
           loadFailed: !!error,

--- a/src/lib/Components/Home/ArtworkRails/__tests__/ArtworkRail-tests.tsx
+++ b/src/lib/Components/Home/ArtworkRails/__tests__/ArtworkRail-tests.tsx
@@ -72,7 +72,7 @@ const railProps = (startedFetching = true) => {
       variables: {
         fetchContent: startedFetching,
       },
-      refetch: (a, b, c) => {
+      refetch: (_a, _b, c) => {
         return c && c()
       },
     },

--- a/src/lib/Components/Inbox/ActiveBids/__stories__/ActiveBids.story.tsx
+++ b/src/lib/Components/Inbox/ActiveBids/__stories__/ActiveBids.story.tsx
@@ -1,10 +1,8 @@
 import { storiesOf } from "@storybook/react-native"
 import createEnvironment from "lib/relay/createEnvironment"
-import { InboxRenderer } from "lib/relay/QueryRenderers"
 import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
 import React from "react"
-import { Text, View } from "react-native"
-import { graphql, QueryRenderer, QueryRendererProps } from "react-relay"
+import { graphql, QueryRenderer } from "react-relay"
 import ActiveBids from "../index"
 
 function ActiveBidsRenderer({ render }) {

--- a/src/lib/Components/Inbox/ActiveBids/__tests__/ActiveBid-tests.tsx
+++ b/src/lib/Components/Inbox/ActiveBids/__tests__/ActiveBid-tests.tsx
@@ -18,7 +18,7 @@ it("looks right for bids in live open auctions", () => {
   expect(tree).toMatchSnapshot()
 })
 
-const bid = (isLive?: boolean, isOpen?: boolean) => {
+const bid = (_isLive?: boolean, isOpen?: boolean) => {
   return {
     sale: {
       is_live_open: isOpen,

--- a/src/lib/Components/Inbox/ActiveBids/index.tsx
+++ b/src/lib/Components/Inbox/ActiveBids/index.tsx
@@ -2,7 +2,6 @@ import React from "react"
 import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
 import styled from "styled-components/native"
 
-import { View } from "react-native"
 import { LargeHeadline } from "../Typography"
 import ActiveBid from "./ActiveBid"
 
@@ -50,20 +49,26 @@ class ActiveBids extends React.Component<Props, State> {
       return
     }
 
-    this.setState({ fetchingData: true })
+    this.setState({
+      fetchingData: true,
+    })
 
-    this.props.relay.refetch(
-      {},
-      {},
-      () => {
-        this.setState({ fetchingData: false })
+    const onFetchComplete = error => {
+      if (error) {
+        // FIXME: Handle error
+        console.error("ActiveBids/index.tsx", error.message)
+      }
 
-        if (callback) {
-          callback()
-        }
-      },
-      { force: true }
-    )
+      this.setState({
+        fetchingData: false,
+      })
+
+      if (callback) {
+        callback()
+      }
+    }
+
+    this.props.relay.refetch({}, {}, onFetchComplete, { force: true })
   }
 
   render() {

--- a/src/lib/Components/Inbox/Conversations/Avatar.tsx
+++ b/src/lib/Components/Inbox/Conversations/Avatar.tsx
@@ -1,7 +1,5 @@
 import React from "react"
 
-import { Text, View } from "react-native"
-
 import colors from "lib/data/colors"
 import fonts from "lib/data/fonts"
 import styled from "styled-components/native"

--- a/src/lib/Components/Inbox/Conversations/Composer.tsx
+++ b/src/lib/Components/Inbox/Conversations/Composer.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Dimensions, KeyboardAvoidingView, TextInput, TouchableWithoutFeedback, ViewStyle } from "react-native"
+import { Dimensions, TextInput, TouchableWithoutFeedback } from "react-native"
 
 import colors from "lib/data/colors"
 import fonts from "lib/data/fonts"
@@ -66,7 +66,7 @@ export default class Composer extends React.Component<Props, State> {
     }
   }
 
-  @track((props, state) => ({
+  @track(_props => ({
     action_type: Schema.ActionTypes.Tap,
     action_name: Schema.ActionNames.ConversationSendReply,
   }))

--- a/src/lib/Components/Inbox/Conversations/ConversationSnippet.tsx
+++ b/src/lib/Components/Inbox/Conversations/ConversationSnippet.tsx
@@ -6,9 +6,8 @@ import { Schema, Track, track as _track } from "../../../utils/track"
 
 import { MetadataText, PreviewText as P, SmallHeadline } from "../Typography"
 
-import { Dimensions, StyleSheet, TouchableWithoutFeedback, ViewStyle } from "react-native"
+import { Dimensions, TouchableWithoutFeedback } from "react-native"
 
-import DottedLine from "lib/Components/DottedLine"
 import OpaqueImageView from "lib/Components/OpaqueImageView"
 import { Colors } from "lib/data/colors"
 import { Fonts } from "lib/data/fonts"
@@ -81,22 +80,7 @@ const SeparatorLine = styled.View`
   ${isPad ? "align-self: center; width: 708;" : ""};
 `
 
-export interface Conversation {
-  id: string | null
-  to: {
-    name: string | null
-  }
-  last_message: string | null
-  last_message_at: string | null
-  is_last_message_to_user: boolean
-  last_message_open: string | null
-  items: Array<{
-    item: any
-  }>
-}
-
-interface Props {
-  conversation: Conversation
+export interface Props extends RelayProps {
   onSelected?: () => void
 }
 
@@ -141,7 +125,7 @@ export class ConversationSnippet extends React.Component<Props, any> {
     }
   }
 
-  @track((props, state) => ({
+  @track(props => ({
     action_type: Schema.ActionTypes.Tap,
     action_name: Schema.ActionNames.ConversationSelected,
     owner_id: props.conversation.id,
@@ -252,7 +236,6 @@ interface RelayProps {
     last_message_at: string | null
     is_last_message_to_user: boolean
     last_message_open: string | null
-    __typename: string
     items: Array<{
       item: any
     } | null> | null

--- a/src/lib/Components/Inbox/Conversations/Message.tsx
+++ b/src/lib/Components/Inbox/Conversations/Message.tsx
@@ -113,7 +113,7 @@ export class Message extends React.Component<Props, any> {
     })
   }
 
-  @track((props, state) => ({
+  @track(props => ({
     action_type: Schema.ActionTypes.Tap,
     action_name: Schema.ActionNames.ConversationLink,
     owner_type: Schema.OwnerEntityTypes.Conversation,

--- a/src/lib/Components/Inbox/Conversations/Messages.tsx
+++ b/src/lib/Components/Inbox/Conversations/Messages.tsx
@@ -1,7 +1,9 @@
 import React from "react"
-import { ActivityIndicator, Dimensions, FlatList, RefreshControl } from "react-native"
+import { Dimensions, FlatList, RefreshControl } from "react-native"
 import { ConnectionData, createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 import styled from "styled-components/native"
+
+import { PAGE_SIZE } from "lib/data/constants"
 
 import ARSwitchBoard from "../../../NativeModules/SwitchBoard"
 import Message from "./Message"
@@ -80,7 +82,11 @@ export class Messages extends React.Component<Props, State> {
     }
 
     updateState(true)
-    this.props.relay.loadMore(10, e => {
+    this.props.relay.loadMore(PAGE_SIZE, error => {
+      if (error) {
+        // FIXME: Handle error
+        console.error("Messages.tsx", error.message)
+      }
       updateState(false)
     })
   }
@@ -88,7 +94,11 @@ export class Messages extends React.Component<Props, State> {
   reload() {
     const count = this.props.conversation.messages.edges.length
     this.setState({ reloadingData: true })
-    this.props.relay.refetchConnection(count, e => {
+    this.props.relay.refetchConnection(count, error => {
+      if (error) {
+        // FIXME: Handle error
+        console.error("Messages.tsx", error.message)
+      }
       this.setState({ reloadingData: false })
     })
   }
@@ -118,7 +128,7 @@ export class Messages extends React.Component<Props, State> {
         keyboardShouldPersistTaps="always"
         onEndReached={this.loadMore.bind(this)}
         onEndReachedThreshold={0.2}
-        onContentSizeChange={(width, height) => {
+        onContentSizeChange={(_width, height) => {
           // If there aren't enough items to scroll through
           // display messages from the top
           const windowHeight = Dimensions.get("window").height
@@ -205,7 +215,7 @@ export default createPaginationContainer(
         count: totalCount,
       }
     },
-    getVariables(props, paginationInfo, fragmentVariables) {
+    getVariables(props, paginationInfo, _fragmentVariables) {
       return {
         conversationID: props.conversation.id,
         count: paginationInfo.count,

--- a/src/lib/Components/Inbox/Conversations/Preview/ArtworkPreview.tsx
+++ b/src/lib/Components/Inbox/Conversations/Preview/ArtworkPreview.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 
-import { Text, TouchableHighlight } from "react-native"
+import { TouchableHighlight } from "react-native"
 
 import { PreviewText as P, Subtitle } from "../../Typography"
 
@@ -56,7 +56,7 @@ const track: Track<Props> = _track
 
 @track()
 export class ArtworkPreview extends React.Component<Props, any> {
-  @track((props, state) => ({
+  @track(props => ({
     action_type: Schema.ActionTypes.Tap,
     action_name: Schema.ActionNames.ConversationAttachmentArtwork,
     owner_type: Schema.OwnerEntityTypes.Artwork,

--- a/src/lib/Components/Inbox/Conversations/Preview/Attachment/AttachmentPreview.tsx
+++ b/src/lib/Components/Inbox/Conversations/Preview/Attachment/AttachmentPreview.tsx
@@ -5,7 +5,6 @@ import { TouchableHighlight } from "react-native"
 import styled from "styled-components/native"
 
 import colors from "lib/data/colors"
-import fonts from "lib/data/fonts"
 
 const Container = styled.View`flex-direction: row;`
 

--- a/src/lib/Components/Inbox/Conversations/Preview/Attachment/ImagePreview.tsx
+++ b/src/lib/Components/Inbox/Conversations/Preview/Attachment/ImagePreview.tsx
@@ -1,10 +1,6 @@
 import React from "react"
-import { TouchableHighlight } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components/native"
-
-import colors from "lib/data/colors"
-import fonts from "lib/data/fonts"
 
 import OpaqueImageView from "lib/Components/OpaqueImageView"
 import AttachmentPreview, { AttachmentProps } from "./AttachmentPreview"

--- a/src/lib/Components/Inbox/Conversations/Preview/Attachment/PDFPreview.tsx
+++ b/src/lib/Components/Inbox/Conversations/Preview/Attachment/PDFPreview.tsx
@@ -1,10 +1,9 @@
 import React from "react"
-import { Image, Text, TouchableHighlight } from "react-native"
+import { Image, Text } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components/native"
 
 import colors from "lib/data/colors"
-import fonts from "lib/data/fonts"
 
 import AttachmentPreview, { AttachmentProps } from "./AttachmentPreview"
 

--- a/src/lib/Components/Inbox/Conversations/Preview/InvoicePreview.tsx
+++ b/src/lib/Components/Inbox/Conversations/Preview/InvoicePreview.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { EmitterSubscription, Image, TouchableHighlight } from "react-native"
+import { EmitterSubscription, Image } from "react-native"
 import { createRefetchContainer, graphql } from "react-relay"
 import { RelayRefetchProp } from "react-relay"
 import styled from "styled-components/native"
@@ -134,14 +134,14 @@ export class InvoicePreview extends React.Component<Props, State> {
   }
 
   handlePaymentRequestPaidNotification(notification: PaymentRequestPaidNotification) {
-    const { invoice, conversationId, relay } = this.props
+    const { invoice } = this.props
     if (notification.url === invoice.payment_url) {
       // Optimistically update the UI, refetch, then re-render without optimistic update.
       this.setState({ paid: true })
     }
   }
 
-  @track((props, state) => ({
+  @track(props => ({
     action_type: Schema.ActionTypes.Tap,
     action_name: Schema.ActionNames.ConversationAttachmentInvoice,
     owner_type: Schema.OwnerEntityTypes.Invoice,

--- a/src/lib/Components/Inbox/Conversations/Preview/ShowPreview.tsx
+++ b/src/lib/Components/Inbox/Conversations/Preview/ShowPreview.tsx
@@ -3,7 +3,7 @@ import { createFragmentContainer, graphql } from "react-relay"
 
 import { TouchableHighlight } from "react-native"
 
-import { PreviewText as P, Subtitle } from "../../Typography"
+import { PreviewText as P } from "../../Typography"
 
 import { Schema, Track, track as _track } from "../../../../utils/track"
 
@@ -55,7 +55,7 @@ const track: Track<Props> = _track
 
 @track()
 export class ShowPreview extends React.Component<Props, any> {
-  @track((props, state) => ({
+  @track(props => ({
     action_type: Schema.ActionTypes.Tap,
     action_name: Schema.ActionNames.ConversationAttachmentShow,
     owner_type: Schema.OwnerEntityTypes.Show,

--- a/src/lib/Components/Inbox/Conversations/Preview/__tests__/ShowPreview-tests.tsx
+++ b/src/lib/Components/Inbox/Conversations/Preview/__tests__/ShowPreview-tests.tsx
@@ -26,16 +26,3 @@ const show = {
   },
   fair: null,
 }
-
-const booth = {
-  name: "Catty Booth",
-  cover_image: {
-    url: "https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/normalized.jpg",
-  },
-  partner: {
-    name: "Catty Partner",
-  },
-  fair: {
-    name: "Catty Fair",
-  },
-}

--- a/src/lib/Components/Inbox/Conversations/ZeroStateInbox.tsx
+++ b/src/lib/Components/Inbox/Conversations/ZeroStateInbox.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 
-import { Dimensions, Image, ListView, ListViewDataSource, ScrollView, Text, View } from "react-native"
+import { Dimensions, Image } from "react-native"
 import { LargeHeadline } from "../Typography"
 
 import { Fonts } from "lib/data/fonts"

--- a/src/lib/Components/Inbox/Conversations/__stories__/ConversationSnippet.story.tsx
+++ b/src/lib/Components/Inbox/Conversations/__stories__/ConversationSnippet.story.tsx
@@ -1,16 +1,15 @@
 import { storiesOf } from "@storybook/react-native"
-import moment from "moment"
 import React from "react"
 import "react-native"
 import { ScrollView } from "react-native"
 
-import { Conversation, ConversationSnippet } from "../ConversationSnippet"
+import { ConversationSnippet } from "../ConversationSnippet"
 
-const conversation: Conversation = {
+const conversation = {
   id: "582",
   to: { name: "ACA Galleries" },
   last_message: "Karl and Anna... Fab!",
-  last_message_at: moment().subtract(1, "year").toISOString(),
+  last_message_at: null, // moment().subtract(1, "year").toISOString(),
   is_last_message_to_user: true,
   last_message_open: null,
   items: [

--- a/src/lib/Components/Inbox/Conversations/__stories__/Inbox.story.tsx
+++ b/src/lib/Components/Inbox/Conversations/__stories__/Inbox.story.tsx
@@ -41,63 +41,64 @@ storiesOf("Conversations/Overview").add("With live data", () => <RootContainer C
 // .add("With dummy data", () => <StubContainer Component={Inbox} props={{ me: meProps }} />)
 // .add("With no data", () => <StubContainer Component={Inbox} props={{ me: { conversations: { edges: [] } } }} />)
 
-const meProps = {
-  conversations: {
-    edges: [
-      {
-        node: {
-          id: "582",
-          inquiry_id: "59302144275b244a81d0f9c6",
-          from: {
-            name: "Jean-Luc Collecteur",
-            email: "luc+messaging@artsymail.com",
-          },
-          to: { name: "ACA Galleries" },
-          last_message: "Karl and Anna... Fab!",
-          created_at: "2017-06-01T14:14:35.538Z",
-          artworks: [
-            {
-              id: "bradley-theodore-karl-and-anna-face-off-diptych",
-              href: "/artwork/bradley-theodore-karl-and-anna-face-off-diptych",
-              title: "Karl and Anna Face Off (Diptych)",
-              date: "2016",
-              artist_names: "Bradley Theodore",
-              image: {
-                url: "https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/normalized.jpg",
-                image_url: "https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/:version.jpg",
-              },
-            },
-          ],
-        },
-      },
-      {
-        node: {
-          id: "581",
-          inquiry_id: "593020be8b3b814f9f86f2fd",
-          from: {
-            name: "Jean-Luc Collecteur",
-            email: "luc+messaging@artsymail.com",
-          },
-          to: { name: "David Krut Projects" },
-          last_message:
-            "Hi, I’m interested in purchasing this work. \
-                    Could you please provide more information about the piece?",
-          created_at: "2017-06-01T14:12:19.155Z",
-          artworks: [
-            {
-              id: "aida-muluneh-darkness-give-way-to-light-1",
-              href: "/artwork/aida-muluneh-darkness-give-way-to-light-1",
-              title: "Darkness Give Way to Light",
-              date: "2016",
-              artist_names: "Aida Muluneh",
-              image: {
-                url: "https://d32dm0rphc51dk.cloudfront.net/FDIuqbZUY1kLR-1Pd-Ec8w/normalized.jpg",
-                image_url: "https://d32dm0rphc51dk.cloudfront.net/FDIuqbZUY1kLR-1Pd-Ec8w/:version.jpg",
-              },
-            },
-          ],
-        },
-      },
-    ],
-  },
-}
+// TODO: Uncomment when ^ is fixed
+// const meProps = {
+//   conversations: {
+//     edges: [
+//       {
+//         node: {
+//           id: "582",
+//           inquiry_id: "59302144275b244a81d0f9c6",
+//           from: {
+//             name: "Jean-Luc Collecteur",
+//             email: "luc+messaging@artsymail.com",
+//           },
+//           to: { name: "ACA Galleries" },
+//           last_message: "Karl and Anna... Fab!",
+//           created_at: "2017-06-01T14:14:35.538Z",
+//           artworks: [
+//             {
+//               id: "bradley-theodore-karl-and-anna-face-off-diptych",
+//               href: "/artwork/bradley-theodore-karl-and-anna-face-off-diptych",
+//               title: "Karl and Anna Face Off (Diptych)",
+//               date: "2016",
+//               artist_names: "Bradley Theodore",
+//               image: {
+//                 url: "https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/normalized.jpg",
+//                 image_url: "https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/:version.jpg",
+//               },
+//             },
+//           ],
+//         },
+//       },
+//       {
+//         node: {
+//           id: "581",
+//           inquiry_id: "593020be8b3b814f9f86f2fd",
+//           from: {
+//             name: "Jean-Luc Collecteur",
+//             email: "luc+messaging@artsymail.com",
+//           },
+//           to: { name: "David Krut Projects" },
+//           last_message:
+//             "Hi, I’m interested in purchasing this work. \
+//                     Could you please provide more information about the piece?",
+//           created_at: "2017-06-01T14:12:19.155Z",
+//           artworks: [
+//             {
+//               id: "aida-muluneh-darkness-give-way-to-light-1",
+//               href: "/artwork/aida-muluneh-darkness-give-way-to-light-1",
+//               title: "Darkness Give Way to Light",
+//               date: "2016",
+//               artist_names: "Aida Muluneh",
+//               image: {
+//                 url: "https://d32dm0rphc51dk.cloudfront.net/FDIuqbZUY1kLR-1Pd-Ec8w/normalized.jpg",
+//                 image_url: "https://d32dm0rphc51dk.cloudfront.net/FDIuqbZUY1kLR-1Pd-Ec8w/:version.jpg",
+//               },
+//             },
+//           ],
+//         },
+//       },
+//     ],
+//   },
+// }

--- a/src/lib/Components/Inbox/Conversations/__tests__/ConversationSnippet-tests.tsx
+++ b/src/lib/Components/Inbox/Conversations/__tests__/ConversationSnippet-tests.tsx
@@ -40,6 +40,7 @@ const show = {
 }
 
 const artworkConversation = {
+  __typename: "Conversation",
   id: "582",
   inquiry_id: "59302144275b244a81d0f9c6",
   from: { name: "Jean-Luc Collecteur", email: "luc+messaging@artsymail.com" },
@@ -57,6 +58,7 @@ const artworkConversation = {
 }
 
 const showConversation = {
+  __typename: "Conversation",
   id: "582",
   inquiry_id: "59302144275b244a81d0f9c6",
   from: { name: "Jean-Luc Collecteur", email: "luc+messaging@artsymail.com" },

--- a/src/lib/Components/Inbox/Conversations/index.tsx
+++ b/src/lib/Components/Inbox/Conversations/index.tsx
@@ -2,15 +2,13 @@ import React from "react"
 import { ConnectionData, createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 import styled from "styled-components/native"
 
+import { PAGE_SIZE } from "lib/data/constants"
 import { ListView, ListViewDataSource, View } from "react-native"
 import { LargeHeadline } from "../Typography"
 
 import SwitchBoard from "../../../NativeModules/SwitchBoard"
-import ConversationSnippet from "./ConversationSnippet"
-
 import Spinner from "../../Spinner"
-
-const PageSize = 10
+import ConversationSnippet from "./ConversationSnippet"
 
 const Headline = styled(LargeHeadline)`
   margin-top: 20px;
@@ -64,8 +62,15 @@ export class Conversations extends React.Component<Props, State> {
     }
 
     this.setState({ fetchingNextPage: true })
-    this.props.relay.refetchConnection(10, () => {
-      this.setState({ fetchingNextPage: false })
+    this.props.relay.refetchConnection(10, error => {
+      if (error) {
+        // FIXME: Handle error
+        console.error("Conversations/index.jsx", error.message)
+      }
+
+      this.setState({
+        fetchingNextPage: false,
+      })
 
       if (callback) {
         callback()
@@ -101,9 +106,17 @@ export class Conversations extends React.Component<Props, State> {
     if (this.state.fetchingNextPage) {
       return
     }
-    this.setState({ fetchingNextPage: true })
-    this.props.relay.loadMore(PageSize, error => {
-      // TODO: Not performing any error handling here
+
+    this.setState({
+      fetchingNextPage: true,
+    })
+
+    this.props.relay.loadMore(PAGE_SIZE, error => {
+      if (error) {
+        // FIXME: Handle error
+        console.error("Conversations/index.tsx", error.message)
+      }
+
       this.setState({
         fetchingNextPage: false,
         dataSource: this.state.dataSource.cloneWithRows(this.conversations),
@@ -172,7 +185,7 @@ export default createPaginationContainer(
         count: totalCount,
       }
     },
-    getVariables(props, { count, cursor }, fragmentVariables) {
+    getVariables(_props, { count, cursor }, fragmentVariables) {
       return {
         // in most cases, for variables other than connection filters like
         // `first`, `after`, etc. you may want to use the previous values.

--- a/src/lib/Components/Inbox/Typography/index.tsx
+++ b/src/lib/Components/Inbox/Typography/index.tsx
@@ -1,6 +1,5 @@
 import React from "react"
 import { StyleSheet, Text, TextProperties, TextStyle } from "react-native"
-import styled from "styled-components"
 
 import colors from "lib/data/colors"
 import fonts from "lib/data/fonts"

--- a/src/lib/Components/Lists/SavedItemRow.tsx
+++ b/src/lib/Components/Lists/SavedItemRow.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import styled from "styled-components/native"
 
-import { Text, TouchableWithoutFeedback, View } from "react-native"
+import { TouchableWithoutFeedback } from "react-native"
 
 import OpaqueImageView from "lib/Components/OpaqueImageView"
 import { Colors } from "lib/data/colors"

--- a/src/lib/Components/RelatedArtists/RelatedArtist.tsx
+++ b/src/lib/Components/RelatedArtists/RelatedArtist.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { Component } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 
 import { StyleSheet, Text, TextStyle, TouchableWithoutFeedback, View } from "react-native"
@@ -8,7 +8,13 @@ import fonts from "lib/data/fonts"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import ImageView from "../OpaqueImageView"
 
-class RelatedArtist extends React.Component<any, any> {
+interface Props extends RelayProps {
+  imageSize: {
+    width: number
+  }
+}
+
+class RelatedArtist extends Component<Props> {
   handleTap() {
     SwitchBoard.presentNavigationViewController(this, this.props.artist.href)
   }

--- a/src/lib/Components/RelatedArtists/index.tsx
+++ b/src/lib/Components/RelatedArtists/index.tsx
@@ -6,8 +6,6 @@ import { LayoutChangeEvent, StyleSheet, TextStyle, View, ViewProperties, ViewSty
 import SerifText from "../Text/Serif"
 import RelatedArtist from "./RelatedArtist"
 
-interface Props extends ViewProperties, RelayProps {}
-
 interface State {
   columns: number
   imageSize: {
@@ -16,7 +14,7 @@ interface State {
   }
 }
 
-class RelatedArtists extends React.Component<Props, State> {
+class RelatedArtists extends React.Component<RelayProps & ViewProperties, State> {
   constructor(props) {
     super(props)
     this.state = {
@@ -122,5 +120,14 @@ export default createFragmentContainer(
 interface RelayProps {
   artists: Array<{
     __id: string
+    href: string | null
+    name: string | null
+    counts: {
+      for_sale_artworks: boolean | number | string | null
+      artworks: boolean | number | string | null
+    } | null
+    image: {
+      url: string | null
+    } | null
   } | null> | null
 }

--- a/src/lib/Components/Sale/Header.tsx
+++ b/src/lib/Components/Sale/Header.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Dimensions, NativeModules, StyleSheet, Text, TextStyle, View, ViewProperties, ViewStyle } from "react-native"
+import { Dimensions, StyleSheet, TextStyle, View } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 import OpaqueImageView from "../OpaqueImageView"
 import Headline from "../Text/Headline"

--- a/src/lib/Components/Sale/__tests__/Header-tests.tsx
+++ b/src/lib/Components/Sale/__tests__/Header-tests.tsx
@@ -1,5 +1,3 @@
-import { NativeModules } from "react-native"
-
 import React from "react"
 import * as renderer from "react-test-renderer"
 

--- a/src/lib/Components/States/ZeroState.tsx
+++ b/src/lib/Components/States/ZeroState.tsx
@@ -1,7 +1,6 @@
 import React from "react"
 import styled from "styled-components/native"
 
-import { Colors } from "lib/data/colors"
 import { Fonts } from "lib/data/fonts"
 
 const Container = styled.View`

--- a/src/lib/Components/States/__stories__/ZeroState.story.tsx
+++ b/src/lib/Components/States/__stories__/ZeroState.story.tsx
@@ -1,6 +1,5 @@
 import { storiesOf } from "@storybook/react-native"
 import React from "react"
-import { View } from "react-native"
 
 import ZeroState from "../ZeroState"
 

--- a/src/lib/Components/Storybooks/__tests__/utils-tests.tsx
+++ b/src/lib/Components/Storybooks/__tests__/utils-tests.tsx
@@ -1,4 +1,3 @@
-import { StorySection } from "../index"
 import { sectionsToTree, toSectionHeirarchy } from "../utils"
 
 const stubbedStories = [

--- a/src/lib/Components/Storybooks/index.tsx
+++ b/src/lib/Components/Storybooks/index.tsx
@@ -20,7 +20,7 @@ export interface StorySection {
 const stories = storybook.getStorybook()
 const root = storiesToTree(stories)
 
-const render = (props: any) =>
+const render = (_props: any) =>
   <NavigatorIOS
     navigationBarHidden={true}
     initialRoute={{ component: Browser, title: "Welcome", passProps: { section: root } }}

--- a/src/lib/Components/TabBar.tsx
+++ b/src/lib/Components/TabBar.tsx
@@ -1,6 +1,6 @@
 import React from "react"
-import { Animated, StyleSheet, Text, View } from "react-native"
-import styled, { StyledFunction } from "styled-components/native"
+import { Animated, View } from "react-native"
+import styled from "styled-components/native"
 
 import colors from "lib/data/colors"
 import fonts from "lib/data/fonts"

--- a/src/lib/Containers/Artist.tsx
+++ b/src/lib/Containers/Artist.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { Component } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 
 import { Dimensions, ScrollView, StyleSheet, View, ViewProperties, ViewStyle } from "react-native"
@@ -20,11 +20,7 @@ const TABS = {
   SHOWS: "SHOWS",
 }
 
-interface Props extends ViewProperties {
-  artist: any
-}
-
-export class Artist extends React.Component<Props, {}> {
+export class Artist extends Component<RelayProps & ViewProperties> {
   state: {
     selectedTabIndex: number
   }
@@ -66,7 +62,7 @@ export class Artist extends React.Component<Props, {}> {
   }
 
   // This is *not* called on the initial render, thus it will only post events for when the user actually taps a tab.
-  componentDidUpdate(previousProps, previousState) {
+  componentDidUpdate() {
     Events.postEvent({
       name: "Tapped artist view tab",
       tab: this.selectedTabTitle().toLowerCase(),
@@ -159,14 +155,25 @@ export default createFragmentContainer(
 
 interface RelayProps {
   artist: {
-    _id: string
-    id: string
-    has_metadata: boolean | null
+    _id: string | null
+    id: string | null
+    birthday: string | null
     counts: {
+      articles: boolean | number | string | null
       artworks: boolean | number | string | null
+      follows: boolean | number | string | null
       partner_shows: boolean | number | string | null
       related_artists: boolean | number | string | null
-      articles: boolean | number | string | null
+      for_sale_artworks: boolean | number | string | null
     } | null
+    has_metadata: boolean | null
+    name: string | null
+    nationality: string | null
+    current_shows: Array<boolean | number | string | null> | null
+    upcoming_shows: Array<boolean | number | string | null> | null
+    past_small_shows: Array<boolean | number | string | null> | null
+    past_large_shows: Array<{
+      __id: string | null
+    }> | null
   }
 }

--- a/src/lib/Containers/Conversation.tsx
+++ b/src/lib/Containers/Conversation.tsx
@@ -1,16 +1,13 @@
-import { MarkdownString } from "danger/distribution/dsl/Aliases"
 import React from "react"
 import { createFragmentContainer, graphql, RelayPaginationProp } from "react-relay"
-import { ConnectionHandler } from "relay-runtime"
 
 import { Schema, Track, track as _track } from "../utils/track"
 
-import { MetadataText, SmallHeadline } from "../Components/Inbox/Typography"
+import { SmallHeadline } from "../Components/Inbox/Typography"
 
-import { FlatList, ImageURISource, NetInfo, View, ViewProperties } from "react-native"
+import { NetInfo, View } from "react-native"
 
 import colors from "lib/data/colors"
-import fonts from "lib/data/fonts"
 import styled from "styled-components/native"
 
 import ConnectivityBanner from "../Components/ConnectivityBanner"
@@ -21,11 +18,6 @@ import { sendConversationMessage } from "../Components/Inbox/Conversations/SendC
 import Separator from "../Components/Separator"
 
 import { markLastMessageRead } from "../Components/Inbox/Conversations/MarkReadMessage"
-
-import ARSwitchBoard from "../NativeModules/SwitchBoard"
-
-// tslint:disable-next-line:no-var-requires
-const chevron: ImageURISource = require("../../../images/horizontal_chevron.png")
 
 const Container = styled.View`
   flex: 1;
@@ -44,25 +36,6 @@ const PlaceholderView = View
 const HeaderTextContainer = styled.View`
   flex-direction: row;
   justify-content: center;
-`
-
-const BackButtonPlaceholder = styled.Image`
-  height: 12;
-  width: 7;
-  transform: rotate(180deg);
-`
-
-const DottedBorder = styled.View`
-  height: 1;
-  border-width: 1;
-  border-style: dotted;
-  border-color: ${colors["gray-regular"]};
-  margin-left: 20;
-  margin-right: 20;
-`
-
-const MessagesList = styled(FlatList)`
-  margin-top: 10;
 `
 
 interface Props extends RelayProps {
@@ -119,7 +92,7 @@ export class Conversation extends React.Component<Props, State> {
         this.props.relay.environment,
         conversation,
         conversation.last_message_delivery_id,
-        response => {
+        _response => {
           this.setState({ markedMessageAsRead: true })
         },
         error => {
@@ -130,7 +103,7 @@ export class Conversation extends React.Component<Props, State> {
     }
   }
 
-  @track((props, state) => ({
+  @track(props => ({
     action_type: Schema.ActionTypes.Success,
     action_name: Schema.ActionNames.ConversationSendReply,
     owner_id: props.me.conversation.id,
@@ -144,7 +117,7 @@ export class Conversation extends React.Component<Props, State> {
     }
   }
 
-  @track((props, state) => ({
+  @track(props => ({
     action_type: Schema.ActionTypes.Fail,
     action_name: Schema.ActionNames.ConversationSendReply,
     owner_id: props.me.conversation.id,
@@ -170,7 +143,7 @@ export class Conversation extends React.Component<Props, State> {
             this.props.relay.environment,
             conversation,
             text,
-            response => {
+            _response => {
               this.messageSuccessfullySent(text)
             },
             error => {

--- a/src/lib/Containers/Gene.tsx
+++ b/src/lib/Containers/Gene.tsx
@@ -168,7 +168,7 @@ export class Gene extends React.Component<Props, State> {
     return HeaderHeight
   }
 
-  refineTapped = button => {
+  refineTapped = _button => {
     const initialSettings = {
       sort: "-partner_updated_at",
       selectedMedium: this.props.medium,

--- a/src/lib/Containers/Inbox.tsx
+++ b/src/lib/Containers/Inbox.tsx
@@ -5,7 +5,7 @@ import styled from "styled-components/native"
 import ActiveBids from "lib/Components/Inbox/ActiveBids"
 import Conversations from "lib/Components/Inbox/Conversations"
 import ZeroStateInbox from "lib/Components/Inbox/Conversations/ZeroStateInbox"
-import { RefreshControl, ScrollView, Text, View } from "react-native"
+import { RefreshControl } from "react-native"
 
 interface Props extends RelayProps {
   relay?: RelayRefetchProp

--- a/src/lib/Containers/Inquiry.tsx
+++ b/src/lib/Containers/Inquiry.tsx
@@ -1,20 +1,9 @@
 import React from "react"
+import { Dimensions, NativeModules } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
-import { Schema, Track, track as _track } from "../utils/track"
 
 import { MetadataText, SmallHeadline } from "../Components/Inbox/Typography"
-
-import {
-  Dimensions,
-  FlatList,
-  ImageURISource,
-  KeyboardAvoidingView,
-  NativeModules,
-  Text,
-  TextInput,
-  TouchableOpacity,
-  ViewProperties,
-} from "react-native"
+import { Schema, Track, track as _track } from "../utils/track"
 
 import colors from "lib/data/colors"
 import fonts from "lib/data/fonts"
@@ -76,14 +65,16 @@ const ResponseRate = styled(SmallHeadline)`
   color: ${colors["yellow-bold"]};
   margin-top: 5;
 `
-const ResponseIndicator = styled.View`
-  width: 8;
-  height: 8;
-  border-radius: 4;
-  margin-top: 5;
-  margin-right: 5;
-  background-color: ${colors["yellow-bold"]};
-`
+// TODO: Uncomment when use is uncommented in code below
+// const ResponseIndicator = styled.View`
+//   width: 8;
+//   height: 8;
+//   border-radius: 4;
+//   margin-top: 5;
+//   margin-right: 5;
+//   background-color: ${colors["yellow-bold"]};
+// `
+
 const ResponseRateLine = styled.View`
   flex: 1;
   flex-direction: row;
@@ -109,7 +100,7 @@ export class Inquiry extends React.Component<RelayProps, any> {
     }
   }
 
-  @track((props, state) => ({
+  @track(props => ({
     action_type: Schema.ActionTypes.Tap,
     action_name: Schema.ActionNames.InquiryCancel,
     owner_type: Schema.OwnerEntityTypes.Artwork,
@@ -120,7 +111,7 @@ export class Inquiry extends React.Component<RelayProps, any> {
     this.dismissModal()
   }
 
-  @track((props, state) => ({
+  @track(props => ({
     action_type: Schema.ActionTypes.Success,
     action_name: Schema.ActionNames.InquirySend,
     owner_type: Schema.OwnerEntityTypes.Artwork,
@@ -135,7 +126,7 @@ export class Inquiry extends React.Component<RelayProps, any> {
     ARSwitchBoard.dismissModalViewController(this)
   }
 
-  @track((props, state) => ({
+  @track(props => ({
     action_type: Schema.ActionTypes.Tap,
     action_name: Schema.ActionNames.InquirySend,
     owner_type: Schema.OwnerEntityTypes.Artwork,
@@ -171,7 +162,7 @@ export class Inquiry extends React.Component<RelayProps, any> {
       })
   }
 
-  @track((props, state) => ({
+  @track(props => ({
     action_type: Schema.ActionTypes.Fail,
     action_name: Schema.ActionNames.InquirySend,
     owner_type: Schema.OwnerEntityTypes.Artwork,

--- a/src/lib/Containers/Sale.tsx
+++ b/src/lib/Containers/Sale.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { Dimensions, StyleSheet, View, ViewProperties, ViewStyle } from "react-native"
 import ParallaxScrollView from "react-native-parallax-scroll-view"
-import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
+import { createRefetchContainer, graphql } from "react-relay"
 
 import SaleArtworksGrid from "lib/Components/ArtworkGrids/RelayConnections/SaleArtworksGrid"
 import { GhostButton } from "lib/Components/Buttons"
@@ -92,7 +92,7 @@ export class Sale extends React.Component<Props, State> {
     }
   }
 
-  refineTapped = button => {
+  refineTapped = _button => {
     // Aww yeah
   }
 

--- a/src/lib/Containers/WorksForYou.tsx
+++ b/src/lib/Containers/WorksForYou.tsx
@@ -2,7 +2,6 @@ import React from "react"
 import { ConnectionData, createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 
 import {
-  LayoutChangeEvent,
   ListView,
   ListViewDataSource,
   NativeModules,
@@ -15,18 +14,17 @@ import {
 
 import Events from "../NativeModules/Events"
 
+// FIXME: IS this kind of empty import still needed?
 import GenericGrid from "../Components/ArtworkGrids/GenericGrid"
 // tslint:disable-next-line:no-unused-expression
 GenericGrid
 
+import { PAGE_SIZE } from "lib/data/constants"
+
 import ZeroState from "lib/Components/States/ZeroState"
-import SerifText from "lib/Components/Text/Serif"
 import Notification from "lib/Components/WorksForYou/Notification"
-import { isCloseToBottom } from "lib/utils/isCloseToBottom"
-
 import colors from "lib/data/colors"
-
-const PageSize = 10
+import { isCloseToBottom } from "lib/utils/isCloseToBottom"
 
 interface Props extends RelayProps {
   relay?: RelayPaginationProp
@@ -95,7 +93,12 @@ export class WorksForYou extends React.Component<Props, State> {
     if (!this.props.relay.hasMore() || this.props.relay.isLoading()) {
       return
     }
-    this.props.relay.loadMore(PageSize, error => {
+    this.props.relay.loadMore(PAGE_SIZE, error => {
+      if (error) {
+        // FIXME: Handle error
+        console.error("WorksForYou.tsx", error.message)
+      }
+
       const notifications = this.props.viewer.me.notifications.edges.map(edge => edge.node)
 
       // Make sure we maintain the special notification if it exists
@@ -222,7 +225,7 @@ const WorksForYouContainer = createPaginationContainer(
         count: totalCount,
       }
     },
-    getVariables(props, { count, cursor }, fragmentVariables) {
+    getVariables(_props, { count, cursor }, fragmentVariables) {
       return {
         // in most cases, for variables other than connection filters like
         // `first`, `after`, etc. you may want to use the previous values.

--- a/src/lib/Containers/__tests__/Artist-tests.tsx
+++ b/src/lib/Containers/__tests__/Artist-tests.tsx
@@ -85,8 +85,17 @@ const artistProps = (hasMetadata: boolean, counts?: any) => {
   }
   return {
     artist: {
+      _id: null,
+      id: null,
       has_metadata: hasMetadata,
       counts,
+      birthday: null,
+      name: null,
+      nationality: null,
+      current_shows: null,
+      upcoming_shows: null,
+      past_small_shows: null,
+      past_large_shows: null,
     },
   }
 }

--- a/src/lib/Containers/__tests__/Conversation-tests.tsx
+++ b/src/lib/Containers/__tests__/Conversation-tests.tsx
@@ -1,9 +1,7 @@
-import { mount, shallow } from "enzyme"
-import * as moment from "moment"
+import { shallow } from "enzyme"
 import React from "react"
 
 import "react-native"
-import * as renderer from "react-test-renderer"
 import Conversation from "../Conversation"
 
 jest.unmock("react-tracking")
@@ -13,7 +11,7 @@ jest.mock("NetInfo", () => {
     addEventListener: jest.fn(),
     isConnected: {
       fetch: () => {
-        return new Promise((accept, resolve) => {
+        return new Promise(accept => {
           accept(false)
         })
       },
@@ -45,25 +43,25 @@ it("displays a connectivity banner when network is down", () => {
 it("sends message when composer is submitted", async () => {
   function sendMessage() {
     return new Promise((resolve, reject) => {
-      const onMessageSent = text => {
-        expect(text).toEqual("Hello world")
-        resolve(true)
-      }
+      // TODO: The following commented areas are not being used
+      // const onMessageSent = text => {
+      //   expect(text).toEqual("Hello world")
+      //   resolve(true)
+      // }
 
       setTimeout(reject, 1000)
 
-      const conversation = shallow(
-        <Conversation
-          me={props}
-          onMessageSent={onMessageSent}
-          relay={{
-            environment: {},
-          }}
-        />
-      ).dive()
+      // const conversation = shallow(
+      //   <Conversation
+      //     me={props}
+      //     onMessageSent={onMessageSent}
+      //     relay={{
+      //       environment: {},
+      //     }}
+      //   />
+      // ).dive()
 
-      const instance = conversation.instance()
-
+      // const instance = conversation.instance()
       // instance.composer.setState({ text: "Hello world" })
       // instance.composer.submitText()
       // TODO(luc): fix composer so it's not undefined anymore. enzyme.shallow doesn't

--- a/src/lib/Containers/__tests__/Inbox-tests.tsx
+++ b/src/lib/Containers/__tests__/Inbox-tests.tsx
@@ -1,9 +1,7 @@
 import React from "react"
-import * as TestUtils from "react-dom/test-utils"
 import "react-native"
 import * as renderer from "react-test-renderer"
 
-import ZeroStateInbox from "../../Components/Inbox/Conversations/ZeroStateInbox"
 import Inbox from "../Inbox"
 
 it("renders correctly", () => {
@@ -12,7 +10,8 @@ it("renders correctly", () => {
 })
 
 it("shows empty state if there's no data", () => {
-  const tree = renderer.create(<Inbox me={meProps(false, false)} />).toJSON()
+  // TODO: Reenable test
+  // const tree = renderer.create(<Inbox me={meProps(false, false)} />).toJSON()
   // const emptyStateView = TestUtils.scryRenderedComponentsWithType(tree, ZeroStateInbox)
   // expect(emptyStateView.length).toEqual(1)
 })

--- a/src/lib/Containers/__tests__/WorksForYou-tests.tsx
+++ b/src/lib/Containers/__tests__/WorksForYou-tests.tsx
@@ -1,4 +1,3 @@
-import moment from "moment"
 import React from "react"
 import { NativeModules } from "react-native"
 import * as renderer from "react-test-renderer"

--- a/src/lib/Containers/__tests__/__snapshots__/Artist-tests.tsx.snap
+++ b/src/lib/Containers/__tests__/__snapshots__/Artist-tests.tsx.snap
@@ -17,12 +17,21 @@ exports[`layout works as expected with no tabs 1`] = `
       <Header
         artist={
           Object {
+            "_id": null,
+            "birthday": null,
             "counts": Object {
               "articles": 0,
               "artworks": 0,
               "partner_shows": 0,
             },
+            "current_shows": null,
             "has_metadata": false,
+            "id": null,
+            "name": null,
+            "nationality": null,
+            "past_large_shows": null,
+            "past_small_shows": null,
+            "upcoming_shows": null,
           }
         }
       />
@@ -55,12 +64,21 @@ exports[`layout works as expected with one tab 1`] = `
       <Header
         artist={
           Object {
+            "_id": null,
+            "birthday": null,
             "counts": Object {
               "articles": 0,
               "artworks": 0,
               "partner_shows": 0,
             },
+            "current_shows": null,
             "has_metadata": true,
+            "id": null,
+            "name": null,
+            "nationality": null,
+            "past_large_shows": null,
+            "past_small_shows": null,
+            "upcoming_shows": null,
           }
         }
       />
@@ -74,12 +92,21 @@ exports[`layout works as expected with one tab 1`] = `
         <About
           artist={
             Object {
+              "_id": null,
+              "birthday": null,
               "counts": Object {
                 "articles": 0,
                 "artworks": 0,
                 "partner_shows": 0,
               },
+              "current_shows": null,
               "has_metadata": true,
+              "id": null,
+              "name": null,
+              "nationality": null,
+              "past_large_shows": null,
+              "past_small_shows": null,
+              "upcoming_shows": null,
             }
           }
         />
@@ -106,11 +133,20 @@ exports[`layout works as expected with three tabs 1`] = `
       <Header
         artist={
           Object {
+            "_id": null,
+            "birthday": null,
             "counts": Object {
               "artworks": 2,
               "partner_shows": 1,
             },
+            "current_shows": null,
             "has_metadata": true,
+            "id": null,
+            "name": null,
+            "nationality": null,
+            "past_large_shows": null,
+            "past_small_shows": null,
+            "upcoming_shows": null,
           }
         }
       />
@@ -138,11 +174,20 @@ exports[`layout works as expected with three tabs 1`] = `
           <Artworks
             artist={
               Object {
+                "_id": null,
+                "birthday": null,
                 "counts": Object {
                   "artworks": 2,
                   "partner_shows": 1,
                 },
+                "current_shows": null,
                 "has_metadata": true,
+                "id": null,
+                "name": null,
+                "nationality": null,
+                "past_large_shows": null,
+                "past_small_shows": null,
+                "upcoming_shows": null,
               }
             }
           />

--- a/src/lib/NativeModules/Events.tsx
+++ b/src/lib/NativeModules/Events.tsx
@@ -1,4 +1,4 @@
-import { findNodeHandle, NativeModules } from "react-native"
+import { NativeModules } from "react-native"
 const { AREventsModule } = NativeModules
 
 function postEvent(info: any) {

--- a/src/lib/NativeModules/NotificationsManager.tsx
+++ b/src/lib/NativeModules/NotificationsManager.tsx
@@ -1,5 +1,4 @@
-import React from "react"
-import { EmitterSubscription, NativeEventEmitter, NativeModules } from "react-native"
+import { NativeEventEmitter, NativeModules } from "react-native"
 const { ARNotificationsManager } = NativeModules
 
 export const NotificationsManager = new NativeEventEmitter(ARNotificationsManager)

--- a/src/lib/Scenes/Favorites/Components/Artists/Relay/ArtistsRenderer.tsx
+++ b/src/lib/Scenes/Favorites/Components/Artists/Relay/ArtistsRenderer.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { graphql, QueryRenderer, QueryRendererProps } from "react-relay"
+import { graphql, QueryRenderer } from "react-relay"
 
 import createEnvironment from "lib/relay/createEnvironment"
 const environment = createEnvironment()

--- a/src/lib/Scenes/Favorites/Components/Artists/index.tsx
+++ b/src/lib/Scenes/Favorites/Components/Artists/index.tsx
@@ -1,11 +1,13 @@
 import React from "react"
-import { FlatList, View } from "react-native"
-import { createFragmentContainer, createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
+import { FlatList } from "react-native"
+import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 
 import SavedItemRow from "lib/Components/Lists/SavedItemRow"
 import ZeroState from "lib/Components/States/ZeroState"
 
-class Artists extends React.Component<RelayProps, null> {
+import { PAGE_SIZE } from "lib/data/constants"
+
+class Artists extends React.Component<RelayProps> {
   render() {
     const rows: any[] = this.props.me.followed_artists_connection.edges.map(e => e.node.artist)
     const EmptyState = (
@@ -20,7 +22,12 @@ class Artists extends React.Component<RelayProps, null> {
         return
       }
 
-      this.props.relay.loadMore(10, () => undefined)
+      this.props.relay.loadMore(PAGE_SIZE, error => {
+        if (error) {
+          // FIXME: Handle error
+          console.error("Artists/index.tsx", error.message)
+        }
+      })
     }
 
     const ArtistsList = (
@@ -77,7 +84,7 @@ export default createPaginationContainer<RelayProps>(
         count: totalCount,
       }
     },
-    getVariables(props, pageInfo, fragmentVariables) {
+    getVariables(_props, pageInfo, _fragmentVariables) {
       return pageInfo
     },
     query: graphql.experimental`

--- a/src/lib/Scenes/Favorites/Components/Artworks/Relay/ArtworksRenderer.tsx
+++ b/src/lib/Scenes/Favorites/Components/Artworks/Relay/ArtworksRenderer.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { graphql, QueryRenderer, QueryRendererProps } from "react-relay"
+import { graphql, QueryRenderer } from "react-relay"
 
 import createEnvironment from "lib/relay/createEnvironment"
 const environment = createEnvironment()

--- a/src/lib/Scenes/Favorites/Components/Artworks/index.tsx
+++ b/src/lib/Scenes/Favorites/Components/Artworks/index.tsx
@@ -1,10 +1,10 @@
-import React from "react"
-import { View } from "react-native"
+import React, { Component } from "react"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 import styled from "styled-components/native"
 
 import GenericGrid from "lib/Components/ArtworkGrids/GenericGrid"
 import ZeroState from "lib/Components/States/ZeroState"
+import { PAGE_SIZE } from "lib/data/constants"
 import { isCloseToBottom } from "lib/utils/isCloseToBottom"
 
 const Container = styled.ScrollView`
@@ -17,7 +17,7 @@ interface Props extends RelayProps {
   onDataFetching?: (loading: boolean) => void
 }
 
-export class SavedWorks extends React.Component<Props, any> {
+export class SavedWorks extends Component<Props> {
   loadMore = () => {
     if (!this.props.relay.hasMore() || this.props.relay.isLoading()) {
       return
@@ -31,7 +31,11 @@ export class SavedWorks extends React.Component<Props, any> {
     }
 
     updateState(true)
-    this.props.relay.loadMore(10, e => {
+    this.props.relay.loadMore(PAGE_SIZE, error => {
+      if (error) {
+        // FIXME: Handle error
+        console.error("Artworks/index.tsx", error.message)
+      }
       updateState(false)
     })
   }
@@ -90,7 +94,7 @@ export default createPaginationContainer(
         count: totalCount,
       }
     },
-    getVariables(props, { count, cursor }, fragmentVariables) {
+    getVariables(_props, { count, cursor }, fragmentVariables) {
       return {
         ...fragmentVariables,
         count,

--- a/src/lib/Scenes/Favorites/Components/Categories/Relay/CategoriesRenderer.tsx
+++ b/src/lib/Scenes/Favorites/Components/Categories/Relay/CategoriesRenderer.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { graphql, QueryRenderer, QueryRendererProps } from "react-relay"
+import { graphql, QueryRenderer } from "react-relay"
 
 import createEnvironment from "lib/relay/createEnvironment"
 const environment = createEnvironment()

--- a/src/lib/Scenes/Favorites/Components/Categories/index.tsx
+++ b/src/lib/Scenes/Favorites/Components/Categories/index.tsx
@@ -1,11 +1,12 @@
 import React from "react"
-import { FlatList, Text, View } from "react-native"
-import { createFragmentContainer, createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
+import { FlatList } from "react-native"
+import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 
 import SavedItemRow from "lib/Components/Lists/SavedItemRow"
 import ZeroState from "lib/Components/States/ZeroState"
+import { PAGE_SIZE } from "lib/data/constants"
 
-export class Categories extends React.Component<RelayProps, null> {
+export class Categories extends React.Component<RelayProps> {
   render() {
     const rows: any[] = this.props.me.followed_genes.edges.map(edge => edge.node.gene)
     const EmptyState = (
@@ -19,7 +20,13 @@ export class Categories extends React.Component<RelayProps, null> {
       if (!this.props.relay.hasMore() || this.props.relay.isLoading()) {
         return
       }
-      this.props.relay.loadMore(10, () => undefined)
+
+      this.props.relay.loadMore(PAGE_SIZE, error => {
+        if (error) {
+          // FIXME: Handle error
+          console.error("Artists/index.tsx", error.message)
+        }
+      })
     }
 
     const CategoriesList = (
@@ -75,7 +82,7 @@ export default createPaginationContainer<RelayProps>(
         count: totalCount,
       }
     },
-    getVariables(props, pageInfo, fragmentVariables) {
+    getVariables(_props, pageInfo, _fragmentVariables) {
       return pageInfo
     },
     query: graphql.experimental`

--- a/src/lib/Scenes/Favorites/index.tsx
+++ b/src/lib/Scenes/Favorites/index.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { NativeModules, View } from "react-native"
+import { View } from "react-native"
 import ScrollableTabView from "react-native-scrollable-tab-view"
 import styled from "styled-components/native"
 
@@ -7,7 +7,6 @@ import TabBar, { Tab } from "lib/Components/TabBar"
 import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
 
 import DarkNavigationButton from "lib/Components/Buttons/DarkNavigationButton"
-import Headline from "lib/Components/Text/Headline"
 import { Fonts } from "lib/data/fonts"
 
 import Artists from "./Components/Artists"

--- a/src/lib/Scenes/Home/Components/ForYou/Components/ArtworkCarousel.tsx
+++ b/src/lib/Scenes/Home/Components/ForYou/Components/ArtworkCarousel.tsx
@@ -67,6 +67,10 @@ export class ArtworkCarousel extends React.Component<Props & RelayPropsWorkaroun
   componentDidMount() {
     if (this.props.relay) {
       this.props.relay.refetch({ __id: this.props.rail.__id, fetchContent: true }, null, error => {
+        if (error) {
+          console.error("ArtworkCarousel.tsx", error.message)
+        }
+
         this.setState({
           didPerformFetch: true,
           loadFailed: !!error,

--- a/src/lib/Scenes/Home/Components/ForYou/Components/ArtworkCarouselHeader.tsx
+++ b/src/lib/Scenes/Home/Components/ForYou/Components/ArtworkCarouselHeader.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { Component } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 
 import {
@@ -42,7 +42,7 @@ interface State {
   following: boolean
 }
 
-class ArtworkCarouselHeader extends React.Component<Props & RelayPropsWorkaround, State> {
+class ArtworkCarouselHeader extends Component<Props & RelayPropsWorkaround, State> {
   constructor(props) {
     super(props)
     this.state = { following: props.rail.key === "followed_artist" }

--- a/src/lib/Scenes/Home/Components/ForYou/Components/FairsRail.tsx
+++ b/src/lib/Scenes/Home/Components/ForYou/Components/FairsRail.tsx
@@ -1,11 +1,10 @@
 import React from "react"
-import { createFragmentContainer, graphql, RelayRefetchProp } from "react-relay"
+import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components/native"
 
-import { Dimensions, ScrollView, TouchableHighlight } from "react-native"
+import { Dimensions, TouchableHighlight } from "react-native"
 
 import ImageView from "lib/Components/OpaqueImageView"
-import Separator from "lib/Components/Separator"
 import Switchboard from "lib/NativeModules/SwitchBoard"
 import SectionTitle from "lib/Scenes/Home/Components/SectionTitle"
 

--- a/src/lib/Scenes/Home/Components/Sales/Components/LotsByFollowedArtists.tsx
+++ b/src/lib/Scenes/Home/Components/Sales/Components/LotsByFollowedArtists.tsx
@@ -1,12 +1,13 @@
+import React from "react"
+import { ScrollView } from "react-native"
+import { ConnectionData, createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
+import styled from "styled-components/native"
+
+import { once } from "lodash"
+
 import GenericGrid from "lib/Components/ArtworkGrids/GenericGrid"
 import Spinner from "lib/Components/Spinner"
 import { isCloseToBottom } from "lib/utils/isCloseToBottom"
-import { once } from "lodash"
-import PropTypes from "prop-types"
-import React, { Component } from "react"
-import { FlatList, ScrollView, Text, View } from "react-native"
-import { ConnectionData, createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
-import styled from "styled-components/native"
 import { SectionHeader } from "./SectionHeader"
 
 const DEFAULT_TITLE = "Lots by Artists You Follow"
@@ -65,7 +66,7 @@ export default createPaginationContainer(
   {
     getConnectionFromProps: ({ viewer }) => viewer && (viewer.sale_artworks as ConnectionData),
     getFragmentVariables: (prevVars, totalCount) => ({ ...prevVars, count: totalCount }),
-    getVariables: (props, { count, cursor }) => ({ count, cursor }),
+    getVariables: (_props, { count, cursor }) => ({ count, cursor }),
     query: graphql.experimental`
       query LotsByFollowedArtistsQuery($count: Int!, $cursor: String) {
         viewer {

--- a/src/lib/Scenes/Home/Components/Sales/Components/SaleList.tsx
+++ b/src/lib/Scenes/Home/Components/Sales/Components/SaleList.tsx
@@ -1,5 +1,6 @@
 import React, { Component } from "react"
 import { Dimensions, FlatList, View } from "react-native"
+
 import SaleListItem from "./SaleListItem"
 import { SectionHeader } from "./SectionHeader"
 
@@ -18,7 +19,7 @@ export class SaleList extends Component<any> {
           }}
           data={this.props.item.data}
           numColumns={numColumns}
-          keyExtractor={(item, index) => item.__id}
+          keyExtractor={item => item.__id}
           renderItem={({ item, index }) => <SaleListItem key={index} sale={item} />}
         />
       </View>

--- a/src/lib/Scenes/Home/Components/Sales/Components/SaleListItem.tsx
+++ b/src/lib/Scenes/Home/Components/Sales/Components/SaleListItem.tsx
@@ -1,12 +1,13 @@
+import React from "react"
+import { Dimensions, TouchableWithoutFeedback } from "react-native"
+import { createFragmentContainer, graphql } from "react-relay"
+import styled from "styled-components/native"
+
 import OpaqueImageView from "lib/Components/OpaqueImageView"
 import Serif from "lib/Components/Text/Serif"
 import fonts from "lib/data/fonts"
 import Switchboard from "lib/NativeModules/SwitchBoard"
-import moment from "moment"
-import React from "react"
-import { Dimensions, Text, TouchableWithoutFeedback, View } from "react-native"
-import { createFragmentContainer, graphql } from "react-relay"
-import styled from "styled-components/native"
+
 import { liveDate, timedDate } from "../Utils/formatDate"
 
 const Image = styled(OpaqueImageView)`

--- a/src/lib/Scenes/Home/Components/Sales/Components/SectionHeader.tsx
+++ b/src/lib/Scenes/Home/Components/Sales/Components/SectionHeader.tsx
@@ -1,6 +1,7 @@
-import fonts from "lib/data/fonts"
 import React from "react"
 import styled from "styled-components/native"
+
+import fonts from "lib/data/fonts"
 
 const Header = styled.View`
   padding: 10px;

--- a/src/lib/Scenes/Home/Components/Sales/Components/__tests__/LotsByFollowedArtists-tests.tsx
+++ b/src/lib/Scenes/Home/Components/Sales/Components/__tests__/LotsByFollowedArtists-tests.tsx
@@ -1,7 +1,8 @@
-import { getTestWrapper } from "lib/utils/getTestWrapper"
-import React from "react"
 import "react-native"
-import renderer from "react-test-renderer"
+
+import React from "react"
+
+import { getTestWrapper } from "lib/utils/getTestWrapper"
 import { LotsByFollowedArtists } from "../LotsByFollowedArtists"
 
 describe("LotsByFollowedArtists", () => {

--- a/src/lib/Scenes/Home/Components/Sales/__tests__/index-tests.tsx
+++ b/src/lib/Scenes/Home/Components/Sales/__tests__/index-tests.tsx
@@ -1,4 +1,3 @@
-import * as moment from "moment"
 import React from "react"
 import "react-native"
 import * as renderer from "react-test-renderer"

--- a/src/lib/Scenes/Home/Components/Sales/index.tsx
+++ b/src/lib/Scenes/Home/Components/Sales/index.tsx
@@ -1,21 +1,9 @@
-import fonts from "lib/data/fonts"
-import { isCloseToBottom } from "lib/utils/isCloseToBottom"
 import React from "react"
-import { Dimensions, FlatList, SectionList, Text, TouchableWithoutFeedback, View } from "react-native"
-import { StyleSheet, TextStyle } from "react-native"
-import {
-  ConnectionData,
-  createFragmentContainer,
-  createPaginationContainer,
-  graphql,
-  QueryRenderer,
-  QueryRendererProps,
-  RelayPaginationProp,
-} from "react-relay"
-import styled from "styled-components/native"
+import { SectionList } from "react-native"
+import { StyleSheet } from "react-native"
+import { createFragmentContainer, graphql } from "react-relay"
 import LotsByFollowedArtists from "./Components/LotsByFollowedArtists"
 import { SaleList } from "./Components/SaleList"
-import { SectionHeader } from "./Components/SectionHeader"
 
 class Sales extends React.Component<Props> {
   get data() {
@@ -54,7 +42,7 @@ class Sales extends React.Component<Props> {
         contentContainerStyle={SectionListStyles.contentContainer}
         stickySectionHeadersEnabled={false}
         sections={sections}
-        keyExtractor={(item, index) => item.id}
+        keyExtractor={item => item.id}
       />
     )
   }

--- a/src/lib/Scenes/Settings/MyProfile.tsx
+++ b/src/lib/Scenes/Settings/MyProfile.tsx
@@ -3,7 +3,7 @@ import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components/native"
 
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
-import { Dimensions, ScrollView, Text, TouchableOpacity, View, ViewProperties, ViewStyle } from "react-native"
+import { ScrollView, TouchableOpacity, View, ViewProperties } from "react-native"
 
 import { Colors } from "lib/data/colors"
 import { Fonts } from "lib/data/fonts"
@@ -96,13 +96,12 @@ interface Props extends ViewProperties, RelayProps {}
 
 export class MyProfile extends React.Component<Props, {}> {
   render() {
-    const windowDimensions = Dimensions.get("window")
-    const commonPadding = windowDimensions.width > 700 ? 40 : 20
+    // TODO: go to overview / implement below
+    // const windowDimensions = Dimensions.get("window")
+    // const commonPadding = windowDimensions.width > 700 ? 40 : 20
+    // const goToConsignmentsOverview = () => SwitchBoard.presentNavigationViewController(this, Router.SellingOverview)
 
-    // TODO: go to overview
-    const goToConsignmentsOverview = () => SwitchBoard.presentNavigationViewController(this, Router.SellingOverview)
     const startSubmission = () => SwitchBoard.presentModalViewController(this, Router.ConsignmentsStartSubmission)
-
     const goToUserSettings = () => SwitchBoard.presentNavigationViewController(this, Router.UserSettingsiOS)
 
     return (

--- a/src/lib/__mocks__/metaphysics.ts
+++ b/src/lib/__mocks__/metaphysics.ts
@@ -1,5 +1,5 @@
-function metaphysics(query) {
-  return new Promise((resolve, reject) => {
+function metaphysics(_query) {
+  return new Promise(resolve => {
     resolve({})
   })
 }

--- a/src/lib/data/constants.ts
+++ b/src/lib/data/constants.ts
@@ -1,0 +1,1 @@
+export const PAGE_SIZE = 10

--- a/src/lib/relay/createEnvironment.ts
+++ b/src/lib/relay/createEnvironment.ts
@@ -1,9 +1,9 @@
-import { Environment, Network, RecordSource, RelayInMemoryRecordSource, Store } from "relay-runtime"
+import { Environment, Network, RecordSource, Store } from "relay-runtime"
 import { metaphysics } from "../metaphysics"
 
 // Define a function that fetches the results of an operation (query/mutation/etc)
 // and returns its results as a Promise:
-function fetchQuery(operation, variables, cacheConfig, uploadables) {
+function fetchQuery(operation, variables, _cacheConfig, _uploadables) {
   return metaphysics({ query: operation.text, variables })
 }
 

--- a/src/lib/utils/getTestWrapper.tsx
+++ b/src/lib/utils/getTestWrapper.tsx
@@ -7,7 +7,6 @@
  *  const { text }  = getTestSnapshot(<MyComponent title='Hi!' />)
  *  expect(text).toContain('Hi!')
  */
-import { shallow } from "enzyme"
 import "react-native"
 import renderer from "react-test-renderer"
 

--- a/src/lib/utils/track.ts
+++ b/src/lib/utils/track.ts
@@ -1,4 +1,3 @@
-import React from "react"
 import _track, { Track as _Track, TrackingInfo } from "react-tracking"
 
 import Events from "lib/NativeModules/Events"

--- a/src/setupJest.ts
+++ b/src/setupJest.ts
@@ -11,7 +11,7 @@ expect.extend({ toMatchDiffSnapshot: (diff as any).toMatchDiffSnapshot })
 const originalConsoleError = console.error
 
 // Remove on the next React-Native update.
-console.error = (message?: any, ...optionalParams: any[]) => {
+console.error = (message?: any) => {
   if (
     typeof message === "string" &&
     (message.includes("PropTypes has been moved to a separate package.") ||

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,19 +1,21 @@
 {
   "compilerOptions": {
+    "allowJs": true,
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": "src",
+    "experimentalDecorators": true,
     "jsx": "react",
-    "target": "es6",
     "module": "es2015",
     "moduleResolution": "node",
-    "rootDir": "src",
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "outDir": "build",
-    "allowJs": true,
-    "pretty": true,
-    "strictNullChecks": false,
-    "allowSyntheticDefaultImports": true,
-    "experimentalDecorators": true,
-    "types": ["jest", "react", "react-native"],
     "plugins": [{ "name": "typescript-styled-plugin" }],
-    "baseUrl": "src"
+    "pretty": true,
+    "rootDir": "src",
+    "strictNullChecks": false,
+    "target": "es6",
+    "types": ["jest", "react", "react-native"]
   },
   "include": ["typings/*.d.ts", "src/**/*.ts", "src/**/*.tsx", "dangerfile.ts"],
   "exclude": [

--- a/tslint.json
+++ b/tslint.json
@@ -5,10 +5,11 @@
     "interface-name": [true, "never-prefix"],
     "max-classes-per-file": [false],
     "member-access": [false, "check-accessor", "check-constructor"],
+    "no-console": [true, ["error", ["warn", "error"]]],
+    "no-unused-variable": [true, { "ignore-pattern": "^_" }],
     "object-literal-sort-keys": false,
     "ordered-imports": true,
     "switch-default": false,
-    "no-unused-variable": [true],
-    "no-console": [true, ["error", ["warn", "error"]]]
+    "variable-name": [true, "allow-pascal-case", "allow-leading-underscore"]
   }
 }


### PR DESCRIPTION
One thing I noticed when I first started working in Emission was all of the unused variables and imports. There's [a TSLint rule](https://palantir.github.io/tslint/rules/no-unused-variable/) available, but since the check occurs in TypeScript it never gets fired. This PR enables `noUnusedLocals` and `noUnusedParameters` in [tsconfig.json](https://www.typescriptlang.org/docs/handbook/compiler-options.html) and sweeps through the code. 

While making edits I also found handful of unguarded error code for which I entered `console.error`s and `FIXME: Handle error` notes. 

Skip New Tests

There are a couple questions which I've noted inline. 