### PR TITLE
Adds nil protection to a check for the length of images to upload to s3

### DIFF
--- a/src/lib/Components/Consignments/Screens/Overview.tsx
+++ b/src/lib/Components/Consignments/Screens/Overview.tsx
@@ -151,7 +151,7 @@ export default class Info extends React.Component<Props, State> {
   uploadPhotosIfNeeded = async () => {
     const toUpload = this.state.photos && this.state.photos.filter(f => !f.uploaded && f.file)
 
-    if (toUpload.length) {
+    if (toUpload && toUpload.length) {
       // Pull out the first in the queue and upload it
       const photo = toUpload[0]
       await uploadImageAndPassToGemini(photo.file, "private", this.state.submission_id)


### PR DESCRIPTION
Resolves: https://sentry.io/artsynet/eigen-staging/issues/413385206/

This was due to our nil checking not being enforced in Emission as `toUpload` could be an falsey value.

#trivial