### PR TITLE
[home] do not render artist rail if it does not have artists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### Master
 
+-   Don't load an ArtistRail if it doesn't have any artists - sarah
 -   Refetch data when user re-enters Inbox tab - luc
 -   Send event from view controller to react component when tab changes - luc
 -   Allow passing a set of Artworks and an index to load to Eigen when clicking on

--- a/src/lib/Components/Home/ArtistRails/ArtistRail.tsx
+++ b/src/lib/Components/Home/ArtistRails/ArtistRail.tsx
@@ -180,7 +180,7 @@ class ArtistRail extends React.Component<Props, State> {
   }
 
   render() {
-    if (this.state.loadFailed) {
+    if (this.state.loadFailed || !this.state.artists.length) {
       return null
     }
 


### PR DESCRIPTION
I couldn't reproduce this issue but I added this little check anyway to make sure it probably can't happen.

Fixes https://github.com/artsy/collector-experience/issues/766 (sort of)

Skip New Tests