### PR TITLE
[Home] Adds some null protection to the home / auctions pages

### DIFF
--- a/src/lib/Containers/WorksForYou.tsx
+++ b/src/lib/Containers/WorksForYou.tsx
@@ -42,7 +42,8 @@ export class WorksForYou extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props)
 
-    const notifications = this.props.viewer.me.notifications.edges.map(edge => edge.node)
+    const notifications =
+      (this.props.viewer.me.notifications && this.props.viewer.me.notifications.edges.map(edge => edge.node)) || []
     if (this.props.viewer.selectedArtist) {
       notifications.unshift(this.formattedSpecialNotification())
     }

--- a/src/lib/Scenes/Home/Components/Sales/Components/LotsByFollowedArtists.tsx
+++ b/src/lib/Scenes/Home/Components/Sales/Components/LotsByFollowedArtists.tsx
@@ -15,9 +15,11 @@ const PAGE_SIZE = 10
 
 export const LotsByFollowedArtists: React.SFC<Props> = props => {
   const { viewer, relay, title = DEFAULT_TITLE } = props
-  const artworks = viewer.sale_artworks.edges.filter(({ node }) => node.is_biddable).map(({ node }) => node.artwork)
+  const artworks =
+    viewer.sale_artworks &&
+    viewer.sale_artworks.edges.filter(({ node }) => node.is_biddable).map(({ node }) => node.artwork)
 
-  if (!artworks.length) {
+  if (!artworks || artworks.length === 0) {
     return null
   }
 


### PR DESCRIPTION
In looking at https://sentry.io/artsynet/eigen-staging/issues/406930867/ we had wondered if it was related to an expired access token. TBH, I don't think it does right now, (and our access tokens are 25 years by default, you'd need to change your password) but this at least exposes a bunch of easy to grab nil crashes bugs.

#trivial