### PR TITLE
[Home/Auctions] Sort Auctions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 // These docs are aimed at developers, but are shown inside collector GMV's channel
 
 ### Master
+-   Sort Home/Auctions list
 
 ### 1.4.0-beta.10
 

--- a/src/lib/Scenes/Home/Components/Sales/Components/SaleList.tsx
+++ b/src/lib/Scenes/Home/Components/Sales/Components/SaleList.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from "react"
 import { Dimensions, FlatList, View } from "react-native"
 
-import SaleListItem from "./SaleListItem"
+import { SaleListItem } from "./SaleListItem"
 import { SectionHeader } from "./SectionHeader"
 
 export class SaleList extends Component<any> {
@@ -19,7 +19,9 @@ export class SaleList extends Component<any> {
           }}
           data={this.props.item.data}
           numColumns={numColumns}
-          keyExtractor={item => item.__id}
+          // keyExtractor={item => item.__id}
+          // FIXME:
+          keyExtractor={item => Math.random().toString()}
           renderItem={({ item, index }) => <SaleListItem key={index} sale={item} />}
         />
       </View>

--- a/src/lib/Scenes/Home/Components/Sales/Utils/__tests__/sortSales-tests.ts
+++ b/src/lib/Scenes/Home/Components/Sales/Utils/__tests__/sortSales-tests.ts
@@ -1,0 +1,173 @@
+import { flatten, shuffle, unzip } from "lodash"
+import moment from "moment"
+import { sortLiveSales, sortTimedSales } from "../sortSales"
+
+describe("home/sales/utils/sortSales", () => {
+  describe("#sortLiveSales", () => {
+    const testData = [
+      [
+        [
+          {
+            is_live_open: true,
+            live_start_at: moment().subtract(1, "days"),
+            registration_ends_at: moment().subtract(2, "days"),
+          },
+        ],
+        "In Progress",
+      ],
+      [
+        [
+          {
+            is_live_open: true,
+            live_start_at: moment().subtract(2, "days"),
+            registration_ends_at: moment().subtract(3, "days"),
+          },
+        ],
+        "In Progress",
+      ],
+      [
+        [
+          {
+            live_start_at: moment().add(10, "minutes"),
+            registration_ends_at: moment().subtract(2, "days"),
+          },
+        ],
+        "Live in 10 minutes",
+      ],
+      [
+        [
+          {
+            live_start_at: moment().add(20, "minutes"),
+            registration_ends_at: moment().subtract(2, "days"),
+          },
+        ],
+        "Live in 20 minutes",
+      ],
+      [
+        [
+          {
+            live_start_at: moment().add(20, "days"),
+            registration_ends_at: moment().add(10, "minutes"),
+          },
+        ],
+        `Register by\n${moment(moment().add(10, "minutes")).format("ha")}`,
+      ],
+      [
+        [
+          {
+            live_start_at: moment().add(30, "days"),
+            registration_ends_at: moment().add(10, "days"),
+          },
+        ],
+        `Register by\n${moment(moment().add(10, "days")).format("MMM D, ha")}`,
+      ],
+    ]
+
+    it("renders correct labels", () => {
+      testData.forEach(([input, expectedLabelOutput]) => {
+        sortLiveSales(input).forEach(([_sale, label]) => {
+          expect(label).toEqual(expectedLabelOutput)
+        })
+      })
+    })
+
+    it("sorts sales", () => {
+      const [, labels] = unzip(testData)
+      const [shuffledSales] = unzip(shuffle(testData))
+      const [, sortedLabels] = unzip(sortLiveSales(flatten(shuffledSales)))
+      expect(sortedLabels).toEqual(labels)
+    })
+  })
+
+  describe("#sortTimedSales", () => {
+    const testData = [
+      [
+        [
+          {
+            start_at: moment().add(10, "minutes"),
+            end_at: moment().add(2, "days"),
+          },
+        ],
+        "10 minutes left",
+      ],
+      [
+        [
+          {
+            start_at: moment().add(20, "minutes"),
+            end_at: moment().add(2, "days"),
+          },
+        ],
+        "20 minutes left",
+      ],
+      [
+        [
+          {
+            start_at: moment().add(10, "hours"),
+            end_at: moment().add(2, "days"),
+          },
+        ],
+        "10 hours left",
+      ],
+      [
+        [
+          {
+            start_at: moment().add(20, "hours"),
+            end_at: moment().add(2, "days"),
+          },
+        ],
+        "20 hours left",
+      ],
+      [
+        [
+          {
+            start_at: moment().add(2, "days"),
+            end_at: moment().add(4, "days"),
+          },
+        ],
+        "2 days left",
+      ],
+      [
+        [
+          {
+            start_at: moment().add(5, "days"),
+            end_at: moment().add(10, "days"),
+          },
+        ],
+        "5 days left",
+      ],
+      [
+        [
+          {
+            start_at: moment().add(20, "days"),
+            end_at: moment().add(30, "days"),
+          },
+        ],
+        `Ends on ${moment(moment().add(30, "days")).format("MMM D, ha")}`,
+      ],
+      [
+        [
+          {
+            start_at: moment().add(30, "days"),
+            end_at: moment().add(40, "days"),
+          },
+        ],
+        `Ends on ${moment(moment().add(40, "days")).format("MMM D, ha")}`,
+      ],
+    ]
+
+    it("renders correct labels", () => {
+      testData.forEach(([input, expectedLabelOutput]) => {
+        sortTimedSales(input).forEach(([_sale, label]) => {
+          expect(label).toEqual(expectedLabelOutput)
+        })
+      })
+    })
+
+    it("sorts sales", () => {
+      const [, labels] = unzip(testData)
+      const [shuffledSales] = unzip(shuffle(testData))
+      const [, sortedLabels] = unzip(sortTimedSales(flatten(shuffledSales)))
+      expect(sortedLabels).toEqual(labels)
+    })
+  })
+})

--- a/src/lib/Scenes/Home/Components/Sales/Utils/formatDate.ts
+++ b/src/lib/Scenes/Home/Components/Sales/Utils/formatDate.ts
@@ -2,7 +2,7 @@ import moment from "moment"
 
 export function liveDate(auction) {
   if (moment(auction.registration_ends_at) > moment()) {
-    return formatDate(auction.registration_ends_at, false, true)
+    return formatDate(auction.registration_ends_at, { isStarted: false, isRegister: true })
   } else if (moment(auction.live_start_at) > moment()) {
     return formatDate(auction.live_start_at)
   } else {
@@ -14,12 +14,13 @@ export function timedDate(auction) {
   if (moment(auction.start_at) > moment()) {
     return formatDate(auction.start_at)
   } else {
-    return formatDate(auction.end_at, true)
+    return formatDate(auction.end_at, { isStarted: true })
   }
 }
 
-function formatDate(date, isStarted = false, isRegister = false) {
+function formatDate(date, { isStarted = false, isRegister = false } = {}) {
   const diff = moment().diff(moment(date), "hours")
+  // return moment(date).format("MMM D, ha") // FIXME:
   let formatted
 
   if (isStarted) {

--- a/src/lib/Scenes/Home/Components/Sales/Utils/sortSales.ts
+++ b/src/lib/Scenes/Home/Components/Sales/Utils/sortSales.ts
@@ -1,0 +1,105 @@
+import { compose, filter, flatten, map, prop, sortBy, zip } from "lodash/fp"
+import moment from "moment"
+
+/**
+ * Live Auctions are sorted top to bottom by auctions that are in progress, the soonest
+ * to open and the soonest to have registration close.
+ *
+ * Labels should read:
+ * - In Progress
+ * - Live in x minutes
+ * - Live in x hours
+ * - Live in x days
+ * - Register by x time (once registered should display live in x days/hours/mins)
+ */
+export function sortLiveSales(saleData) {
+  const dateField = prop("live_start_at")
+  const upcoming = filter(sale => moment(dateField(sale)) > moment() && moment(sale.registration_ends_at) < moment())
+  const inProgress = filter(sale => sale.is_live_open)
+  const registrationEndsAt = filter(sale => moment(sale.registration_ends_at) > moment())
+  const doSort = sortFn => compose(sortBy(dateField), sortFn)
+
+  const sorted = [
+    {
+      sortFn: doSort(inProgress),
+      getLabel: () => "In Progress",
+    },
+    {
+      sortFn: doSort(upcoming),
+      getLabel: sale => {
+        const label = `Live ${moment(sale.live_start_at).fromNow()}`
+        return label
+      },
+    },
+    {
+      sortFn: doSort(registrationEndsAt),
+      getLabel: sale => {
+        const date = sale.registration_ends_at
+        const diff = moment().diff(moment(date), "hours")
+        const format = diff > -24 ? "ha" : "MMM D, ha"
+        const label = `Register by\n${moment(date).format(format)}`
+        return label
+      },
+    },
+  ].map(({ sortFn, getLabel }) => {
+    const results = sortFn(saleData)
+    const labels = map(getLabel)(results)
+    return zip(results, labels)
+  })
+
+  // console.log("Live:", sorted)
+
+  return flatten(sorted)
+  // return sorted
+}
+
+/**
+ * Timed auctions are sorted top to bottom by the auction closing the soonest.
+ *
+ * Labels should read:
+ * - X min left
+ * - X hours left
+ * - X days left
+ * - Ends on <closing date> (if greater than 5 days away)
+ */
+export function sortTimedSales(saleData) {
+  const dateField = prop("start_at")
+  const range = moment().add(5, "days")
+  const inProgress = filter(sale => moment(dateField(sale)) < moment())
+  const upcoming = filter(sale => moment(dateField(sale)) > moment() && moment(dateField(sale)) < range)
+  const nearFuture = filter(sale => moment(dateField(sale)) > range)
+  const dateLabel = date => moment(date).fromNow().replace("in", "").trim() + " left"
+  const doSort = sortFn => compose(sortBy(dateField), sortFn)
+
+  const sorted = [
+    {
+      sortFn: doSort(inProgress),
+      getLabel: sale => {
+        const label = dateLabel(sale.end_at)
+        return label
+      },
+    },
+    {
+      sortFn: doSort(upcoming),
+      getLabel: sale => {
+        const label = dateLabel(sale.start_at)
+        return label
+      },
+    },
+    {
+      sortFn: doSort(nearFuture),
+      getLabel: sale => {
+        const label = `Ends on ${moment(sale.end_at).format("MMM D, ha")}`
+        return label
+      },
+    },
+  ].map(({ sortFn, getLabel }) => {
+    const results = sortFn(saleData)
+    const labels = map(getLabel)(results)
+    return zip(results, labels)
+  })
+
+  // console.log("Timed:", sorted)
+
+  return flatten(sorted)
+}

--- a/src/lib/Scenes/Home/Components/Sales/index.tsx
+++ b/src/lib/Scenes/Home/Components/Sales/index.tsx
@@ -2,18 +2,22 @@ import React from "react"
 import { SectionList } from "react-native"
 import { StyleSheet } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
+
 import LotsByFollowedArtists from "./Components/LotsByFollowedArtists"
 import { SaleList } from "./Components/SaleList"
+import { sortLiveSales, sortTimedSales } from "./Utils/sortSales"
 
 class Sales extends React.Component<Props> {
   get data() {
     const { viewer } = this.props
-    const liveAuctions = viewer.sales.filter(a => !!a.live_start_at)
-    const timedAuctions = viewer.sales.filter(a => !a.live_start_at)
+    // const liveSales = sortLiveSales(viewer.sales.filter(a => !!a.live_start_at))
+    // const timedSales = sortTimedSales(viewer.sales.filter(a => !a.live_start_at))
+    const liveSales = viewer.sales.filter(a => !!a.live_start_at)
+    const timedSales = viewer.sales.filter(a => !a.live_start_at)
 
     return {
-      liveAuctions,
-      timedAuctions,
+      liveSales,
+      timedSales,
       viewer,
     }
   }
@@ -21,12 +25,12 @@ class Sales extends React.Component<Props> {
   render() {
     const sections = [
       {
-        data: [{ data: this.data.liveAuctions }],
+        data: [{ data: this.data.liveSales }],
         title: "Current Live Auctions",
         renderItem: props => <SaleList {...props} />,
       },
       {
-        data: [{ data: this.data.timedAuctions }],
+        data: [{ data: this.data.timedSales }],
         title: "Current Timed Auctions",
         renderItem: props => <SaleList {...props} />,
       },
@@ -53,7 +57,7 @@ export default createFragmentContainer(
   graphql`
     fragment Sales_viewer on Viewer {
       sales(live: true, is_auction: true, size: 100) {
-        ...SaleListItem_sale
+        ...SaleListItem_sale @relay(mask: false)
         href
         live_start_at
       }


### PR DESCRIPTION
Fixes https://github.com/artsy/collector-experience/issues/756

Adds a new sale-sorting heuristic according to these rules:

**Live Auctions** (sorted top to bottom by auctions that are in progress, the soonest to open AND the soonest to have registration close): 

- In Progress
- Live in x minutes
- Live in x hours
- Live in x days
- Register by x time (once registered should display live in x days/hours/mins)

**Timed** (sorted top to bottom by the auction closing the soonest): 

- X min left
- X hours left
- 3 days left
- 4 days left
- 5 days left
- (more than 5 days to go) Ends on closing date