### PR TITLE
[Gene] Pass defaults for medium/price to native refine hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ### Master
 
+-   Bug fix for the Gene refine not showing on Eigen - orta
+
 ### 1.4.0-beta.10
 
 -   Update WorksForYou to use new Metaphysics schema to avoid frequent empty states - matt

--- a/src/lib/Containers/Gene.tsx
+++ b/src/lib/Containers/Gene.tsx
@@ -171,8 +171,8 @@ export class Gene extends React.Component<Props, State> {
   refineTapped = _button => {
     const initialSettings = {
       sort: "-partner_updated_at",
-      selectedMedium: this.props.medium,
-      selectedPrice: this.props.price_range,
+      selectedMedium: this.props.medium || "*",
+      selectedPrice: this.props.price_range || "*-*",
       aggregations: this.props.gene.filtered_artworks.aggregations,
     }
 


### PR DESCRIPTION
I think a React Native update meant that a value being `undefined` instead of being sent as `null` does not get passed to the native code at all. This means that checks in Eigen that the data is correct would fail. So now if we have undefined, we send the default values.