### PR TITLE
Adds support for a native code versioning system

### DIFF
--- a/Emission.podspec
+++ b/Emission.podspec
@@ -1,16 +1,17 @@
 require 'json'
 
 root = ENV["EMISSION_ROOT"] || __dir__
-pkg_version = lambda do |dir_from_root = ''|
+pkg_version = lambda do |dir_from_root = '', version = 'version'|
   path = File.join(root, dir_from_root, 'package.json')
-  JSON.load(File.read(path))['version']
+  JSON.load(File.read(path))[version]
 end
 
 emission_version = pkg_version.call
+emission_native_version = pkg_version.call('', 'native-code-version')
 react_native_version = pkg_version.call('node_modules/react-native')
 sentry_version = pkg_version.call('node_modules/react-native-sentry')
 
-Pod::Spec.new do |s|
+podspec = Pod::Spec.new do |s|
   s.name           = 'Emission'
   s.version        = emission_version
   s.summary        = 'React Native Components used by Eigen.'
@@ -43,3 +44,7 @@ Pod::Spec.new do |s|
   # with the SentryReactNative version that CocoaPods would pull into Eigen.
   s.dependency 'SentryReactNative', sentry_version
 end
+
+# Attach the native version info into the podspec
+podspec.attributes_hash['native_version'] = emission_native_version
+podspec

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -16,8 +16,9 @@ const modified = danger.git.modified_files
 const bodyAndTitle = (pr.body + pr.title).toLowerCase()
 
 // Custom modifiers for people submitting PRs to be able to say "skip this"
-const trivialPR = bodyAndTitle.includes("trivial")
-const acceptedNoTests = bodyAndTitle.includes("skip new tests")
+const trivialPR = bodyAndTitle.includes("#trivial")
+const acceptedNoTests = bodyAndTitle.includes("#skip_new_tests")
+const acceptedNoNativeChanges = bodyAndTitle.includes("#native_no_changes")
 
 const typescriptOnly = (file: string) => includes(file, ".ts")
 const filesOnly = (file: string) => fs.existsSync(file) && fs.lstatSync(file).isFile()
@@ -69,7 +70,7 @@ if (testFilesThatDontExist.length > 0) {
 
 ${testFilesThatDontExist.map(f => `- \`${f}\``).join("\n")}
 
-If these files are supposed to not exist, please update your PR body to include "Skip New Tests".`
+If these files are supposed to not exist, please update your PR body to include "#skip_new_tests".`
   callout(output)
 }
 
@@ -171,5 +172,18 @@ if (fs.existsSync("tslint-errors.json")) {
   }
 }
 
+// Show Jest fails in the PR
 import jest from "danger-plugin-jest"
 jest()
+
+// Raise when native code changes are made, but the package.json does not
+// have a bump for the native code version
+//
+const hasNativeCodeChanges = modifiedAppFiles.find(p => p.includes("Pod/Classes"))
+const hasPackageJSONChanges = modifiedAppFiles.find(p => p === "package.json")
+if (hasNativeCodeChanges && !hasPackageJSONChanges && !acceptedNoNativeChanges) {
+  fail(
+    `This PR includes changes to the Emission Pod's native code but does not have a \`package.json\`
+     change for the update to the \`"native-code-version"\`. If this is fine, add #native_no_changes to your PR message.`
+  )
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "emission",
   "version": "1.4.0-beta.10",
+  "native-code-version": 1,
   "description": "Artsy React(Native) components.",
   "engines": {
     "node": "8.4.x",

--- a/scripts/deploy_master.sh
+++ b/scripts/deploy_master.sh
@@ -22,8 +22,11 @@ PR_NUM=`git log --format=%B -n 1 $SHA | grep -Eo '#[0-9]+' | tail -n 1 | cut -d 
 # format hardcoded because https://stackoverflow.com/questions/7216358/date-command-on-os-x-doesnt-have-iso-8601-i-option
 DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"`
 
+# Pulls the native code version from the package.json
+NATIVE_VERSION=`ruby -e "require'json';puts(JSON.parse(File.read('package.json'))['native-code-version'])"`
+
 # Create a metadata file
-echo "{\"title\":\"$PR_DESC\",\"sha\":\"$SHA\", \"date\":\"$DATE\", \"number\": $PR_NUM }" > head_metadata.json
+echo "{\"title\": \"$PR_DESC\",\"sha\": \"$SHA\", \"date\": \"$DATE\", \"number\": $PR_NUM,  \"native_version\": $NATIVE_VERSION,}" > head_metadata.json
 cat head_metadata.json
 
 # Uploads the metadata so that the app can show some info


### PR DESCRIPTION
Adds a native code versioning system, so that we can know when we've broken native compatibility with the JS. Right now this is passed through both the Podspec and via the [master JSON file](https://s3.amazonaws.com/artsy-emission-js/master-metadata.json) 

Also fixes https://github.com/artsy/emission/issues/869 - given that no-one responded I figured it was time to migrate them to be consistent.