### PR TITLE
Improve network error reporting in Emission

### DIFF
--- a/src/lib/utils/errors.tsx
+++ b/src/lib/utils/errors.tsx
@@ -1,3 +1,6 @@
+/**
+ * An extension of the Error with a Response object
+ */
 export class NetworkError extends Error {
-  response: any
+  response?: Response
 }

--- a/src/lib/utils/renderWithLoadProgress.tsx
+++ b/src/lib/utils/renderWithLoadProgress.tsx
@@ -8,6 +8,12 @@ export default (Component: React.ReactType, initialProps: object = {}): RenderCa
   let retrying = false
   return ({ error, props, retry }) => {
     if (error) {
+      const networkError = error as any
+      if (networkError.response && networkError.response._bodyInit) {
+        const data = networkError.response._bodyInit || {}
+        console.error(`Metaphysics Error: ${error.message}\n`, JSON.parse(data))
+      }
+
       if (retrying) {
         retrying = false
         // TODO: Even though this code path is reached, the retry button keeps spinning. iirc it _should_ disappear when


### PR DESCRIPTION
Adds a `console.error` to a failing Relay query. 

This will show a red screen in dev mode when a Relay query totally fails ( e.g. not status 200 ) which happens when you make a bad request e.g.  `{"errors":[{"message":"Cannot query field \"__id\" on type \"FilterArtworks\"."}]}`

You can't rely on [this code](https://github.com/artsy/emission/blob/master/src/lib/metaphysics.ts#L20-L30) because by this point Relay has caught the error and has asked you to re-render.

#trivial #skip_new_tests