### PR TITLE
[consignments] edition number field is now a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### 1.4.0-beta.11
 
+* Edition number field allows letters too - sarah
 * Makes sure Home view shows Artists tab whenever there's a selected artist - sarah
 * Adds webview support and zero state page for Auction tab - luc
 * Sets the status bar BG color to dark for Consignments - orta

--- a/src/lib/Components/Consignments/Screens/Edition.tsx
+++ b/src/lib/Components/Consignments/Screens/Edition.tsx
@@ -44,8 +44,7 @@ export default class Edition extends React.Component<Props, ConsignmentSetup> {
   updateCert = () => this.setState({ certificateOfAuth: !this.state.certificateOfAuth })
 
   updateEditionSize = text => this.setState({ editionInfo: { ...this.state.editionInfo, size: text } })
-  updateEditionNumber = text =>
-    this.setState({ editionInfo: { ...this.state.editionInfo, number: parseInt(text, 10) } })
+  updateEditionNumber = text => this.setState({ editionInfo: { ...this.state.editionInfo, number: text } })
 
   render() {
     return (
@@ -72,10 +71,7 @@ export default class Edition extends React.Component<Props, ConsignmentSetup> {
                   text={{
                     placeholder: "Edition Number",
                     onChangeText: this.updateEditionNumber,
-                    value:
-                      this.state.editionInfo &&
-                      this.state.editionInfo.number &&
-                      this.state.editionInfo.number.toString(),
+                    value: this.state.editionInfo && this.state.editionInfo.number,
                   }}
                   style={{ margin: 10 }}
                 />

--- a/src/lib/Components/Consignments/index.tsx
+++ b/src/lib/Components/Consignments/index.tsx
@@ -39,7 +39,7 @@ export interface ConsignmentSetup {
   provenance?: string
   editionInfo?: {
     size?: string
-    number?: number
+    number?: string
   }
   signed?: boolean
   certificateOfAuth?: boolean


### PR DESCRIPTION
Fixes #https://github.com/artsy/collector-experience/issues/785

![consignments](https://user-images.githubusercontent.com/2712962/34220487-d3ebaf1c-e582-11e7-83cc-3198e42105a6.gif)



Skip New Tests

