### PR TITLE
[Home/Auctions] Show the ZeroState component when there are no sales.

### DIFF
--- a/src/lib/Scenes/Home/Components/Sales/__tests__/index-tests.tsx
+++ b/src/lib/Scenes/Home/Components/Sales/__tests__/index-tests.tsx
@@ -1,3 +1,4 @@
+import { shallow } from "enzyme"
 import React from "react"
 import "react-native"
 import * as renderer from "react-test-renderer"
@@ -5,6 +6,11 @@ import Sales from "../index"
 
 jest.mock("WebView", () => "WebView")
 jest.mock("../Components/ZeroState/index.html", () => "")
+
+it("renders the ZeroState when there are no sales", () => {
+  const auctions = shallow(<Sales {...Object.assign({}, props, { viewer: { sales: [] } })} />)
+  expect(auctions.find("ZeroState").length).toEqual(1)
+})
 
 it("looks correct when rendered", () => {
   const auctions = renderer.create(<Sales {...props} />)

--- a/src/lib/Scenes/Home/Components/Sales/index.tsx
+++ b/src/lib/Scenes/Home/Components/Sales/index.tsx
@@ -3,6 +3,7 @@ import { SectionList, StyleSheet } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 import LotsByFollowedArtists from "./Components/LotsByFollowedArtists"
 import { SaleList } from "./Components/SaleList"
+import { ZeroState } from "./Components/ZeroState"
 
 class Sales extends React.Component<Props> {
   get data() {
@@ -18,6 +19,10 @@ class Sales extends React.Component<Props> {
   }
 
   render() {
+    if (this.props.viewer.sales.length === 0) {
+      return <ZeroState />
+    }
+
     const sections = [
       {
         data: [{ data: this.data.liveAuctions }],


### PR DESCRIPTION
This concludes https://github.com/artsy/collector-experience/issues/703. While the ZeroState component existed, it wasn’t actually being shown yet.

#trivial