### PR TITLE
@l2succes => Switch to use new unread methodology for the indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### Master
 
+* New methodology for unread indicator and marking conversation as read - matt
 * Fixes Inbox loading indicator stuck and conversation row collapsing - luc
 * Optimize the Home/ForYou view by re-enabling removal of clipped subviews - alloy
 * Brings back artist rails on the Home/ForYou view - alloy

--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -1130,6 +1130,7 @@ type ArtworkFilterTag implements Node {
   ): FilterArtworks
 }
 
+# An inquiry on an Artwork
 type ArtworkInquiry {
   artwork: Artwork!
   id: ID
@@ -2411,6 +2412,15 @@ input FollowArtistInput {
 
 type FollowArtistPayload {
   artist: Artist
+
+  # Popular artists
+  popular_artists(
+    # If true, will exclude followed artists for the user
+    exclude_followed_artists: Boolean
+
+    # Number of results to return
+    size: Int
+  ): PopularArtists
   clientMutationId: String
 }
 
@@ -3669,6 +3679,8 @@ type Mutation {
 
   # Appending a message to a conversation thread
   sendConversationMessage(input: SendConversationMessageMutationInput!): SendConversationMessageMutationPayload
+
+  # Save (or remove) an artwork to (from) a users default collection.
   saveArtwork(input: SaveArtworkInput!): SaveArtworkPayload
 
   # Attach an gemini asset to a consignment submission

--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -1056,6 +1056,7 @@ type ArtworkFilterGene implements Node {
     dimension_range: String
     extra_aggregation_gene_ids: [String]
     include_artworks_by_followed_artists: Boolean
+    include_medium_filter_in_aggregation: Boolean
     for_sale: Boolean
     gene_id: String
     gene_ids: [String]
@@ -1105,6 +1106,7 @@ type ArtworkFilterTag implements Node {
     dimension_range: String
     extra_aggregation_gene_ids: [String]
     include_artworks_by_followed_artists: Boolean
+    include_medium_filter_in_aggregation: Boolean
     for_sale: Boolean
     gene_id: String
     gene_ids: [String]
@@ -1678,16 +1680,6 @@ type BidIncrement {
   to: Int
 }
 
-enum BuyerOutcomeTypes {
-  PURCHASED
-  STILL_CONSIDERING
-  HIGH_PRICE
-  LOST_INTEREST
-  WORK_UNAVAILABLE
-  OTHER
-  BLANK
-}
-
 type BuyersPremium {
   # A globally unique ID.
   __id: ID!
@@ -1913,6 +1905,7 @@ type Conversation implements Node {
     timezone: String
   ): String
   purchase_request: Boolean
+  from_last_viewed_message_id: String
   initial_message: String!
 
   # This is a snippet of text from the last message.
@@ -1932,7 +1925,7 @@ type Conversation implements Node {
   is_last_message_to_user: Boolean
 
   # Timestamp if the user opened the last message, null in all other cases
-  last_message_open: String
+  last_message_open: String @deprecated(reason: "Prefer to use `unread`")
 
   # Delivery id if the user is a recipient of the last message, null otherwise.
   last_message_delivery_id: String
@@ -1945,6 +1938,9 @@ type Conversation implements Node {
 
   # A connection for all messages in a single conversation
   messages(sort: sort, after: String, first: Int, before: String, last: Int): MessageConnection
+
+  # True if there is an unread message by the user.
+  unread: Boolean
 }
 
 # A connection to a list of items.
@@ -1954,6 +1950,7 @@ type ConversationConnection {
 
   # A list of edges.
   edges: [ConversationEdge]
+  totalUnreadCount: Int
 }
 
 # An edge in a connection.
@@ -2531,6 +2528,7 @@ type Gene implements Node {
     dimension_range: String
     extra_aggregation_gene_ids: [String]
     include_artworks_by_followed_artists: Boolean
+    include_medium_filter_in_aggregation: Boolean
     for_sale: Boolean
     gene_id: String
     gene_ids: [String]
@@ -2569,6 +2567,7 @@ type Gene implements Node {
     dimension_range: String
     extra_aggregation_gene_ids: [String]
     include_artworks_by_followed_artists: Boolean
+    include_medium_filter_in_aggregation: Boolean
     for_sale: Boolean
     gene_id: String
     gene_ids: [String]
@@ -2693,6 +2692,7 @@ type GeneItem implements Node {
     dimension_range: String
     extra_aggregation_gene_ids: [String]
     include_artworks_by_followed_artists: Boolean
+    include_medium_filter_in_aggregation: Boolean
     for_sale: Boolean
     gene_id: String
     gene_ids: [String]
@@ -2731,6 +2731,7 @@ type GeneItem implements Node {
     dimension_range: String
     extra_aggregation_gene_ids: [String]
     include_artworks_by_followed_artists: Boolean
+    include_medium_filter_in_aggregation: Boolean
     for_sale: Boolean
     gene_id: String
     gene_ids: [String]
@@ -3150,6 +3151,7 @@ type HomePageModuleContextGene implements Node {
     dimension_range: String
     extra_aggregation_gene_ids: [String]
     include_artworks_by_followed_artists: Boolean
+    include_medium_filter_in_aggregation: Boolean
     for_sale: Boolean
     gene_id: String
     gene_ids: [String]
@@ -3188,6 +3190,7 @@ type HomePageModuleContextGene implements Node {
     dimension_range: String
     extra_aggregation_gene_ids: [String]
     include_artworks_by_followed_artists: Boolean
+    include_medium_filter_in_aggregation: Boolean
     for_sale: Boolean
     gene_id: String
     gene_ids: [String]
@@ -3459,20 +3462,6 @@ type LotStanding {
   sale_artwork: SaleArtwork
 }
 
-input MarkReadMessageMutationInput {
-  # The id of the conversation to be updated
-  conversationId: String!
-
-  # The delivery object that is marked as read
-  deliveryId: String!
-  clientMutationId: String
-}
-
-type MarkReadMessageMutationPayload {
-  delivery: Delivery
-  clientMutationId: String
-}
-
 type Me implements Node {
   # A globally unique ID.
   __id: ID!
@@ -3595,6 +3584,9 @@ type Me implements Node {
     # Exclude artists the user already follows
     exclude_followed_artists: Boolean
 
+    # Exclude these ids from results, may result in all artists being excluded.
+    exclude_artist_ids: [String]
+
     # Pagination, need I say more?
     page: Int
 
@@ -3672,14 +3664,11 @@ type Mutation {
   # Update the current logged in user.
   updateMyUserProfile(input: UpdateMyProfileInput!): UpdateMyProfilePayload
 
-  # Updating buyer outcome of a conversation.
+  # Update a conversation.
   updateConversation(input: UpdateConversationMutationInput!): UpdateConversationMutationPayload
 
   # Appending a message to a conversation thread
   sendConversationMessage(input: SendConversationMessageMutationInput!): SendConversationMessageMutationPayload
-
-  # Marking a message as read
-  markReadMessage(input: MarkReadMessageMutationInput!): MarkReadMessageMutationPayload
   saveArtwork(input: SaveArtworkInput!): SaveArtworkPayload
 
   # Attach an gemini asset to a consignment submission
@@ -4390,6 +4379,7 @@ type Query {
     dimension_range: String
     extra_aggregation_gene_ids: [String]
     include_artworks_by_followed_artists: Boolean
+    include_medium_filter_in_aggregation: Boolean
     for_sale: Boolean
     gene_id: String
     gene_ids: [String]
@@ -4640,6 +4630,9 @@ type RelatedArtists {
 
     # Exclude artists the user already follows
     exclude_followed_artists: Boolean
+
+    # Exclude these ids from results, may result in all artists being excluded.
+    exclude_artist_ids: [String]
 
     # Pagination, need I say more?
     page: Int
@@ -5337,6 +5330,7 @@ type Tag implements Node {
     dimension_range: String
     extra_aggregation_gene_ids: [String]
     include_artworks_by_followed_artists: Boolean
+    include_medium_filter_in_aggregation: Boolean
     for_sale: Boolean
     gene_id: String
     gene_ids: [String]
@@ -5435,13 +5429,16 @@ type UpdateCollectorProfilePayload {
 }
 
 input UpdateConversationMutationInput {
-  buyer_outcome: BuyerOutcomeTypes!
-  ids: [String]
+  # The id of the conversation to be updated.
+  conversationId: String!
+
+  # The message id to mark as read.
+  fromLastViewedMessageId: String!
   clientMutationId: String
 }
 
 type UpdateConversationMutationPayload {
-  conversations: [Conversation]
+  conversation: Conversation
   clientMutationId: String
 }
 
@@ -5662,6 +5659,7 @@ type Viewer {
     dimension_range: String
     extra_aggregation_gene_ids: [String]
     include_artworks_by_followed_artists: Boolean
+    include_medium_filter_in_aggregation: Boolean
     for_sale: Boolean
     gene_id: String
     gene_ids: [String]

--- a/data/schema.json
+++ b/data/schema.json
@@ -27273,7 +27273,7 @@
         {
           "kind": "OBJECT",
           "name": "ArtworkInquiry",
-          "description": null,
+          "description": "An inquiry on an Artwork",
           "fields": [
             {
               "name": "artwork",
@@ -41874,7 +41874,7 @@
             },
             {
               "name": "saveArtwork",
-              "description": null,
+              "description": "Save (or remove) an artwork to (from) a users default collection.",
               "args": [
                 {
                   "name": "input",
@@ -42093,6 +42093,39 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Artist",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "popular_artists",
+              "description": "Popular artists",
+              "args": [
+                {
+                  "name": "exclude_followed_artists",
+                  "description": "If true, will exclude followed artists for the user",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "size",
+                  "description": "Number of results to return",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PopularArtists",
                 "ofType": null
               },
               "isDeprecated": false,

--- a/data/schema.json
+++ b/data/schema.json
@@ -541,8 +541,7 @@
                 },
                 {
                   "name": "partner_categories",
-                  "description":
-                    "\n        Only return partners of the specified partner categories.\n        Accepts list of slugs.\n      ",
+                  "description": "\n        Only return partners of the specified partner categories.\n        Accepts list of slugs.\n      ",
                   "type": {
                     "kind": "LIST",
                     "name": null,
@@ -717,6 +716,16 @@
                 },
                 {
                   "name": "include_artworks_by_followed_artists",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "include_medium_filter_in_aggregation",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
@@ -1743,8 +1752,7 @@
                 },
                 {
                   "name": "partner_categories",
-                  "description":
-                    "\n        Only return partners of the specified partner categories.\n        Accepts list of slugs.\n      ",
+                  "description": "\n        Only return partners of the specified partner categories.\n        Accepts list of slugs.\n      ",
                   "type": {
                     "kind": "LIST",
                     "name": null,
@@ -2332,8 +2340,7 @@
         {
           "kind": "SCALAR",
           "name": "String",
-          "description":
-            "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
+          "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -2822,8 +2829,7 @@
         {
           "kind": "SCALAR",
           "name": "ID",
-          "description":
-            "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID.",
+          "description": "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -2833,8 +2839,7 @@
         {
           "kind": "SCALAR",
           "name": "Int",
-          "description":
-            "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1. ",
+          "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1. ",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -3357,8 +3362,7 @@
         {
           "kind": "SCALAR",
           "name": "Float",
-          "description":
-            "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point). ",
+          "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point). ",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -7488,8 +7492,7 @@
         {
           "kind": "SCALAR",
           "name": "FormattedNumber",
-          "description":
-            "The `FormattedNumber` type represents a number that can optionally be returnedas a formatted String. It does not try to coerce the type.",
+          "description": "The `FormattedNumber` type represents a number that can optionally be returnedas a formatted String. It does not try to coerce the type.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -11954,6 +11957,20 @@
                     "kind": "SCALAR",
                     "name": "Boolean",
                     "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "exclude_artist_ids",
+                  "description": "Exclude these ids from results, may result in all artists being excluded.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
                   },
                   "defaultValue": null
                 },
@@ -20036,6 +20053,16 @@
                   "defaultValue": null
                 },
                 {
+                  "name": "include_medium_filter_in_aggregation",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "for_sale",
                   "description": null,
                   "type": {
@@ -20469,6 +20496,16 @@
                 },
                 {
                   "name": "include_artworks_by_followed_artists",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "include_medium_filter_in_aggregation",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
@@ -21135,6 +21172,16 @@
                   "defaultValue": null
                 },
                 {
+                  "name": "include_medium_filter_in_aggregation",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "for_sale",
                   "description": null,
                   "type": {
@@ -21495,6 +21542,16 @@
                 },
                 {
                   "name": "include_artworks_by_followed_artists",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "include_medium_filter_in_aggregation",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
@@ -23427,6 +23484,16 @@
                   "defaultValue": null
                 },
                 {
+                  "name": "include_medium_filter_in_aggregation",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "for_sale",
                   "description": null,
                   "type": {
@@ -23787,6 +23854,16 @@
                 },
                 {
                   "name": "include_artworks_by_followed_artists",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "include_medium_filter_in_aggregation",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
@@ -26479,6 +26556,20 @@
                   "defaultValue": null
                 },
                 {
+                  "name": "exclude_artist_ids",
+                  "description": "Exclude these ids from results, may result in all artists being excluded.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "page",
                   "description": "Pagination, need I say more?",
                   "type": {
@@ -28647,6 +28738,18 @@
               "deprecationReason": null
             },
             {
+              "name": "from_last_viewed_message_id",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "initial_message",
               "description": null,
               "args": [],
@@ -28754,8 +28857,8 @@
                 "name": "String",
                 "ofType": null
               },
-              "isDeprecated": false,
-              "deprecationReason": null
+              "isDeprecated": true,
+              "deprecationReason": "Prefer to use `unread`"
             },
             {
               "name": "last_message_delivery_id",
@@ -28859,6 +28962,18 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "MessageConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "unread",
+              "description": "True if there is an unread message by the user.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -29029,8 +29144,7 @@
             },
             {
               "name": "reply_to_impulse_ids",
-              "description":
-                "An array of Impulse IDs that correspond to all email addresses that messages should be sent to",
+              "description": "An array of Impulse IDs that correspond to all email addresses that messages should be sent to",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -30023,6 +30137,18 @@
                   "name": "ConversationEdge",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalUnreadCount",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -33943,6 +34069,16 @@
                   "defaultValue": null
                 },
                 {
+                  "name": "include_medium_filter_in_aggregation",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "for_sale",
                   "description": null,
                   "type": {
@@ -34303,6 +34439,16 @@
                 },
                 {
                   "name": "include_artworks_by_followed_artists",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "include_medium_filter_in_aggregation",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
@@ -34864,8 +35010,7 @@
                 },
                 {
                   "name": "partner_categories",
-                  "description":
-                    "\n        Only return partners of the specified partner categories.\n        Accepts list of slugs.\n      ",
+                  "description": "\n        Only return partners of the specified partner categories.\n        Accepts list of slugs.\n      ",
                   "type": {
                     "kind": "LIST",
                     "name": null,
@@ -38917,6 +39062,16 @@
                   "defaultValue": null
                 },
                 {
+                  "name": "include_medium_filter_in_aggregation",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "for_sale",
                   "description": null,
                   "type": {
@@ -39766,8 +39921,7 @@
                 },
                 {
                   "name": "partner_categories",
-                  "description":
-                    "\n        Only return partners of the specified partner categories.\n        Accepts list of slugs.\n      ",
+                  "description": "\n        Only return partners of the specified partner categories.\n        Accepts list of slugs.\n      ",
                   "type": {
                     "kind": "LIST",
                     "name": null,
@@ -39942,6 +40096,16 @@
                 },
                 {
                   "name": "include_artworks_by_followed_artists",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "include_medium_filter_in_aggregation",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
@@ -40968,8 +41132,7 @@
                 },
                 {
                   "name": "partner_categories",
-                  "description":
-                    "\n        Only return partners of the specified partner categories.\n        Accepts list of slugs.\n      ",
+                  "description": "\n        Only return partners of the specified partner categories.\n        Accepts list of slugs.\n      ",
                   "type": {
                     "kind": "LIST",
                     "name": null,
@@ -41657,7 +41820,7 @@
             },
             {
               "name": "updateConversation",
-              "description": "Updating buyer outcome of a conversation.",
+              "description": "Update a conversation.",
               "args": [
                 {
                   "name": "input",
@@ -41704,33 +41867,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "SendConversationMessageMutationPayload",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "markReadMessage",
-              "description": "Marking a message as read",
-              "args": [
-                {
-                  "name": "input",
-                  "description": null,
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "MarkReadMessageMutationInput",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "MarkReadMessageMutationPayload",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -42768,24 +42904,24 @@
           "fields": null,
           "inputFields": [
             {
-              "name": "buyer_outcome",
-              "description": null,
+              "name": "conversationId",
+              "description": "The id of the conversation to be updated.",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "ENUM",
-                  "name": "BuyerOutcomeTypes",
+                  "kind": "SCALAR",
+                  "name": "String",
                   "ofType": null
                 }
               },
               "defaultValue": null
             },
             {
-              "name": "ids",
-              "description": null,
+              "name": "fromLastViewedMessageId",
+              "description": "The message id to mark as read.",
               "type": {
-                "kind": "LIST",
+                "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
@@ -42811,75 +42947,18 @@
           "possibleTypes": null
         },
         {
-          "kind": "ENUM",
-          "name": "BuyerOutcomeTypes",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "PURCHASED",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "STILL_CONSIDERING",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "HIGH_PRICE",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "LOST_INTEREST",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "WORK_UNAVAILABLE",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "OTHER",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "BLANK",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
-        },
-        {
           "kind": "OBJECT",
           "name": "UpdateConversationMutationPayload",
           "description": null,
           "fields": [
             {
-              "name": "conversations",
+              "name": "conversation",
               "description": null,
               "args": [],
               "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Conversation",
-                  "ofType": null
-                }
+                "kind": "OBJECT",
+                "name": "Conversation",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -43003,90 +43082,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "MessageEdge",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "clientMutationId",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "INPUT_OBJECT",
-          "name": "MarkReadMessageMutationInput",
-          "description": null,
-          "fields": null,
-          "inputFields": [
-            {
-              "name": "conversationId",
-              "description": "The id of the conversation to be updated",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "deliveryId",
-              "description": "The delivery object that is marked as read",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "clientMutationId",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            }
-          ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "MarkReadMessageMutationPayload",
-          "description": null,
-          "fields": [
-            {
-              "name": "delivery",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "Delivery",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -43513,8 +43508,7 @@
             },
             {
               "name": "metadata",
-              "description":
-                "Additional JSON data to pass through gemini, should deiinitely contain an `id` and a `_type`",
+              "description": "Additional JSON data to pass through gemini, should deiinitely contain an `id` and a `_type`",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -43544,8 +43538,7 @@
         {
           "kind": "SCALAR",
           "name": "JSON",
-          "description":
-            "The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).",
+          "description": "The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -44312,8 +44305,7 @@
         {
           "kind": "OBJECT",
           "name": "__Schema",
-          "description":
-            "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
+          "description": "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
           "fields": [
             {
               "name": "types",
@@ -44369,8 +44361,7 @@
             },
             {
               "name": "subscriptionType",
-              "description":
-                "If this server support subscription, the type that subscription operations will be rooted at.",
+              "description": "If this server support subscription, the type that subscription operations will be rooted at.",
               "args": [],
               "type": {
                 "kind": "OBJECT",
@@ -44413,8 +44404,7 @@
         {
           "kind": "OBJECT",
           "name": "__Type",
-          "description":
-            "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
+          "description": "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
           "fields": [
             {
               "name": "kind",
@@ -44658,8 +44648,7 @@
         {
           "kind": "OBJECT",
           "name": "__Field",
-          "description":
-            "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
+          "description": "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
           "fields": [
             {
               "name": "name",
@@ -44766,8 +44755,7 @@
         {
           "kind": "OBJECT",
           "name": "__InputValue",
-          "description":
-            "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
+          "description": "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
           "fields": [
             {
               "name": "name",
@@ -44834,8 +44822,7 @@
         {
           "kind": "OBJECT",
           "name": "__EnumValue",
-          "description":
-            "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
+          "description": "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
           "fields": [
             {
               "name": "name",
@@ -44902,8 +44889,7 @@
         {
           "kind": "OBJECT",
           "name": "__Directive",
-          "description":
-            "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
+          "description": "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
           "fields": [
             {
               "name": "name",
@@ -45038,8 +45024,7 @@
         {
           "kind": "ENUM",
           "name": "__DirectiveLocation",
-          "description":
-            "A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.",
+          "description": "A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -45160,7 +45145,11 @@
         {
           "name": "include",
           "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
-          "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
+          "locations": [
+            "FIELD",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
           "args": [
             {
               "name": "if",
@@ -45181,7 +45170,11 @@
         {
           "name": "skip",
           "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
-          "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
+          "locations": [
+            "FIELD",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
           "args": [
             {
               "name": "if",
@@ -45202,12 +45195,14 @@
         {
           "name": "deprecated",
           "description": "Marks an element of a GraphQL schema as no longer supported.",
-          "locations": ["FIELD_DEFINITION", "ENUM_VALUE"],
+          "locations": [
+            "FIELD_DEFINITION",
+            "ENUM_VALUE"
+          ],
           "args": [
             {
               "name": "reason",
-              "description":
-                "Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted in [Markdown](https://daringfireball.net/projects/markdown/).",
+              "description": "Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted in [Markdown](https://daringfireball.net/projects/markdown/).",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
       "cd externals/elan && git fetch && git checkout origin/master && cp components/lib/variables/colors.json ../../data",
     "sync-externals": "npm run-script sync-schema && npm run-script sync-colors",
     "sync-schema":
-      "cd externals/metaphysics && git fetch && git checkout origin/master && yarn install && yarn dump-schema -- ../../data && rm -rf node_modules",
+      "cd externals/metaphysics && git fetch && git checkout origin/new_unread_stuff && yarn install && yarn dump-schema -- ../../data && rm -rf node_modules",
     "sync-schema:localhost": "cd ../metaphysics && yarn dump-schema -- ../emission/data",
     "version":
       "yarn install && yarn bundle && pushd Example && bundle install && bundle exec pod install && popd && git add Pod/Assets Example/Podfile.lock",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
       "cd externals/elan && git fetch && git checkout origin/master && cp components/lib/variables/colors.json ../../data",
     "sync-externals": "npm run-script sync-schema && npm run-script sync-colors",
     "sync-schema":
-      "cd externals/metaphysics && git fetch && git checkout origin/new_unread_stuff && yarn install && yarn dump-schema -- ../../data && rm -rf node_modules",
+      "cd externals/metaphysics && git fetch && git checkout origin/master && yarn install && yarn dump-schema -- ../../data && rm -rf node_modules",
     "sync-schema:localhost": "cd ../metaphysics && yarn dump-schema -- ../emission/data",
     "version":
       "yarn install && yarn bundle && pushd Example && bundle install && bundle exec pod install && popd && git add Pod/Assets Example/Podfile.lock",

--- a/src/lib/Components/Inbox/Conversations/ConversationSnippet.tsx
+++ b/src/lib/Components/Inbox/Conversations/ConversationSnippet.tsx
@@ -158,9 +158,7 @@ export class ConversationSnippet extends React.Component<Props, any> {
             <TextPreview>
               <HorizontalLayout>
                 <SmallHeadline>{partnerName}</SmallHeadline>
-                <DateHeading>
-                  {conversation.is_last_message_to_user && !conversation.last_message_open && <UnreadIndicator />}
-                </DateHeading>
+                <DateHeading>{conversation.unread && <UnreadIndicator />}</DateHeading>
               </HorizontalLayout>
               {this.renderTitleForItem(item)}
               <P>{conversationText}</P>
@@ -184,8 +182,7 @@ export default createFragmentContainer(
       }
       last_message
       last_message_at
-      last_message_open
-      is_last_message_to_user
+      unread
       items {
         item {
           __typename
@@ -220,8 +217,7 @@ interface RelayProps {
     }
     last_message: string
     last_message_at: string | null
-    is_last_message_to_user: boolean
-    last_message_open: string | null
+    unread: boolean
     items: Array<{
       item: any
     } | null> | null

--- a/src/lib/Components/Inbox/Conversations/UpdateConversation.ts
+++ b/src/lib/Components/Inbox/Conversations/UpdateConversation.ts
@@ -6,26 +6,25 @@ interface Conversation {
   id: string
 }
 
-export function markLastMessageRead(
+export function updateConversation(
   environment: Environment,
   conversation: Conversation,
-  deliveryId: string,
+  fromLastViewedMessageId: string,
   onCompleted: MutationConfig<any>["onCompleted"],
   onError: MutationConfig<any>["onError"]
 ) {
   return commitMutation(environment, {
     updater: store => {
-      const currentTime = new Date().toISOString()
-      store.get(conversation.__id).setValue(currentTime, "last_message_open")
+      store.get(conversation.__id).setValue(false, "unread")
     },
     onCompleted,
     onError,
     mutation: graphql`
-      mutation MarkReadMessageMutation($input: MarkReadMessageMutationInput!) {
-        markReadMessage(input: $input) {
-          delivery {
+      mutation UpdateConversationMutation($input: UpdateConversationMutationInput!) {
+        updateConversation(input: $input) {
+          conversation {
             id
-            opened_at
+            from_last_viewed_message_id
           }
         }
       }
@@ -33,7 +32,7 @@ export function markLastMessageRead(
     variables: {
       input: {
         conversationId: conversation.id,
-        deliveryId,
+        fromLastViewedMessageId,
       },
     },
   })

--- a/src/lib/Components/Inbox/Conversations/__stories__/ConversationSnippet.story.tsx
+++ b/src/lib/Components/Inbox/Conversations/__stories__/ConversationSnippet.story.tsx
@@ -10,8 +10,7 @@ const conversation = {
   to: { name: "ACA Galleries" },
   last_message: "Karl and Anna... Fab!",
   last_message_at: null, // moment().subtract(1, "year").toISOString(),
-  is_last_message_to_user: true,
-  last_message_open: null,
+  unread: true,
   items: [
     {
       item: {

--- a/src/lib/Components/Inbox/Conversations/__tests__/ConversationSnippet-tests.tsx
+++ b/src/lib/Components/Inbox/Conversations/__tests__/ConversationSnippet-tests.tsx
@@ -49,8 +49,7 @@ const artworkConversation = {
   last_message_at: moment()
     .subtract(1, "year")
     .toISOString(),
-  is_last_message_to_user: true,
-  last_message_open: null,
+  unread: true,
   created_at: "2017-06-01T14:14:35.538Z",
   items: [
     {
@@ -69,8 +68,7 @@ const showConversation = {
   last_message_at: moment()
     .subtract(1, "year")
     .toISOString(),
-  is_last_message_to_user: true,
-  last_message_open: null,
+  unread: true,
   created_at: "2017-06-01T14:14:35.538Z",
   items: [
     {

--- a/src/lib/Containers/Conversation.tsx
+++ b/src/lib/Containers/Conversation.tsx
@@ -17,7 +17,7 @@ import Messages from "../Components/Inbox/Conversations/Messages"
 import { sendConversationMessage } from "../Components/Inbox/Conversations/SendConversationMessage"
 import Separator from "../Components/Separator"
 
-import { markLastMessageRead } from "../Components/Inbox/Conversations/MarkReadMessage"
+import { updateConversation } from "../Components/Inbox/Conversations/UpdateConversation"
 
 const Container = styled.View`
   flex: 1;
@@ -87,11 +87,11 @@ export class Conversation extends React.Component<Props, State> {
 
   maybeMarkLastMessageAsRead() {
     const conversation = this.props.me.conversation
-    if (conversation.is_last_message_to_user && !conversation.last_message_open && !this.state.markedMessageAsRead) {
-      markLastMessageRead(
+    if (conversation.unread && !this.state.markedMessageAsRead) {
+      updateConversation(
         this.props.relay.environment,
         conversation,
-        conversation.last_message_delivery_id,
+        conversation.last_message_id,
         _response => {
           this.setState({ markedMessageAsRead: true })
         },
@@ -192,9 +192,7 @@ export default createFragmentContainer(Conversation, {
         last_message_id
         ...Messages_conversation
         initial_message
-        is_last_message_to_user
-        last_message_open
-        last_message_delivery_id
+        unread
       }
     }
   `,
@@ -214,9 +212,7 @@ interface RelayProps {
       }
       last_message_id: string
       initial_message: string
-      is_last_message_to_user: boolean
-      last_message_open: string | null
-      last_message_delivery_id: string | null
+      unread: boolean
     }
   }
 }

--- a/src/lib/relay/config.tsx
+++ b/src/lib/relay/config.tsx
@@ -12,8 +12,6 @@ if (Emission && Emission.gravityAPIHost && Emission.metaphysicsAPIHost) {
   gravityURL = "https://api.artsy.net"
 }
 
-metaphysicsURL = "http://localhost:5001"
-
 export { metaphysicsURL, gravityURL }
 
 // Disable the native polyfill during development, which will make network requests show-up in the Chrome dev-tools.

--- a/src/lib/relay/config.tsx
+++ b/src/lib/relay/config.tsx
@@ -12,6 +12,8 @@ if (Emission && Emission.gravityAPIHost && Emission.metaphysicsAPIHost) {
   gravityURL = "https://api.artsy.net"
 }
 
+metaphysicsURL = "http://localhost:5001"
+
 export { metaphysicsURL, gravityURL }
 
 // Disable the native polyfill during development, which will make network requests show-up in the Chrome dev-tools.


### PR DESCRIPTION
And also to mark a message as being viewed.

This uses the branch in https://github.com/artsy/metaphysics/pull/873 , all the Impulse stuff is already on staging.

Tangentially, that Metaphysics PR also offers the `total_unread_count`, which precipitated this refactor.

#skip_new_tests