### PR TITLE
[WIP] Update to relay 1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
       "git push --follow-tags && env EMISSION_ROOT=\"$(pwd)\" pod repo push artsy --allow-warnings --use-json --skip-import-validation",
     "postinstall":
       "sed -i '' 's/#import <RCTAnimation\\/RCTValueAnimatedNode.h>/#import \"RCTValueAnimatedNode.h\"/' ./node_modules/react-native/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.h && ./scripts/post_installs.sh || true",
-    "prestorybook": "rnstl"
+    "prestorybook": "rnstl",
+    "prepare": "patch-package"
   },
   "repository": {
     "type": "git",
@@ -62,6 +63,10 @@
   },
   "homepage": "https://github.com/artsy/emission#readme",
   "files": ["index.js", "data", "lib"],
+  "resolutions": {
+    "graphql": "^0.12.3",
+    "relay-runtime": "https://github.com/alloy/relay/releases/download/v1.5.0-alpha.4/relay-runtime-1.5.0-alpha.4.tgz"
+  },
   "dependencies": {
     "lodash": "^4.17.4",
     "moment": "^2.19.4",
@@ -73,9 +78,9 @@
     "react-native-parallax-scroll-view": "https://github.com/orta/react-native-parallax-scroll-view",
     "react-native-scrollable-tab-view": "^0.8.0",
     "react-native-sentry": "^0.30.2",
-    "react-relay": "https://github.com/alloy/relay/releases/download/v1.3.0-artsy/react-relay-1.3.0-artsy.1.tgz",
+    "react-relay": "https://github.com/alloy/relay/releases/download/v1.5.0-alpha.4/react-relay-1.5.0-alpha.4.tgz",
     "react-tracking": "^5.0.0",
-    "relay-runtime": "https://github.com/alloy/relay/releases/download/v1.3.0-artsy/relay-runtime-artsy.1.tgz",
+    "relay-runtime": "https://github.com/alloy/relay/releases/download/v1.5.0-alpha.4/relay-runtime-1.5.0-alpha.4.tgz",
     "remove-markdown": "0.1.0",
     "styled-components": "^2.0.0"
   },
@@ -93,7 +98,7 @@
     "awesome-typescript-loader": "^3.2.3",
     "babel-jest": "^18.0.0",
     "babel-plugin-relay":
-      "https://github.com/alloy/relay/releases/download/v1.3.0-artsy/babel-plugin-relay-1.3.0-artsy.1.tgz",
+      "https://github.com/alloy/relay/releases/download/v1.5.0-alpha.4/babel-plugin-relay-1.5.0-alpha.4.tgz",
     "babel-polyfill": "^6.13.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
@@ -108,13 +113,16 @@
     "jest-react-native": "18.0.0",
     "jest-styled-components": "^4.9.0",
     "lint-staged": "^6.0.0",
+    "patch-package": "^5.0.0",
+    "postinstall-prepare": "^1.0.1",
     "prettier": "1.9.2",
     "react-dom": "16.0.0-alpha.12",
     "react-native-storybook-loader": "^1.6.0",
     "react-storybooks-relay-container": "^1.0.0",
     "react-test-renderer": "16.0.0-alpha.12",
     "recursive-readdir-sync": "^1.0.6",
-    "relay-compiler": "https://github.com/alloy/relay/releases/download/v1.3.0-artsy/relay-compiler-1.3.0-artsy.1.tgz",
+    "relay-compiler":
+      "https://github.com/alloy/relay/releases/download/v1.5.0-alpha.4/relay-compiler-1.5.0-alpha.4.tgz",
     "relay2ts": "^0.2.0",
     "snapshot-diff": "^0.2.1",
     "stylelint": "^7.13.0",

--- a/patches/graphql+0.12.3.patch
+++ b/patches/graphql+0.12.3.patch
@@ -1,0 +1,24 @@
+patch-package
+--- a/node_modules/graphql/utilities/assertValidName.js
++++ b/node_modules/graphql/utilities/assertValidName.js
+@@ -41,13 +41,13 @@ function assertValidName(name) {
+  */
+ function isValidNameError(name, node) {
+   !(typeof name === 'string') ? (0, _invariant2.default)(0, 'Expected string') : void 0;
+-  if (name.length > 1 && name[0] === '_' && name[1] === '_' &&
+-  // Note: this special case is not part of the spec and exists only to
+-  // support legacy server configurations. Do not rely on this special case
+-  // as it may be removed at any time.
+-  name !== '__configs__') {
+-    return new _GraphQLError.GraphQLError('Name "' + name + '" must not begin with "__", which is reserved by ' + 'GraphQL introspection.', node);
+-  }
++  // if (name.length > 1 && name[0] === '_' && name[1] === '_' &&
++  // // Note: this special case is not part of the spec and exists only to
++  // // support legacy server configurations. Do not rely on this special case
++  // // as it may be removed at any time.
++  // name !== '__configs__') {
++  //   return new _GraphQLError.GraphQLError('Name "' + name + '" must not begin with "__", which is reserved by ' + 'GraphQL introspection.', node);
++  // }
+   if (!NAME_RX.test(name)) {
+     return new _GraphQLError.GraphQLError('Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "' + name + '" does not.', node);
+   }

--- a/src/lib/Components/Artist/Artworks/index.tsx
+++ b/src/lib/Components/Artist/Artworks/index.tsx
@@ -115,7 +115,7 @@ const styles = StyleSheet.create({
 
 export default createFragmentContainer(
   Artworks,
-  graphql.experimental`
+  graphql`
     fragment Artworks_artist on Artist {
       counts {
         artworks

--- a/src/lib/Components/ArtworkGrids/RelayConnections/ArtistForSaleArtworksGrid.tsx
+++ b/src/lib/Components/ArtworkGrids/RelayConnections/ArtistForSaleArtworksGrid.tsx
@@ -9,7 +9,7 @@ Artwork
 const ArtistForSaleArtworksGrid = createPaginationContainer(
   InfiniteScrollArtworksGrid,
   {
-    artist: graphql.experimental`
+    artist: graphql`
       fragment ArtistForSaleArtworksGrid_artist on Artist
         @argumentDefinitions(
           count: { type: "Int", defaultValue: 10 }
@@ -61,7 +61,7 @@ const ArtistForSaleArtworksGrid = createPaginationContainer(
         filter,
       }
     },
-    query: graphql.experimental`
+    query: graphql`
       query ArtistForSaleArtworksGridQuery(
         $__id: ID!
         $count: Int!

--- a/src/lib/Components/ArtworkGrids/RelayConnections/ArtistNotForSaleArtworksGrid.tsx
+++ b/src/lib/Components/ArtworkGrids/RelayConnections/ArtistNotForSaleArtworksGrid.tsx
@@ -9,7 +9,7 @@ Artwork
 const ArtistNotForSaleArtworksGrid = createPaginationContainer(
   InfiniteScrollArtworksGrid,
   {
-    artist: graphql.experimental`
+    artist: graphql`
       fragment ArtistNotForSaleArtworksGrid_artist on Artist
         @argumentDefinitions(
           count: { type: "Int", defaultValue: 10 }
@@ -61,7 +61,7 @@ const ArtistNotForSaleArtworksGrid = createPaginationContainer(
         filter,
       }
     },
-    query: graphql.experimental`
+    query: graphql`
       query ArtistNotForSaleArtworksGridQuery(
         $__id: ID!
         $count: Int!

--- a/src/lib/Components/ArtworkGrids/RelayConnections/GeneArtworksGrid.tsx
+++ b/src/lib/Components/ArtworkGrids/RelayConnections/GeneArtworksGrid.tsx
@@ -9,7 +9,7 @@ Artwork
 const GeneArtworksGrid = createPaginationContainer(
   InfiniteScrollArtworksGrid,
   {
-    gene: graphql.experimental`
+    gene: graphql`
       fragment GeneArtworksGrid_gene on Gene
         @argumentDefinitions(
           count: { type: "Int", defaultValue: 10 }
@@ -65,7 +65,7 @@ const GeneArtworksGrid = createPaginationContainer(
         cursor,
       }
     },
-    query: graphql.experimental`
+    query: graphql`
       query GeneArtworksGridQuery(
         $__id: ID!
         $count: Int!

--- a/src/lib/Components/ArtworkGrids/RelayConnections/SaleArtworksGrid.tsx
+++ b/src/lib/Components/ArtworkGrids/RelayConnections/SaleArtworksGrid.tsx
@@ -17,7 +17,7 @@ interface Props extends GridProps {
 const SaleArtworksGrid = createPaginationContainer<Props>(
   InfiniteScrollArtworksGrid as any,
   {
-    sale: graphql.experimental`
+    sale: graphql`
       fragment SaleArtworksGrid_sale on Sale
         @argumentDefinitions(count: { type: "Int", defaultValue: 10 }, cursor: { type: "String" }) {
         __id
@@ -63,7 +63,7 @@ const SaleArtworksGrid = createPaginationContainer<Props>(
         cursor,
       }
     },
-    query: graphql.experimental`
+    query: graphql`
       query SaleArtworksGridQuery($__id: ID!, $count: Int!, $cursor: String) {
         node(__id: $__id) {
           ... on Sale {

--- a/src/lib/Components/Home/ArtistRails/ArtistRail.tsx
+++ b/src/lib/Components/Home/ArtistRails/ArtistRail.tsx
@@ -282,7 +282,7 @@ function suggestedArtistQuery(artistID: string): string {
 
 export default createRefetchContainer(
   ArtistRail,
-  graphql.experimental`
+  graphql`
     fragment ArtistRail_rail on HomePageArtistModule
       @argumentDefinitions(fetchContent: { type: "Boolean!", defaultValue: false }) {
       __id
@@ -294,7 +294,7 @@ export default createRefetchContainer(
       }
     }
   `,
-  graphql.experimental`
+  graphql`
     query ArtistRailRefetchQuery($__id: ID!, $fetchContent: Boolean!) {
       node(__id: $__id) {
         ...ArtistRail_rail @arguments(fetchContent: $fetchContent)

--- a/src/lib/Components/Home/ArtworkRails/ArtworkRail.tsx
+++ b/src/lib/Components/Home/ArtworkRails/ArtworkRail.tsx
@@ -300,7 +300,7 @@ const styles = StyleSheet.create<Styles>({
 
 export default createRefetchContainer(
   ArtworkRail,
-  graphql.experimental`
+  graphql`
     fragment ArtworkRail_rail on HomePageArtworkModule
       @argumentDefinitions(fetchContent: { type: "Boolean!", defaultValue: false }) {
       ...ArtworkRailHeader_rail
@@ -336,7 +336,7 @@ export default createRefetchContainer(
       }
     }
   `,
-  graphql.experimental`
+  graphql`
     query ArtworkRailRefetchQuery($__id: ID!, $fetchContent: Boolean!) {
       node(__id: $__id) {
         ...ArtworkRail_rail @arguments(fetchContent: $fetchContent)

--- a/src/lib/Components/Inbox/Conversations/Messages.tsx
+++ b/src/lib/Components/Inbox/Conversations/Messages.tsx
@@ -158,7 +158,7 @@ export class Messages extends React.Component<Props, State> {
 export default createPaginationContainer(
   Messages,
   {
-    conversation: graphql.experimental`
+    conversation: graphql`
       fragment Messages_conversation on Conversation
         @argumentDefinitions(count: { type: "Int", defaultValue: 10 }, after: { type: "String" }) {
         __id
@@ -226,7 +226,7 @@ export default createPaginationContainer(
         after: paginationInfo.cursor,
       }
     },
-    query: graphql.experimental`
+    query: graphql`
       query MessagesQuery($conversationID: String!, $count: Int!, $after: String) {
         me {
           conversation(id: $conversationID) {

--- a/src/lib/Components/Inbox/Conversations/__stories__/Inbox.story.tsx
+++ b/src/lib/Components/Inbox/Conversations/__stories__/Inbox.story.tsx
@@ -16,7 +16,7 @@ const RootContainer: React.SFC<any> = ({ Component }) => {
   return (
     <QueryRenderer
       environment={createEnvironment()}
-      query={graphql.experimental`
+      query={graphql`
         query InboxQuery($cursor: String) {
           me {
             ...Inbox_me @arguments(after: $cursor)

--- a/src/lib/Components/Inbox/Conversations/index.tsx
+++ b/src/lib/Components/Inbox/Conversations/index.tsx
@@ -126,7 +126,7 @@ export class Conversations extends Component<Props, State> {
 export default createPaginationContainer(
   Conversations,
   {
-    me: graphql.experimental`
+    me: graphql`
       fragment Conversations_me on Me
         @argumentDefinitions(count: { type: "Int", defaultValue: 10 }, cursor: { type: "String", defaultValue: "" }) {
         conversations(first: $count, after: $cursor) @connection(key: "Conversations_conversations") {
@@ -165,7 +165,7 @@ export default createPaginationContainer(
         cursor,
       }
     },
-    query: graphql.experimental`
+    query: graphql`
       query ConversationsQuery($count: Int!, $cursor: String) {
         me {
           ...Conversations_me @arguments(count: $count, cursor: $cursor)

--- a/src/lib/Containers/Gene.tsx
+++ b/src/lib/Containers/Gene.tsx
@@ -342,7 +342,7 @@ const styles = StyleSheet.create<Styles>({
 
 export default createRefetchContainer(
   Gene,
-  graphql.experimental`
+  graphql`
     fragment Gene_gene on Gene
       @argumentDefinitions(
         sort: { type: "String", defaultValue: "-partner_updated_at" }
@@ -372,7 +372,7 @@ export default createRefetchContainer(
       }
     }
   `,
-  graphql.experimental`
+  graphql`
     query GeneRefetchQuery($geneID: String!, $sort: String, $medium: String, $price_range: String) {
       gene(id: $geneID) {
         ...Gene_gene @arguments(sort: $sort, medium: $medium, price_range: $price_range)

--- a/src/lib/Containers/Sale.tsx
+++ b/src/lib/Containers/Sale.tsx
@@ -158,7 +158,7 @@ const styles = StyleSheet.create<Styles>({
 
 export default createRefetchContainer(
   Sale,
-  graphql.experimental`
+  graphql`
     fragment Sale_sale on Sale {
       id
       name
@@ -166,7 +166,7 @@ export default createRefetchContainer(
       ...SaleArtworksGrid_sale
     }
   `,
-  graphql.experimental`
+  graphql`
     query SaleRefetchQuery($saleID: String!) {
       sale(id: $saleID) {
         ...Sale_sale

--- a/src/lib/Containers/WorksForYou.tsx
+++ b/src/lib/Containers/WorksForYou.tsx
@@ -173,7 +173,7 @@ const styles = StyleSheet.create<Styles>({
 const WorksForYouContainer = createPaginationContainer(
   WorksForYou,
   {
-    viewer: graphql.experimental`
+    viewer: graphql`
       fragment WorksForYou_viewer on Viewer
         @argumentDefinitions(
           count: { type: "Int", defaultValue: 10 }
@@ -233,7 +233,7 @@ const WorksForYouContainer = createPaginationContainer(
         cursor,
       }
     },
-    query: graphql.experimental`
+    query: graphql`
       query WorksForYouQuery($count: Int!, $cursor: String) {
         viewer {
           ...WorksForYou_viewer @arguments(count: $count, cursor: $cursor)

--- a/src/lib/Scenes/Favorites/Components/Artists/index.tsx
+++ b/src/lib/Scenes/Favorites/Components/Artists/index.tsx
@@ -47,7 +47,7 @@ class Artists extends React.Component<RelayProps> {
 export default createPaginationContainer<RelayProps>(
   Artists,
   {
-    me: graphql.experimental`
+    me: graphql`
       fragment Artists_me on Me
         @argumentDefinitions(count: { type: "Int", defaultValue: 10 }, cursor: { type: "String" }) {
         followed_artists_connection(first: $count, after: $cursor)
@@ -87,7 +87,7 @@ export default createPaginationContainer<RelayProps>(
     getVariables(_props, pageInfo, _fragmentVariables) {
       return pageInfo
     },
-    query: graphql.experimental`
+    query: graphql`
       query ArtistsMeQuery($count: Int!, $cursor: String) {
         me {
           ...Artists_me @arguments(count: $count, cursor: $cursor)

--- a/src/lib/Scenes/Favorites/Components/Artworks/Relay/ArtworksRenderer.tsx
+++ b/src/lib/Scenes/Favorites/Components/Artworks/Relay/ArtworksRenderer.tsx
@@ -8,7 +8,7 @@ export default ({ render }) => {
   return (
     <QueryRenderer
       environment={environment}
-      query={graphql.experimental`
+      query={graphql`
         query ArtworksRendererQuery($count: Int!, $cursor: String) {
           me {
             ...Artworks_me @arguments(count: $count, cursor: $cursor)

--- a/src/lib/Scenes/Favorites/Components/Artworks/index.tsx
+++ b/src/lib/Scenes/Favorites/Components/Artworks/index.tsx
@@ -63,7 +63,7 @@ export class SavedWorks extends Component<Props> {
 export default createPaginationContainer(
   SavedWorks,
   {
-    me: graphql.experimental`
+    me: graphql`
       fragment Artworks_me on Me
         @argumentDefinitions(count: { type: "Int", defaultValue: 10 }, cursor: { type: "String", defaultValue: "" }) {
         saved_artworks {
@@ -101,7 +101,7 @@ export default createPaginationContainer(
         cursor,
       }
     },
-    query: graphql.experimental`
+    query: graphql`
       query ArtworksQuery($count: Int!, $cursor: String) {
         me {
           ...Artworks_me @arguments(count: $count, cursor: $cursor)

--- a/src/lib/Scenes/Favorites/Components/Categories/index.tsx
+++ b/src/lib/Scenes/Favorites/Components/Categories/index.tsx
@@ -46,7 +46,7 @@ export class Categories extends React.Component<RelayProps> {
 export default createPaginationContainer<RelayProps>(
   Categories,
   {
-    me: graphql.experimental`
+    me: graphql`
       fragment Categories_me on Me
         @argumentDefinitions(count: { type: "Int", defaultValue: 10 }, cursor: { type: "String" }) {
         followed_genes(first: $count, after: $cursor) @connection(key: "Categories_followed_genes") {
@@ -85,7 +85,7 @@ export default createPaginationContainer<RelayProps>(
     getVariables(_props, pageInfo, _fragmentVariables) {
       return pageInfo
     },
-    query: graphql.experimental`
+    query: graphql`
       query CategoriesMeQuery($count: Int!, $cursor: String) {
         me {
           ...Categories_me @arguments(count: $count, cursor: $cursor)

--- a/src/lib/Scenes/Home/Components/ForYou/Components/ArtworkCarousel.tsx
+++ b/src/lib/Scenes/Home/Components/ForYou/Components/ArtworkCarousel.tsx
@@ -330,7 +330,7 @@ const styles = StyleSheet.create<Styles>({
 
 export default createRefetchContainer(
   ArtworkCarousel,
-  graphql.experimental`
+  graphql`
     fragment ArtworkCarousel_rail on HomePageArtworkModule
       @argumentDefinitions(fetchContent: { type: "Boolean!", defaultValue: false }) {
       ...ArtworkCarouselHeader_rail
@@ -366,7 +366,7 @@ export default createRefetchContainer(
       }
     }
   `,
-  graphql.experimental`
+  graphql`
     query ArtworkCarouselRefetchQuery($__id: ID!, $fetchContent: Boolean!) {
       node(__id: $__id) {
         ...ArtworkCarousel_rail @arguments(fetchContent: $fetchContent)

--- a/src/lib/Scenes/Home/Components/Sales/Components/LotsByFollowedArtists.tsx
+++ b/src/lib/Scenes/Home/Components/Sales/Components/LotsByFollowedArtists.tsx
@@ -42,7 +42,7 @@ export const LotsByFollowedArtists: React.SFC<Props> = props => {
 
 export default createPaginationContainer(
   LotsByFollowedArtists,
-  graphql.experimental`
+  graphql`
     fragment LotsByFollowedArtists_viewer on Viewer
       @argumentDefinitions(count: { type: "Int", defaultValue: 10 }, cursor: { type: "String" }) {
       sale_artworks: sale_artworks(first: $count, after: $cursor, include_artworks_by_followed_artists: true)
@@ -67,7 +67,7 @@ export default createPaginationContainer(
     getConnectionFromProps: ({ viewer }) => viewer && (viewer.sale_artworks as ConnectionData),
     getFragmentVariables: (prevVars, totalCount) => ({ ...prevVars, count: totalCount }),
     getVariables: (_props, { count, cursor }) => ({ count, cursor }),
-    query: graphql.experimental`
+    query: graphql`
       query LotsByFollowedArtistsQuery($count: Int!, $cursor: String) {
         viewer {
           ...LotsByFollowedArtists_viewer @arguments(count: $count, cursor: $cursor)

--- a/src/lib/Scenes/Home/Components/Sales/Relay/SalesRenderer.tsx
+++ b/src/lib/Scenes/Home/Components/Sales/Relay/SalesRenderer.tsx
@@ -6,7 +6,7 @@ export function SalesRenderer({ render }) {
   return (
     <QueryRenderer
       environment={defaultEnvironment}
-      query={graphql.experimental`
+      query={graphql`
         query SalesRendererQuery {
           viewer {
             ...Sales_viewer

--- a/src/lib/relay/QueryRenderers.tsx
+++ b/src/lib/relay/QueryRenderers.tsx
@@ -65,7 +65,7 @@ export const ConversationRenderer: React.SFC<ConversationRendererProps> = ({ ren
   return (
     <QueryRenderer
       environment={environment}
-      query={graphql.experimental`
+      query={graphql`
         query QueryRenderersConversationQuery($conversationID: String!) {
           me {
             ...Conversation_me
@@ -154,7 +154,7 @@ export const WorksForYouRenderer: React.SFC<WorksForYouRendererProps> = ({ rende
   return (
     <QueryRenderer
       environment={environment}
-      query={graphql.experimental`
+      query={graphql`
         query QueryRenderersWorksForYouQuery($selectedArtist: String!) {
           viewer {
             ...WorksForYou_viewer @arguments(selectedArtist: $selectedArtist)

--- a/yarn.lock
+++ b/yarn.lock
@@ -696,19 +696,6 @@ babel-core@^6.0.0, babel-core@^6.24.1, babel-core@^6.26.0, babel-core@^6.7.2:
     slash "^1.0.0"
     source-map "^0.5.6"
 
-babel-generator@6.25.0, babel-generator@^6.24.1:
-  version "6.25.0"
-  resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.25.0.tgz#33a1af70d5f2890aeb465a4a7793c1df6a9ea9fc"
-  dependencies:
-    babel-messages "^6.23.0"
-    babel-runtime "^6.22.0"
-    babel-types "^6.25.0"
-    detect-indent "^4.0.0"
-    jsesc "^1.3.0"
-    lodash "^4.2.0"
-    source-map "^0.5.0"
-    trim-right "^1.0.1"
-
 babel-generator@^6.18.0, babel-generator@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.26.0.tgz#ac1ae20070b79f6e3ca1d3269613053774f20dc5"
@@ -720,6 +707,19 @@ babel-generator@^6.18.0, babel-generator@^6.26.0:
     jsesc "^1.3.0"
     lodash "^4.17.4"
     source-map "^0.5.6"
+    trim-right "^1.0.1"
+
+babel-generator@^6.24.1:
+  version "6.25.0"
+  resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.25.0.tgz#33a1af70d5f2890aeb465a4a7793c1df6a9ea9fc"
+  dependencies:
+    babel-messages "^6.23.0"
+    babel-runtime "^6.22.0"
+    babel-types "^6.25.0"
+    detect-indent "^4.0.0"
+    jsesc "^1.3.0"
+    lodash "^4.2.0"
+    source-map "^0.5.0"
     trim-right "^1.0.1"
 
 babel-helper-bindify-decorators@^6.24.1:
@@ -1013,13 +1013,13 @@ babel-plugin-react-transform@2.0.2:
   dependencies:
     lodash "^4.6.1"
 
-"babel-plugin-relay@https://github.com/alloy/relay/releases/download/v1.3.0-artsy/babel-plugin-relay-1.3.0-artsy.1.tgz":
-  version "1.3.0"
-  resolved "https://github.com/alloy/relay/releases/download/v1.3.0-artsy/babel-plugin-relay-1.3.0-artsy.1.tgz#39b21a10303e80177f43b0e4b7d733d5f2b0ab26"
+"babel-plugin-relay@https://github.com/alloy/relay/releases/download/v1.5.0-alpha.4/babel-plugin-relay-1.5.0-alpha.4.tgz":
+  version "1.5.0-alpha.4"
+  resolved "https://github.com/alloy/relay/releases/download/v1.5.0-alpha.4/babel-plugin-relay-1.5.0-alpha.4.tgz#5eb14710df22e5d8c9c9253ba97c01ad62596658"
   dependencies:
     babel-runtime "^6.23.0"
-    babel-types "^6.23.0"
-    graphql "^0.10.5"
+    babel-types "^6.24.1"
+    graphql "^0.12.3"
 
 babel-plugin-syntax-async-functions@^6.13.0, babel-plugin-syntax-async-functions@^6.5.0, babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
@@ -1465,7 +1465,7 @@ babel-polyfill@7.0.0-alpha.19:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-polyfill@^6.13.0, babel-polyfill@^6.20.0, babel-polyfill@^6.23.0, babel-polyfill@^6.26.0:
+babel-polyfill@^6.13.0, babel-polyfill@^6.20.0, babel-polyfill@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
   dependencies:
@@ -1580,7 +1580,7 @@ babel-preset-fbjs@^1.0.0:
     babel-plugin-transform-object-rest-spread "^6.6.5"
     object-assign "^4.0.1"
 
-babel-preset-fbjs@^2.1.0, babel-preset-fbjs@^2.1.4:
+babel-preset-fbjs@^2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/babel-preset-fbjs/-/babel-preset-fbjs-2.1.4.tgz#22f358e6654073acf61e47a052a777d7bccf03af"
   dependencies:
@@ -1810,7 +1810,7 @@ babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0:
     babylon "^6.18.0"
     lodash "^4.17.4"
 
-babel-traverse@6.25.0, babel-traverse@^6.16.0, babel-traverse@^6.24.1:
+babel-traverse@^6.16.0, babel-traverse@^6.24.1:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.25.0.tgz#2257497e2fcd19b89edc13c4c91381f9512496f1"
   dependencies:
@@ -1838,16 +1838,7 @@ babel-traverse@^6.18.0, babel-traverse@^6.26.0:
     invariant "^2.2.2"
     lodash "^4.17.4"
 
-babel-types@6.25.0:
-  version "6.25.0"
-  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.25.0.tgz#70afb248d5660e5d18f811d91c8303b54134a18e"
-  dependencies:
-    babel-runtime "^6.22.0"
-    esutils "^2.0.2"
-    lodash "^4.2.0"
-    to-fast-properties "^1.0.1"
-
-babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24.1, babel-types@^6.25.0, babel-types@^6.26.0:
+babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.25.0, babel-types@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
   dependencies:
@@ -1856,7 +1847,7 @@ babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
 
-babylon@6.18.0, babylon@^6.12.0, babylon@^6.14.0, babylon@^6.17.0, babylon@^6.17.2, babylon@^6.18.0:
+babylon@^6.12.0, babylon@^6.14.0, babylon@^6.17.0, babylon@^6.17.2, babylon@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
 
@@ -2038,6 +2029,18 @@ boxen@1.1.0, boxen@^1.0.0:
     string-width "^2.0.0"
     term-size "^0.1.0"
     widest-line "^1.0.0"
+
+boxen@^1.2.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/boxen/-/boxen-1.3.0.tgz#55c6c39a8ba58d9c61ad22cd877532deb665a20b"
+  dependencies:
+    ansi-align "^2.0.0"
+    camelcase "^4.0.0"
+    chalk "^2.0.1"
+    cli-boxes "^1.0.0"
+    string-width "^2.0.0"
+    term-size "^1.2.0"
+    widest-line "^2.0.0"
 
 bplist-creator@0.0.7:
   version "0.0.7"
@@ -3612,8 +3615,8 @@ es6-map@^0.1.3:
     event-emitter "~0.3.5"
 
 es6-promise@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.1.1.tgz#8811e90915d9a0dba36274f0b242dbda78f9c92a"
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.2.tgz#f722d7769af88bd33bc13ec6605e1f92966b82d9"
 
 es6-set@~0.1.5:
   version "0.1.5"
@@ -4006,7 +4009,7 @@ fbjs@0.8.12:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
-fbjs@^0.8.1, fbjs@^0.8.12, fbjs@^0.8.16, fbjs@^0.8.5, fbjs@^0.8.9:
+fbjs@^0.8.12, fbjs@^0.8.14, fbjs@^0.8.16, fbjs@^0.8.5, fbjs@^0.8.9:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
@@ -4242,7 +4245,7 @@ fs-extra@^1.0.0:
     jsonfile "^2.1.0"
     klaw "^1.0.0"
 
-fs-extra@^4.0.2:
+fs-extra@^4.0.1, fs-extra@^4.0.2:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
   dependencies:
@@ -4435,6 +4438,12 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+global-dirs@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-0.1.1.tgz#b319c0dd4607f353f3be9cca4c72fc148c49f445"
+  dependencies:
+    ini "^1.3.4"
+
 global@^4.3.0, global@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/global/-/global-4.3.2.tgz#e76989268a6c74c38908b1305b10fc0e394e9d0f"
@@ -4540,17 +4549,11 @@ graphql-language-service-utils@0.0.10:
     graphql "^0.9.6"
     graphql-language-service-types "0.0.16"
 
-"graphql@0.7.1 - 1.0.0", "graphql@0.8.2 - 1.0.0", graphql@^0.10.5:
-  version "0.10.5"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.10.5.tgz#c9be17ca2bdfdbd134077ffd9bbaa48b8becd298"
+"graphql@0.7.1 - 1.0.0", "graphql@0.8.2 - 1.0.0", graphql@0.9.6, graphql@^0.12.3, graphql@^0.9.5, graphql@^0.9.6:
+  version "0.12.3"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.12.3.tgz#11668458bbe28261c0dcb6e265f515ba79f6ce07"
   dependencies:
-    iterall "^1.1.0"
-
-graphql@0.9.6, graphql@^0.9.5, graphql@^0.9.6:
-  version "0.9.6"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.9.6.tgz#514421e9d225c29dfc8fd305459abae58815ef2c"
-  dependencies:
-    iterall "^1.0.0"
+    iterall "1.1.3"
 
 growly@^1.3.0:
   version "1.3.0"
@@ -4897,6 +4900,10 @@ immutable@^3.8.1:
   version "3.8.2"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
 
+immutable@~3.7.6:
+  version "3.7.6"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.7.6.tgz#13b4d3cb12befa15482a26fe1b2ebae640071e4b"
+
 import-lazy@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
@@ -5149,6 +5156,13 @@ is-glob@^4.0.0:
   dependencies:
     is-extglob "^2.1.1"
 
+is-installed-globally@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.1.0.tgz#0dfd98f5a9111716dd535dda6492f67bf3d25a80"
+  dependencies:
+    global-dirs "^0.1.0"
+    is-path-inside "^1.0.0"
+
 is-lower-case@^1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/is-lower-case/-/is-lower-case-1.1.3.tgz#7e147be4768dc466db3bfb21cc60b31e6ad69393"
@@ -5383,7 +5397,7 @@ istanbul-reports@^1.1.3:
   dependencies:
     handlebars "^4.0.3"
 
-iterall@^1.0.0, iterall@^1.1.0:
+iterall@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.1.3.tgz#1cbbff96204056dde6656e2ed2e2226d0e6d72c9"
 
@@ -7052,7 +7066,7 @@ os-name@^2.0.1:
     macos-release "^1.0.0"
     win-release "^1.0.0"
 
-os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.2:
+os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
@@ -7186,6 +7200,19 @@ pascal-case@^2.0.0:
 pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
+
+patch-package@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-5.0.0.tgz#59d1aee5093f4d026e24ad4921e826c0324a8a6b"
+  dependencies:
+    chalk "^1.1.3"
+    cross-spawn "^5.1.0"
+    fs-extra "^4.0.1"
+    minimist "^1.2.0"
+    rimraf "^2.6.1"
+    slash "^1.0.0"
+    tmp "^0.0.31"
+    update-notifier "^2.2.0"
 
 path-browserify@0.0.0:
   version "0.0.0"
@@ -7664,6 +7691,10 @@ postcss@^6.0.0, postcss@^6.0.1, postcss@^6.0.14:
     source-map "^0.6.1"
     supports-color "^4.4.0"
 
+postinstall-prepare@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/postinstall-prepare/-/postinstall-prepare-1.0.1.tgz#dac9b5d91b054389141b13c0192eb68a0aa002b5"
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -8109,15 +8140,14 @@ react-proxy@^1.1.7:
     lodash "^4.6.1"
     react-deep-force-update "^1.0.0"
 
-"react-relay@https://github.com/alloy/relay/releases/download/v1.3.0-artsy/react-relay-1.3.0-artsy.1.tgz":
-  version "1.3.0"
-  resolved "https://github.com/alloy/relay/releases/download/v1.3.0-artsy/react-relay-1.3.0-artsy.1.tgz#24e2f9a27950e71350cd9639a1df66c5ef522f1f"
+"react-relay@https://github.com/alloy/relay/releases/download/v1.5.0-alpha.4/react-relay-1.5.0-alpha.4.tgz":
+  version "1.5.0-alpha.4"
+  resolved "https://github.com/alloy/relay/releases/download/v1.5.0-alpha.4/react-relay-1.5.0-alpha.4.tgz#420e18d8e4fb6de3fc16f35df04884cd61189068"
   dependencies:
     babel-runtime "^6.23.0"
-    fbjs "^0.8.1"
+    fbjs "^0.8.14"
     prop-types "^15.5.8"
-    react-static-container "^1.0.1"
-    relay-runtime "1.3.0"
+    relay-runtime "1.5.0-alpha.4"
 
 react-split-pane@^0.1.71:
   version "0.1.71"
@@ -8128,10 +8158,6 @@ react-split-pane@^0.1.71:
     inline-style-prefixer "^3.0.6"
     prop-types "^15.5.10"
     react-style-proptype "^3.0.0"
-
-react-static-container@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/react-static-container/-/react-static-container-1.0.2.tgz#30a4f7548860be1d55d5eb4c20645b835c2bdf34"
 
 react-storybooks-relay-container@^1.0.0:
   version "1.1.2"
@@ -8407,39 +8433,34 @@ regjsparser@^0.1.4:
   dependencies:
     jsesc "~0.5.0"
 
-"relay-compiler@https://github.com/alloy/relay/releases/download/v1.3.0-artsy/relay-compiler-1.3.0-artsy.1.tgz":
-  version "1.3.0"
-  resolved "https://github.com/alloy/relay/releases/download/v1.3.0-artsy/relay-compiler-1.3.0-artsy.1.tgz#90c5e84300eac1728c66298b1cd40fedee82ef1d"
+"relay-compiler@https://github.com/alloy/relay/releases/download/v1.5.0-alpha.4/relay-compiler-1.5.0-alpha.4.tgz":
+  version "1.5.0-alpha.4"
+  resolved "https://github.com/alloy/relay/releases/download/v1.5.0-alpha.4/relay-compiler-1.5.0-alpha.4.tgz#fee3d289f3dca6fa5ed9be113cf4532819b2f81b"
   dependencies:
-    babel-generator "6.25.0"
-    babel-polyfill "^6.23.0"
-    babel-preset-fbjs "^2.1.0"
+    babel-generator "^6.26.0"
+    babel-polyfill "^6.20.0"
+    babel-preset-fbjs "^2.1.4"
     babel-runtime "^6.23.0"
-    babel-traverse "6.25.0"
-    babel-types "6.25.0"
-    babylon "6.18.0"
-    chalk "^1.1.3"
+    babel-traverse "^6.26.0"
+    babel-types "^6.24.1"
+    babylon "^6.18.0"
+    chalk "^1.1.1"
     fast-glob "^1.0.1"
     fb-watchman "^2.0.0"
-    fbjs "^0.8.1"
-    graphql "^0.10.5"
-    immutable "^3.8.1"
-    relay-runtime "1.3.0"
+    fbjs "^0.8.14"
+    graphql "^0.12.3"
+    immutable "~3.7.6"
+    relay-runtime "1.5.0-alpha.4"
     signedsource "^1.0.0"
     typescript "^2.3.2"
-    yargs "^7.0.2"
+    yargs "^9.0.0"
 
-relay-debugger-react-native-runtime@^0.0.9:
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/relay-debugger-react-native-runtime/-/relay-debugger-react-native-runtime-0.0.9.tgz#f9da4bb1f4f4a62189775d3850a18df1d528a4f1"
-
-relay-runtime@1.3.0, "relay-runtime@https://github.com/alloy/relay/releases/download/v1.3.0-artsy/relay-runtime-artsy.1.tgz":
-  version "1.3.0"
-  resolved "https://github.com/alloy/relay/releases/download/v1.3.0-artsy/relay-runtime-artsy.1.tgz#edf42a4ddfce3a0edbf79ff41a416aa4f4fc079d"
+relay-runtime@1.5.0-alpha.4, "relay-runtime@https://github.com/alloy/relay/releases/download/v1.5.0-alpha.4/relay-runtime-1.5.0-alpha.4.tgz":
+  version "1.5.0-alpha.4"
+  resolved "https://github.com/alloy/relay/releases/download/v1.5.0-alpha.4/relay-runtime-1.5.0-alpha.4.tgz#71f1acb148e276e084004867dc60e4a0dd23b205"
   dependencies:
     babel-runtime "^6.23.0"
-    fbjs "^0.8.1"
-    relay-debugger-react-native-runtime "^0.0.9"
+    fbjs "^0.8.14"
 
 relay2ts@^0.2.0:
   version "0.2.0"
@@ -9564,6 +9585,12 @@ term-size@^0.1.0:
   dependencies:
     execa "^0.4.0"
 
+term-size@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/term-size/-/term-size-1.2.0.tgz#458b83887f288fc56d6fffbfad262e26638efa69"
+  dependencies:
+    execa "^0.7.0"
+
 test-exclude@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-3.3.0.tgz#7a17ca1239988c98367b0621456dbb7d4bc38977"
@@ -9635,6 +9662,12 @@ title-case@^2.1.0:
     no-case "^2.2.0"
     upper-case "^1.0.3"
 
+tmp@^0.0.31:
+  version "0.0.31"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.31.tgz#8f38ab9438e17315e5dbd8b3657e8bfb277ae4a7"
+  dependencies:
+    os-tmpdir "~1.0.1"
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -9649,7 +9682,7 @@ to-arraybuffer@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
 
-to-fast-properties@^1.0.1, to-fast-properties@^1.0.3:
+to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
 
@@ -9934,6 +9967,20 @@ update-notifier@2.2.0:
     chalk "^1.0.0"
     configstore "^3.0.0"
     import-lazy "^2.1.0"
+    is-npm "^1.0.0"
+    latest-version "^3.0.0"
+    semver-diff "^2.0.0"
+    xdg-basedir "^3.0.0"
+
+update-notifier@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-2.3.0.tgz#4e8827a6bb915140ab093559d7014e3ebb837451"
+  dependencies:
+    boxen "^1.2.1"
+    chalk "^2.0.1"
+    configstore "^3.0.0"
+    import-lazy "^2.1.0"
+    is-installed-globally "^0.1.0"
     is-npm "^1.0.0"
     latest-version "^3.0.0"
     semver-diff "^2.0.0"
@@ -10249,6 +10296,12 @@ widest-line@^1.0.0:
   dependencies:
     string-width "^1.0.1"
 
+widest-line@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/widest-line/-/widest-line-2.0.0.tgz#0142a4e8a243f8882c0233aa0e0281aa76152273"
+  dependencies:
+    string-width "^2.1.1"
+
 win-release@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/win-release/-/win-release-1.1.1.tgz#5fa55e02be7ca934edfc12665632e849b72e5209"
@@ -10506,7 +10559,7 @@ yargs@^6.4.0:
     y18n "^3.2.1"
     yargs-parser "^4.2.0"
 
-yargs@^7.0.1, yargs@^7.0.2:
+yargs@^7.0.1:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-7.1.0.tgz#6ba318eb16961727f5d284f8ea003e8d6154d0c8"
   dependencies:


### PR DESCRIPTION
This uses my [updated Relay custom Node ID patches](https://github.com/facebook/relay/compare/master...alloy:custom-node-id-redone), which brings in the latest Relay. While it seems to work well, I’m not sure if we should merge it in this repo at this time just before v4. Let’s wait for now, but feel free to give it a spin!