### PR TITLE
[Invoice] Convert NSURL to NSString before passing over JS bridge.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Optimize the Home/ForYou view by re-enabling removal of clipped subviews - alloy
 * Brings back artist rails on the Home/ForYou view - alloy
 * Fix issue where unmounted Home/ForYou rails would be refreshed - chris & alloy
+* Fix payment request component status not updating after payment - alloy
 
 ### 1.4.0-beta.11
 

--- a/Pod/Classes/EigenCommunications/ARNotificationsManager.m
+++ b/Pod/Classes/EigenCommunications/ARNotificationsManager.m
@@ -21,8 +21,8 @@ RCT_EXPORT_MODULE();
 
 - (void)paymentRequestPaidReceived:(NSNotification *)notification
 {
-    NSDictionary *info = notification.userInfo;
-    [self sendEventWithName:@"PaymentRequestPaid" body:@{ @"url": info[@"ARPaymentRequestURL"] }];
+    NSURL *URL = notification.userInfo[@"ARPaymentRequestURL"];
+    [self sendEventWithName:@"PaymentRequestPaid" body:@{ @"url": URL.absoluteString }];
 }
 
 @end


### PR DESCRIPTION
Fixes https://github.com/artsy/collector-experience/issues/782

An `NSURL` object looks like a string when you inspect it, which is why I didn’t notice this sooner (and notification info objects are not strictly typed) and the JS bridge would just serialise it to an empty JS object.

Now we convert it to a string before passing it to the JS bridge.