### PR TITLE
Add pull to refresh to artists and auctions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Brings back artist rails on the Home/ForYou view - alloy
 * Fix issue where unmounted Home/ForYou rails would be refreshed - chris & alloy
 * Fix payment request component status not updating after payment - alloy
+* Add pull-to-refresh to the ARTISTS and AUCTIONS tabs on the Home view - alloy
 
 ### 1.4.0-beta.11
 

--- a/src/lib/Containers/WorksForYou.tsx
+++ b/src/lib/Containers/WorksForYou.tsx
@@ -5,6 +5,7 @@ import {
   ListView,
   ListViewDataSource,
   NativeModules,
+  RefreshControl,
   ScrollView,
   StyleSheet,
   TextStyle,
@@ -32,6 +33,7 @@ interface Props extends RelayProps {
 
 interface State {
   dataSource: ListViewDataSource | null
+  isRefreshing: boolean
 }
 
 export class WorksForYou extends React.Component<Props, State> {
@@ -53,6 +55,7 @@ export class WorksForYou extends React.Component<Props, State> {
 
     this.state = {
       dataSource,
+      isRefreshing: false,
     }
   }
 
@@ -109,6 +112,17 @@ export class WorksForYou extends React.Component<Props, State> {
     })
   }
 
+  handleRefresh = () => {
+    this.setState({ isRefreshing: true })
+    this.props.relay.refetchConnection(PAGE_SIZE, error => {
+      if (error) {
+        // FIXME: Handle error
+        console.error("WorksForYou.tsx #handleRefresh", error.message)
+      }
+      this.setState({ isRefreshing: false })
+    })
+  }
+
   render() {
     const hasNotifications = this.state.dataSource
 
@@ -121,6 +135,13 @@ export class WorksForYou extends React.Component<Props, State> {
         onScroll={isCloseToBottom(this.fetchNextPage)}
         scrollEventThrottle={100}
         ref={scrollView => (this.scrollView = scrollView)}
+        refreshControl={
+          <RefreshControl
+            refreshing={this.state.isRefreshing}
+            onRefresh={this.handleRefresh}
+            style={{ marginBottom: 20 }}
+          />
+        }
       >
         <View style={{ flex: 1 }}>{hasNotifications ? this.renderNotifications() : this.renderEmptyState()}</View>
       </ScrollView>

--- a/src/lib/Containers/__tests__/__snapshots__/WorksForYou-tests.tsx.snap
+++ b/src/lib/Containers/__tests__/__snapshots__/WorksForYou-tests.tsx.snap
@@ -4,8 +4,20 @@ exports[`with notifications lays out correctly on larger screens 1`] = `
 <RCTScrollView
   contentContainerStyle={Object {}}
   onScroll={[Function]}
+  refreshControl={
+    <RefreshControlMock
+      onRefresh={[Function]}
+      refreshing={false}
+      style={
+        Object {
+          "marginBottom": 20,
+        }
+      }
+    />
+  }
   scrollEventThrottle={100}
 >
+  <RCTRefreshControl />
   <View>
     <View
       style={
@@ -285,8 +297,20 @@ exports[`with notifications lays out correctly on small screens 1`] = `
 <RCTScrollView
   contentContainerStyle={Object {}}
   onScroll={[Function]}
+  refreshControl={
+    <RefreshControlMock
+      onRefresh={[Function]}
+      refreshing={false}
+      style={
+        Object {
+          "marginBottom": 20,
+        }
+      }
+    />
+  }
   scrollEventThrottle={100}
 >
+  <RCTRefreshControl />
   <View>
     <View
       style={
@@ -570,8 +594,20 @@ exports[`without notifications lays out correctly on larger screens 1`] = `
     }
   }
   onScroll={[Function]}
+  refreshControl={
+    <RefreshControlMock
+      onRefresh={[Function]}
+      refreshing={false}
+      style={
+        Object {
+          "marginBottom": 20,
+        }
+      }
+    />
+  }
   scrollEventThrottle={100}
 >
+  <RCTRefreshControl />
   <View>
     <View
       style={
@@ -663,8 +699,20 @@ exports[`without notifications lays out correctly on small screens 1`] = `
     }
   }
   onScroll={[Function]}
+  refreshControl={
+    <RefreshControlMock
+      onRefresh={[Function]}
+      refreshing={false}
+      style={
+        Object {
+          "marginBottom": 20,
+        }
+      }
+    />
+  }
   scrollEventThrottle={100}
 >
+  <RCTRefreshControl />
   <View>
     <View
       style={

--- a/src/lib/Scenes/Home/Components/Sales/__tests__/__snapshots__/index-tests.tsx.snap
+++ b/src/lib/Scenes/Home/Components/Sales/__tests__/__snapshots__/index-tests.tsx.snap
@@ -132,6 +132,17 @@ exports[`looks correct when rendered 1`] = `
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
   onViewableItemsChanged={undefined}
+  refreshControl={
+    <RefreshControlMock
+      onRefresh={[Function]}
+      refreshing={false}
+      style={
+        Object {
+          "marginBottom": 20,
+        }
+      }
+    />
+  }
   renderItem={[Function]}
   scrollEventThrottle={50}
   sections={
@@ -245,6 +256,7 @@ exports[`looks correct when rendered 1`] = `
   updateCellsBatchingPeriod={50}
   windowSize={21}
 >
+  <RCTRefreshControl />
   <View>
     <View
       onLayout={[Function]}

--- a/src/lib/Scenes/Home/Components/Sales/__tests__/index-tests.tsx
+++ b/src/lib/Scenes/Home/Components/Sales/__tests__/index-tests.tsx
@@ -19,9 +19,11 @@ it("looks correct when rendered", () => {
 
 const props = {
   relay: {
+    environment: null,
     hasMore: jest.fn(),
     isLoading: jest.fn(),
     loadMore: jest.fn(),
+    refetch: jest.fn(),
   },
   viewer: {
     sales: [

--- a/src/lib/Scenes/Home/Components/Sales/index.tsx
+++ b/src/lib/Scenes/Home/Components/Sales/index.tsx
@@ -1,11 +1,29 @@
 import React from "react"
-import { SectionList, StyleSheet } from "react-native"
-import { createFragmentContainer, graphql } from "react-relay"
+import { RefreshControl, SectionList, StyleSheet } from "react-native"
+import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
 import LotsByFollowedArtists from "./Components/LotsByFollowedArtists"
 import { SaleList } from "./Components/SaleList"
 import { ZeroState } from "./Components/ZeroState"
 
-class Sales extends React.Component<Props> {
+interface Props {
+  relay?: RelayRefetchProp
+  viewer: {
+    sales: Array<{
+      href: string | null
+      live_start_at: string | null
+    }>
+  }
+}
+
+interface State {
+  isRefreshing: boolean
+}
+
+class Sales extends React.Component<Props, State> {
+  state = {
+    isRefreshing: false,
+  }
+
   get data() {
     const { viewer } = this.props
     const liveAuctions = viewer.sales.filter(a => !!a.live_start_at)
@@ -16,6 +34,22 @@ class Sales extends React.Component<Props> {
       timedAuctions,
       viewer,
     }
+  }
+
+  handleRefresh = () => {
+    this.setState({ isRefreshing: true })
+    this.props.relay.refetch(
+      {},
+      {},
+      error => {
+        if (error) {
+          // FIXME: Handle error
+          console.error("Sales/index.tsx", error.message)
+        }
+        this.setState({ isRefreshing: false })
+      },
+      { force: true }
+    )
   }
 
   render() {
@@ -48,12 +82,19 @@ class Sales extends React.Component<Props> {
         stickySectionHeadersEnabled={false}
         sections={sections}
         keyExtractor={item => item.id}
+        refreshControl={
+          <RefreshControl
+            refreshing={this.state.isRefreshing}
+            onRefresh={this.handleRefresh}
+            style={{ marginBottom: 20 }}
+          />
+        }
       />
     )
   }
 }
 
-export default createFragmentContainer(
+export default createRefetchContainer(
   Sales,
   graphql`
     fragment Sales_viewer on Viewer {
@@ -63,6 +104,13 @@ export default createFragmentContainer(
         live_start_at
       }
       ...LotsByFollowedArtists_viewer
+    }
+  `,
+  graphql`
+    query SalesQuery {
+      viewer {
+        ...Sales_viewer
+      }
     }
   `
 )
@@ -75,12 +123,3 @@ const SectionListStyles = StyleSheet.create({
     display: "flex",
   },
 })
-
-interface Props {
-  viewer: {
-    sales: Array<{
-      href: string | null
-      live_start_at: string | null
-    }>
-  }
-}


### PR DESCRIPTION
Related to https://github.com/artsy/collector-experience/issues/855

This only adds pull-to-refresh to these views, rather than a more comprehensive data invalidation scheme, but that can probably wait till post v4.0.0.