### PR TITLE
[Inquiry] Don’t crash when tapping artwork component.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,15 @@
 
 ### Master
 
+* Make sure Home/Fairs rail does not clip any icons at the end of the list - alloy
+* Re-align headers in all Home tabs - alloy
+* Fix crash that would occur when tapping artwork component on inquiry view - alloy
+
 ### 1.4.0-beta.13
 
 * Fixes for the camera roll order in consignments - orta
 * Adds the new photo and selects it when taking a photo - orta
 * Adds a confirmation screen to the end of the consignment submission process - maxim/orta
-* Make sure Home/Fairs rail does not clip any icons at the end of the list - alloy
-* Re-align headers in all Home tabs - alloy
 
 ### 1.4.0-beta.12
 

--- a/src/lib/Components/Inbox/Conversations/Preview/ArtworkPreview.tsx
+++ b/src/lib/Components/Inbox/Conversations/Preview/ArtworkPreview.tsx
@@ -73,7 +73,10 @@ export class ArtworkPreview extends React.Component<Props, any> {
     const artwork = this.props.artwork
 
     return (
-      <TouchableHighlight underlayColor={Colors.GrayLight} onPress={() => this.attachmentSelected()}>
+      <TouchableHighlight
+        underlayColor={Colors.GrayLight}
+        onPress={this.props.onSelected && this.attachmentSelected.bind(this)}
+      >
         <Container>
           <Image imageURL={artwork.image.url} />
           <TextContainer>

--- a/src/lib/Components/Inbox/Conversations/Preview/__tests__/ArtworkPreview-tests.tsx
+++ b/src/lib/Components/Inbox/Conversations/Preview/__tests__/ArtworkPreview-tests.tsx
@@ -1,3 +1,4 @@
+import { shallow } from "enzyme"
 import React from "react"
 import "react-native"
 import * as renderer from "react-test-renderer"
@@ -15,6 +16,20 @@ it("handles dateless artworks", () => {
   const tree = renderer.create(<ArtworkPreview artwork={dateless} />)
 
   expect(tree).toMatchSnapshot()
+})
+
+describe("concerning selection handling", () => {
+  it("passes a onPress handler to the touchable component if an onSelected handler is given", () => {
+    const wrapper = shallow(<ArtworkPreview artwork={artwork} onSelected={() => null} />)
+    const touchable = wrapper.find("TouchableHighlight")
+    expect(touchable.props().onPress).toBeDefined()
+  })
+
+  it("does not pass a onPress handler to the touchable component if no onSelected handler is given", () => {
+    const wrapper = shallow(<ArtworkPreview artwork={artwork} />)
+    const touchable = wrapper.find("TouchableHighlight")
+    expect(touchable.props().onPress).toBeUndefined()
+  })
 })
 
 const artwork = {


### PR DESCRIPTION
Fixes https://github.com/artsy/collector-experience/issues/875