### PR TITLE
Make sure buttons update when their enablement has changed #trivial

### DIFF
--- a/src/lib/Components/Buttons/Button.tsx
+++ b/src/lib/Components/Buttons/Button.tsx
@@ -61,6 +61,18 @@ export default class Button extends React.Component<Props, State> {
   }
 
   componentDidUpdate(_prevProps: any, prevState: any) {
+    const currentDisplayState = this.state.displayState
+
+    // Check to see if it has been enabled/disabled since last render; ignore this if highlighted
+    if (currentDisplayState !== DisplayState.Highlighted) {
+      const enablementState =
+        this.props.onPress && this.props.onPress !== undefined ? DisplayState.Enabled : DisplayState.Disabled
+
+      if (currentDisplayState !== enablementState) {
+        this.setState({ displayState: enablementState })
+      }
+    }
+
     if (this.state.displayState !== prevState.displayState) {
       // Don't animate in when it's the initial press down
       const showHighlight =


### PR DESCRIPTION
Fixes https://github.com/artsy/collector-experience/issues/849

This button relies on the presence of an `onPress` prop to be enabled/disabled; before, this check only happened in the constructor. Now it should check to see if its status has changed in `componentDidUpdate`.

This shows the button being enabled and then disabled based on consignments information (ignore animation warnings):
 
![buttonstatechanges](https://user-images.githubusercontent.com/2712962/34668551-32a0a02c-f46e-11e7-88bf-119acccf9084.gif)

  
#skip_new_tests