### PR TITLE
Fix a bug where infinite scroll doesn't know how to stop unless you use a finished callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Make sure Home/Fairs rail does not clip any icons at the end of the list - alloy
 * Re-align headers in all Home tabs - alloy
 * Fix crash that would occur when tapping artwork component on inquiry view - alloy
+* Fix a bug that would not let an infinite scroll of artworks stop requesting more artworks - orta
 
 ### 1.4.0-beta.13
 

--- a/src/lib/Components/ArtworkGrids/InfiniteScrollGrid.tsx
+++ b/src/lib/Components/ArtworkGrids/InfiniteScrollGrid.tsx
@@ -123,8 +123,10 @@ class InfiniteScrollArtworksGrid extends React.Component<Props, State> {
         console.error("InfiniteScrollGrid.tsx", error.message)
       }
       this.setState({ fetchingNextPage: false })
-      if (!this.artworksConnection().pageInfo.hasNextPage && this.props.onComplete) {
-        this.props.onComplete()
+      if (!this.artworksConnection().pageInfo.hasNextPage) {
+        if (this.props.onComplete) {
+          this.props.onComplete()
+        }
         this.setState({ completed: true })
       }
     })


### PR DESCRIPTION
Found while debugging #578 