### PR TITLE
[Analytics] For home, saves and follows, and gene events

### DIFF
--- a/src/lib/AppRegistry.tsx
+++ b/src/lib/AppRegistry.tsx
@@ -39,10 +39,16 @@ interface GeneProps {
   refineSettings: { medium: string; price_range: string }
 }
 
-const Gene: React.SFC<GeneProps> = ({ geneID, refineSettings: { medium, price_range } }) => {
+const Gene: React.SFC<GeneProps> = track<GeneProps>(props => {
+  return {
+    context_screen: Schema.PageNames.GenePage,
+    context_screen_owner_slug: props.geneID,
+    context_screen_owner_type: Schema.OwnerEntityTypes.Gene,
+  }
+})(({ geneID, refineSettings: { medium, price_range } }) => {
   const initialProps = { geneID, medium, price_range }
   return <GeneRenderer {...initialProps} render={renderWithLoadProgress(Containers.Gene, initialProps)} />
-}
+})
 
 // FIXME: This isn't being used
 // const Sale: React.SFC<{ saleID: string }> = ({ saleID }) => {

--- a/src/lib/Components/Gene/Header.tsx
+++ b/src/lib/Components/Gene/Header.tsx
@@ -4,8 +4,6 @@ import { createFragmentContainer, graphql } from "react-relay"
 import { Dimensions, NativeModules, StyleSheet, TextStyle, View, ViewProperties, ViewStyle } from "react-native"
 const { ARTemporaryAPIModule } = NativeModules
 
-import Events from "../../NativeModules/Events"
-
 import { Schema, Track, track as _track } from "../../utils/track"
 
 import InvertedButton from "../Buttons/InvertedButton"

--- a/src/lib/Components/Home/ArtistRails/ArtistRail.tsx
+++ b/src/lib/Components/Home/ArtistRails/ArtistRail.tsx
@@ -5,6 +5,8 @@ import { Animated, Easing, ScrollView, StyleSheet, TextStyle, View, ViewProperti
 
 import metaphysics from "../../../metaphysics"
 
+import { Schema, Track, track as _track } from "lib/utils/track"
+
 import { Disposable } from "relay-runtime"
 import Separator from "../../Separator"
 import Spinner from "../../Spinner"
@@ -29,7 +31,11 @@ interface State {
   artists: any[]
   loadFailed: boolean
 }
+// FIXME: can remove "trackWithArguments" when the third arguments parameter is added to the typings of react-tracking
+const track: Track<Props, State> = _track
+const trackWithArguments: any = _track
 
+@track()
 export class ArtistRail extends Component<Props, State> {
   inflightRequest: Disposable
 
@@ -114,6 +120,13 @@ export class ArtistRail extends Component<Props, State> {
     })
   }
 
+  @trackWithArguments((_props, _state, [followArtist]) => ({
+    action_name: Schema.ActionNames.HomeArtistRailFollow,
+    action_type: Schema.ActionTypes.Tap,
+    owner_id: followArtist._id,
+    owner_slug: followArtist.id,
+    owner_type: Schema.OwnerEntityTypes.Artist,
+  }))
   handleFollowChange(followArtist, setFollowButtonStatus: ArtistFollowButtonStatusSetter) {
     // Get a new suggested artist based on the followed artist.
     return (

--- a/src/lib/Containers/Gene.tsx
+++ b/src/lib/Containers/Gene.tsx
@@ -6,6 +6,8 @@ import { RelayRefetchProp } from "react-relay"
 
 import { Dimensions, StyleSheet, View, ViewProperties, ViewStyle } from "react-native"
 
+import { Schema, Track, track as _track } from "lib/utils/track"
+
 import { GhostButton } from "../Components/Buttons"
 import Separator from "../Components/Separator"
 import SerifText from "../Components/Text/Serif"
@@ -44,6 +46,7 @@ interface State {
   selectedMedium?: string
   selectedPriceRange?: string
 }
+const track: Track<Props, State> = _track
 
 /**
  *  There are 3 different major views inside this componentDidUpdate
@@ -69,6 +72,7 @@ interface State {
  *     the `stickyHeaderIndices` is always at the right index.
  *
  */
+@track()
 export class Gene extends React.Component<Props, State> {
   foregroundHeight: number = 200
 
@@ -84,7 +88,14 @@ export class Gene extends React.Component<Props, State> {
     }
   }
 
-  switchSelectionDidChange = (event: SwitchEvent) => {
+  @track((props, state) => ({
+    action_name: state.selectedTabIndex ? Schema.ActionNames.GeneWorks : Schema.ActionNames.GeneAbout,
+    action_type: Schema.ActionTypes.Tap,
+    owner_id: props.gene._id,
+    owner_slug: props.gene.id,
+    owner_type: Schema.OwnerEntityTypes.Gene,
+  }))
+  switchSelectionDidChange(event: SwitchEvent) {
     this.setState({ selectedTabIndex: event.nativeEvent.selectedIndex })
   }
 
@@ -146,7 +157,7 @@ export class Gene extends React.Component<Props, State> {
           style={{ marginTop: 30 }}
           titles={this.availableTabs()}
           selectedIndex={this.state.selectedTabIndex}
-          onSelectionChange={this.switchSelectionDidChange}
+          onSelectionChange={this.switchSelectionDidChange.bind(this)}
         />
       </View>
     )
@@ -168,7 +179,14 @@ export class Gene extends React.Component<Props, State> {
     return HeaderHeight
   }
 
-  refineTapped = _button => {
+  @track(props => ({
+    action_name: Schema.ActionNames.Refine,
+    action_type: Schema.ActionTypes.Tap,
+    owner_id: props.gene._id,
+    owner_slug: props.gene.id,
+    owner_type: Schema.OwnerEntityTypes.Gene,
+  }))
+  refineTapped(_button) {
     const initialSettings = {
       sort: "-partner_updated_at",
       selectedMedium: this.props.medium || "*",
@@ -237,7 +255,11 @@ export class Gene extends React.Component<Props, State> {
           <SerifText style={{ fontStyle: "italic", marginTop: 2, maxWidth: maxLabelWidth }}>
             {this.artworkQuerySummaryString()}
           </SerifText>
-          <GhostButton text="REFINE" style={{ height: 26, width: refineButtonWidth }} onPress={this.refineTapped} />
+          <GhostButton
+            text="REFINE"
+            style={{ height: 26, width: refineButtonWidth }}
+            onPress={this.refineTapped.bind(this)}
+          />
         </View>
         <Separator style={{ backgroundColor: separatorColor }} />
       </View>

--- a/src/lib/Scenes/Favorites/__stories__/Favorites.story.tsx
+++ b/src/lib/Scenes/Favorites/__stories__/Favorites.story.tsx
@@ -13,7 +13,7 @@ import ArtworksRenderer from "../Components/Artworks/Relay/ArtworksRenderer"
 import CategoriesRenderer from "../Components/Categories/Relay/CategoriesRenderer"
 
 storiesOf("Favourites/Relay")
-  .add("Root", () => <Favourites />)
+  .add("Root", () => <Favourites tracking={trackingData => console.log(trackingData)} />)
   .add("Artists", () => <ArtistsRenderer render={renderWithLoadProgress(Artists)} />)
   .add("Artworks", () => <ArtworksRenderer render={renderWithLoadProgress(Artworks)} />)
   .add("Genes", () => <CategoriesRenderer render={renderWithLoadProgress(Categories)} />)

--- a/src/lib/Scenes/Favorites/index.tsx
+++ b/src/lib/Scenes/Favorites/index.tsx
@@ -32,15 +32,24 @@ const Title = styled.Text`
 
 const isStaging = gravityURL.includes("staging")
 
+const WorksTab = 0
+const ArtistsTab = 1
+const CategoriesTab = 2
+
+interface Props {
+  tracking: any
+}
+
 @screenTrack({
   context_screen: Schema.PageNames.SavesAndFollows,
   context_screen_owner_type: null,
 })
-class Favorites extends React.Component<null> {
+class Favorites extends React.Component<Props, null> {
   render() {
     return (
       <View style={{ flex: 1 }}>
         <ScrollableTabView
+          onChangeTab={selectedTab => this.fireTabSelectionAnalytics(selectedTab)}
           renderTabBar={props => (
             <View>
               <Title>Saves &amp; Follows</Title>
@@ -61,6 +70,22 @@ class Favorites extends React.Component<null> {
         {isStaging && <DarkNavigationButton title="Warning: on staging, favourites don't migrate" />}
       </View>
     )
+  }
+
+  fireTabSelectionAnalytics = selectedTab => {
+    let tabType
+
+    if (selectedTab.i === WorksTab) {
+      tabType = Schema.ActionNames.SavesAndFollowsWorks
+    } else if (selectedTab.i === ArtistsTab) {
+      tabType = Schema.ActionNames.SavesAndFollowsArtists
+    } else if (selectedTab.i === CategoriesTab) {
+      tabType = Schema.ActionNames.SavesAndFollowsCategories
+    }
+    this.props.tracking.trackEvent({
+      action_name: tabType,
+      action_type: Schema.ActionTypes.Tap,
+    })
   }
 }
 

--- a/src/lib/Scenes/Home/Components/ForYou/Components/ArtworkCarouselHeader.tsx
+++ b/src/lib/Scenes/Home/Components/ForYou/Components/ArtworkCarouselHeader.tsx
@@ -15,8 +15,6 @@ import {
 
 const { ARTemporaryAPIModule } = NativeModules
 
-import Events from "lib/NativeModules/Events"
-
 import { Schema, Track, track as _track } from "lib/utils/track"
 
 import Button from "lib/Components/Buttons/InvertedButton"

--- a/src/lib/Scenes/Home/Components/ForYou/Components/ArtworkCarouselHeader.tsx
+++ b/src/lib/Scenes/Home/Components/ForYou/Components/ArtworkCarouselHeader.tsx
@@ -17,6 +17,8 @@ const { ARTemporaryAPIModule } = NativeModules
 
 import Events from "lib/NativeModules/Events"
 
+import { Schema, Track, track as _track } from "lib/utils/track"
+
 import Button from "lib/Components/Buttons/InvertedButton"
 import SerifText from "lib/Components/Text/Serif"
 import colors from "lib/data/colors"
@@ -42,6 +44,9 @@ interface State {
   following: boolean
 }
 
+const track: Track<Props, State> = _track
+
+@track()
 class ArtworkCarouselHeader extends Component<Props & RelayPropsWorkaround, State> {
   constructor(props) {
     super(props)
@@ -86,26 +91,27 @@ class ArtworkCarouselHeader extends Component<Props & RelayPropsWorkaround, Stat
           <Button
             text={this.state.following ? "Following" : "Follow"}
             selected={this.state.following}
-            onPress={this.handleFollowChange}
+            onPress={this.handleFollowChange.bind(this)}
           />
         </View>
       )
     }
   }
 
-  handleFollowChange = () => {
+  @track(props => ({
+    action_name: Schema.ActionNames.HomeArtistArtworksBlockFollow,
+    action_type: Schema.ActionTypes.Tap,
+    owner_id: props.rail.context.artist._id,
+    owner_slug: props.rail.context.artist.id,
+    owner_type: Schema.OwnerEntityTypes.Artist,
+  }))
+  handleFollowChange() {
     const context = this.props.rail.context
     ARTemporaryAPIModule.setFollowArtistStatus(!this.state.following, context.artist.id, (error, following) => {
       if (error) {
         console.error("ArtworkCarouselHeader.tsx", error)
       } else {
-        Events.postEvent({
-          name: following ? "Follow artist" : "Unfollow artist",
-          artist_id: context.artist.id,
-          artist_slug: context.artist.id,
-          source_screen: "home page",
-          context_module: "random suggested artist",
-        })
+        // success
       }
       this.setState({ following })
     })
@@ -157,6 +163,7 @@ export default createFragmentContainer(
       context {
         ... on HomePageModuleContextRelatedArtist {
           artist {
+            _id
             id
           }
           based_on {
@@ -172,9 +179,13 @@ interface RelayProps {
   rail: {
     title: string | null
     key: string | null
-    context: Array<boolean | number | string | null> | null
+    context: any
   }
 }
+
+// FIXME: What is this workaround? Can we stop using it?
+// Also the context in RelayProps above was set to be an array, now cast to "any" for release
+// Should figure out why
 interface RelayPropsWorkaround {
   rail: {
     context: any

--- a/src/lib/utils/track.ts
+++ b/src/lib/utils/track.ts
@@ -85,6 +85,7 @@ export namespace Schema {
     ConsignmentsWelcome = "ConsignmentsWelcome",
     ConsignmentsOverView = "ConsignmentsOverview",
     ConsignmentsSubmission = "ConsignmentsSubmit",
+    GenePage = "Gene",
     InboxPage = "Inbox",
     InquiryPage = "Inquiry",
     HomeArtistsWorksForYou = "HomeArtistsWorksForYou",
@@ -125,6 +126,15 @@ export namespace Schema {
      */
     ArtistFollow = "artistFollow",
     ArtistUnfollow = "artistUnfollow",
+
+    /**
+     * Gene Page Events
+     */
+    GeneAbout = "geneAbout",
+    GeneFollow = "geneFollow",
+    GeneUnfollow = "geneUnfollow",
+    GeneWorks = "geneWorks",
+    Refine = "geneRefine",
 
     /**
      * Conversations / Inbox / Messaging Events
@@ -274,7 +284,8 @@ export const track: Track = _track
  */
 export function screenTrack<P>(trackingInfo: TrackingInfo<Schema.PageView, P, null>) {
   return _track(trackingInfo as any, {
-    dispatch: data => Events.postEvent(data),
+    // dispatch: data => Events.postEvent(data),
+    dispatch: data => console.log(data),
     dispatchOnMount: true,
   })
 }

--- a/src/lib/utils/track.ts
+++ b/src/lib/utils/track.ts
@@ -137,6 +137,12 @@ export namespace Schema {
     Refine = "geneRefine",
 
     /**
+     * Home page events
+     */
+    HomeArtistRailFollow = "homeArtistRailFollow",
+    HomeArtistArtworksBlockFollow = "homeArtistArtworksBlockFollow",
+
+    /**
      * Conversations / Inbox / Messaging Events
      */
     ConversationSelected = "conversationSelected",
@@ -151,9 +157,9 @@ export namespace Schema {
     /**
      *  Saves And Follows Events
      */
-    SavesAndFollowsWorks = "SavesAndFollowsWorks",
-    SavesAndFollowsArtists = "SavesAndFollowsArtists",
-    SavesAndFollowsCategories = "SavesAndFollowsCategories",
+    SavesAndFollowsWorks = "savesAndFollowsWorks",
+    SavesAndFollowsArtists = "savesAndFollowsArtists",
+    SavesAndFollowsCategories = "savesAndFollowsCategories",
 
     /**
      *  Consignment flow

--- a/src/lib/utils/track.ts
+++ b/src/lib/utils/track.ts
@@ -297,8 +297,7 @@ export const track: Track = _track
  */
 export function screenTrack<P>(trackingInfo: TrackingInfo<Schema.PageView, P, null>) {
   return _track(trackingInfo as any, {
-    // dispatch: data => Events.postEvent(data),
-    dispatch: data => console.log(data),
+    dispatch: data => Events.postEvent(data),
     dispatchOnMount: true,
   })
 }

--- a/src/lib/utils/track.ts
+++ b/src/lib/utils/track.ts
@@ -149,6 +149,13 @@ export namespace Schema {
     InquirySend = "inquirySend",
 
     /**
+     *  Saves And Follows Events
+     */
+    SavesAndFollowsWorks = "SavesAndFollowsWorks",
+    SavesAndFollowsArtists = "SavesAndFollowsArtists",
+    SavesAndFollowsCategories = "SavesAndFollowsCategories",
+
+    /**
      *  Consignment flow
      */
     ConsignmentDraftCreated = "consignmentDraftCreated",


### PR DESCRIPTION
Fix https://github.com/artsy/collector-experience/issues/885

Tracks:
- Tab switches in Saves and Follows
- Follow of artist on artist rail in Home
- Follow of suggested artworks by an artist in Home
- Gene screen view
- Gene refine tap
- Gene tab switching (between works and about)
- Gene follow / unfollow

✨ 

I think that's all folks! 

