### PR TITLE
[Consignments] Sets the default option when you first select a category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Master
 
 * Fix a bug where edition screen was considered seen based on metadata props - maxim
+* Fix for selecting a painting in consignments - orta
 
 ### 1.4.0-rc.0
 

--- a/src/lib/Components/Consignments/Screens/Metadata.tsx
+++ b/src/lib/Components/Consignments/Screens/Metadata.tsx
@@ -99,7 +99,10 @@ export default class Metadata extends React.Component<Props, State> {
 
   showCategorySelection = () => {
     Keyboard.dismiss()
-    this.animateStateChange({ showPicker: true })
+
+    const category = this.state.category || categoryOptions[0].value
+    const categoryName = this.state.categoryName || categoryOptions[0].name
+    this.animateStateChange({ showPicker: true, categoryName, category })
   }
 
   hideCategorySelection = () => this.animateStateChange({ showPicker: false })

--- a/src/lib/Components/Consignments/Screens/__tests__/Metadata-tests.tsx
+++ b/src/lib/Components/Consignments/Screens/__tests__/Metadata-tests.tsx
@@ -50,7 +50,6 @@ describe("state", () => {
 
       metadata.setState = partial => (metadata.state = Object.assign({}, originalState, partial))
     })
-
     it("updates the year", () => {
       metadata.updateYear("1985")
       expect(metadata.state).toMatchDiffSnapshot(originalState)
@@ -78,5 +77,20 @@ describe("state", () => {
 
       expect(originalState).toMatchDiffSnapshot(metadata.state)
     })
+  })
+
+  it("sets the category state to the first when you start selecting if it's null", () => {
+    const metadata = new Metadata({ metadata: {} })
+    metadata.animateStateChange = partial => (metadata.state = Object.assign({}, {}, partial))
+    metadata.showCategorySelection()
+    expect(metadata.state).toEqual({ category: "PAINTING", categoryName: "Painting", showPicker: true })
+  })
+
+  it("doesn't overwrite the category state when you start selecting a category", () => {
+    const originalState = { category: "DESIGN", categoryName: "Design" }
+    const metadata = new Metadata({ metadata: originalState })
+    metadata.animateStateChange = partial => (metadata.state = Object.assign({}, originalState, partial))
+    metadata.showCategorySelection()
+    expect(metadata.state).toEqual({ category: "DESIGN", categoryName: "Design", showPicker: true })
   })
 })


### PR DESCRIPTION
Fixes https://github.com/artsy/collector-experience/issues/894

When you start selecting the categories, painting is now set in the state without you doing anything as the onselect trigger on happens when you change selection.