### PR TITLE
[Consignments] Add height and width as requirements for submission to match force

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 * Fix a bug where edition screen was considered seen based on metadata props - maxim
 * Fix for selecting a painting in consignments - orta
+* Fix submission requirements for consignments to match force - orta/maxim
 
 ### 1.4.0-rc.0
 

--- a/src/lib/Components/Consignments/Components/ArtworkConsignmentTodo.tsx
+++ b/src/lib/Components/Consignments/Components/ArtworkConsignmentTodo.tsx
@@ -113,7 +113,13 @@ const render = (props: TODOProps, canSubmitMetadata: boolean) => (
 
 export default class ConsignmentTODO extends React.Component<TODOProps, null> {
   canSubmitMetadata = props =>
-    props.metadata && props.metadata.category && props.metadata.title && props.metadata.year && props.metadata.medium
+    props.metadata &&
+    props.metadata.category &&
+    props.metadata.title &&
+    props.metadata.year &&
+    props.metadata.medium &&
+    props.metadata.height &&
+    props.metadata.width
 
   render() {
     return render(this.props, this.canSubmitMetadata(this.props))

--- a/src/lib/Components/Consignments/Screens/Overview.tsx
+++ b/src/lib/Components/Consignments/Screens/Overview.tsx
@@ -201,6 +201,8 @@ export default class Info extends React.Component<Props, State> {
       this.state.metadata.title &&
       this.state.metadata.year &&
       this.state.metadata.medium &&
+      this.state.metadata.height &&
+      this.state.metadata.width &&
       this.state.editionScreenViewed
     )
 


### PR DESCRIPTION
Wraps up https://github.com/artsy/collector-experience/issues/895

Height and width were the only two ones we were still missing :)

We now check for:
```
      this.state.artist &&
      this.state.location &&
      this.state.metadata &&
      this.state.metadata.category &&
      this.state.metadata.title &&
      this.state.metadata.year &&
      this.state.metadata.medium &&
      this.state.metadata.height &&
      this.state.metadata.width &&
      this.state.editionScreenViewed
```

As per:

![34785835-4f45e802-f600-11e7-90f9-e2d2ec6e1249](https://user-images.githubusercontent.com/373860/34820738-52005230-f6b9-11e7-98ee-0728386da375.png)
