### PR TITLE
[Home/Auction] Update LotsByFollowedArtist filter logic 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix for selecting a painting in consignments - orta
 * Fix submission requirements for consignments to match force - orta/maxim
 * Add auto focus to the work details / metadata screen - maxim
+* Fix filter logic around sale works by followed artists - chris
 
 ### 1.4.0-rc.0-2
 

--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -92,7 +92,16 @@ type Artist implements Node {
     exclude: [String]
   ): [Artwork]
   artworks_connection(sort: ArtworkSorts, filter: [ArtistArtworksFilters], published: Boolean = true, after: String, first: Int, before: String, last: Int): ArtworkConnection
-  auctionResults(sort: AuctionResultSorts, after: String, first: Int, before: String, last: Int): AuctionResultConnection
+  auctionResults(
+    sort: AuctionResultSorts
+
+    # When true, will only return records for whitelisted artists.
+    recordsTrusted: Boolean = false
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): AuctionResultConnection
   bio: String
 
   # The Artist biography article written by Artsy
@@ -292,7 +301,16 @@ type ArtistItem implements Node {
     exclude: [String]
   ): [Artwork]
   artworks_connection(sort: ArtworkSorts, filter: [ArtistArtworksFilters], published: Boolean = true, after: String, first: Int, before: String, last: Int): ArtworkConnection
-  auctionResults(sort: AuctionResultSorts, after: String, first: Int, before: String, last: Int): AuctionResultConnection
+  auctionResults(
+    sort: AuctionResultSorts
+
+    # When true, will only return records for whitelisted artists.
+    recordsTrusted: Boolean = false
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): AuctionResultConnection
   bio: String
 
   # The Artist biography article written by Artsy
@@ -425,7 +443,16 @@ type ArtistSearchEntity implements Node {
     exclude: [String]
   ): [Artwork]
   artworks_connection(sort: ArtworkSorts, filter: [ArtistArtworksFilters], published: Boolean = true, after: String, first: Int, before: String, last: Int): ArtworkConnection
-  auctionResults(sort: AuctionResultSorts, after: String, first: Int, before: String, last: Int): AuctionResultConnection
+  auctionResults(
+    sort: AuctionResultSorts
+
+    # When true, will only return records for whitelisted artists.
+    recordsTrusted: Boolean = false
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): AuctionResultConnection
   bio: String
 
   # The Artist biography article written by Artsy
@@ -760,6 +787,7 @@ type ArtworkContextAuction implements Node {
   # Returns a live auctions url if the sale is open and start time is after now
   live_url_if_open: String
   profile: Profile
+  promoted_sale: Sale
   registration_ends_at(
     convert_to_utc: Boolean
     format: String
@@ -996,6 +1024,7 @@ type ArtworkContextSale implements Node {
   # Returns a live auctions url if the sale is open and start time is after now
   live_url_if_open: String
   profile: Profile
+  promoted_sale: Sale
   registration_ends_at(
     convert_to_utc: Boolean
     format: String
@@ -1510,39 +1539,7 @@ type AuctionResult implements Node {
   description: String
   external_url: String
   images: AuctionLotImages
-
-  # A formatted price with various currency formatting options.
-  low_estimate(
-    decimal: String = "."
-
-    # Allows control of symbol position (%v = value, %s = symbol)
-    format: String = "%s%v"
-    precision: Int = 0
-    symbol: String
-    thousand: String = ","
-  ): String
-
-  # A formatted price with various currency formatting options.
-  high_estimate(
-    decimal: String = "."
-
-    # Allows control of symbol position (%v = value, %s = symbol)
-    format: String = "%s%v"
-    precision: Int = 0
-    symbol: String
-    thousand: String = ","
-  ): String
-
-  # A formatted price with various currency formatting options.
-  price_realized(
-    decimal: String = "."
-
-    # Allows control of symbol position (%v = value, %s = symbol)
-    format: String = "%s%v"
-    precision: Int = 0
-    symbol: String
-    thousand: String = ","
-  ): String
+  price_realized: AuctionResultPriceRealized
 }
 
 # A connection to a list of items.
@@ -1561,6 +1558,15 @@ type AuctionResultEdge {
 
   # A cursor for use in pagination
   cursor: String!
+}
+
+type AuctionResultPriceRealized {
+  cents: Int
+  cents_usd: Int
+  display(
+    # Passes in to numeral, such as `'0.00'`
+    format: String = ""
+  ): String
 }
 
 enum AuctionResultSorts {
@@ -2417,6 +2423,9 @@ type FollowArtistPayload {
   popular_artists(
     # If true, will exclude followed artists for the user
     exclude_followed_artists: Boolean
+
+    # Exclude these ids from results, may result in all artists being excluded.
+    exclude_artist_ids: [String]
 
     # Number of results to return
     size: Int
@@ -3318,6 +3327,7 @@ type HomePageModuleContextSale implements Node {
   # Returns a live auctions url if the sale is open and start time is after now
   live_url_if_open: String
   profile: Profile
+  promoted_sale: Sale
   registration_ends_at(
     convert_to_utc: Boolean
     format: String
@@ -4620,6 +4630,9 @@ type Query {
     # If true, will exclude followed artists for the user
     exclude_followed_artists: Boolean
 
+    # Exclude these ids from results, may result in all artists being excluded.
+    exclude_artist_ids: [String]
+
     # Number of results to return
     size: Int
   ): PopularArtists
@@ -4781,6 +4794,7 @@ type Sale implements Node {
   # Returns a live auctions url if the sale is open and start time is after now
   live_url_if_open: String
   profile: Profile
+  promoted_sale: Sale
   registration_ends_at(
     convert_to_utc: Boolean
     format: String
@@ -5899,6 +5913,9 @@ type Viewer {
   popular_artists(
     # If true, will exclude followed artists for the user
     exclude_followed_artists: Boolean
+
+    # Exclude these ids from results, may result in all artists being excluded.
+    exclude_artist_ids: [String]
 
     # Number of results to return
     size: Int

--- a/data/schema.json
+++ b/data/schema.json
@@ -541,7 +541,8 @@
                 },
                 {
                   "name": "partner_categories",
-                  "description": "\n        Only return partners of the specified partner categories.\n        Accepts list of slugs.\n      ",
+                  "description":
+                    "\n        Only return partners of the specified partner categories.\n        Accepts list of slugs.\n      ",
                   "type": {
                     "kind": "LIST",
                     "name": null,
@@ -1752,7 +1753,8 @@
                 },
                 {
                   "name": "partner_categories",
-                  "description": "\n        Only return partners of the specified partner categories.\n        Accepts list of slugs.\n      ",
+                  "description":
+                    "\n        Only return partners of the specified partner categories.\n        Accepts list of slugs.\n      ",
                   "type": {
                     "kind": "LIST",
                     "name": null,
@@ -2301,6 +2303,20 @@
                   "defaultValue": null
                 },
                 {
+                  "name": "exclude_artist_ids",
+                  "description": "Exclude these ids from results, may result in all artists being excluded.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "size",
                   "description": "Number of results to return",
                   "type": {
@@ -2340,7 +2356,8 @@
         {
           "kind": "SCALAR",
           "name": "String",
-          "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
+          "description":
+            "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -2829,7 +2846,8 @@
         {
           "kind": "SCALAR",
           "name": "ID",
-          "description": "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID.",
+          "description":
+            "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -2839,7 +2857,8 @@
         {
           "kind": "SCALAR",
           "name": "Int",
-          "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1. ",
+          "description":
+            "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1. ",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -3362,7 +3381,8 @@
         {
           "kind": "SCALAR",
           "name": "Float",
-          "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point). ",
+          "description":
+            "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point). ",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -5248,6 +5268,16 @@
                   "defaultValue": null
                 },
                 {
+                  "name": "recordsTrusted",
+                  "description": "When true, will only return records for whitelisted artists.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false"
+                },
+                {
                   "name": "after",
                   "description": null,
                   "type": {
@@ -6924,189 +6954,12 @@
               "deprecationReason": null
             },
             {
-              "name": "low_estimate",
-              "description": "A formatted price with various currency formatting options.",
-              "args": [
-                {
-                  "name": "decimal",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": "\".\""
-                },
-                {
-                  "name": "format",
-                  "description": "Allows control of symbol position (%v = value, %s = symbol)",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": "\"%s%v\""
-                },
-                {
-                  "name": "precision",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": "0"
-                },
-                {
-                  "name": "symbol",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "thousand",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": "\",\""
-                }
-              ],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "high_estimate",
-              "description": "A formatted price with various currency formatting options.",
-              "args": [
-                {
-                  "name": "decimal",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": "\".\""
-                },
-                {
-                  "name": "format",
-                  "description": "Allows control of symbol position (%v = value, %s = symbol)",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": "\"%s%v\""
-                },
-                {
-                  "name": "precision",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": "0"
-                },
-                {
-                  "name": "symbol",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "thousand",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": "\",\""
-                }
-              ],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "price_realized",
-              "description": "A formatted price with various currency formatting options.",
-              "args": [
-                {
-                  "name": "decimal",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": "\".\""
-                },
-                {
-                  "name": "format",
-                  "description": "Allows control of symbol position (%v = value, %s = symbol)",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": "\"%s%v\""
-                },
-                {
-                  "name": "precision",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": "0"
-                },
-                {
-                  "name": "symbol",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "thousand",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": "\",\""
-                }
-              ],
+              "description": null,
+              "args": [],
               "type": {
-                "kind": "SCALAR",
-                "name": "String",
+                "kind": "OBJECT",
+                "name": "AuctionResultPriceRealized",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -7195,6 +7048,64 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Image",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "AuctionResultPriceRealized",
+          "description": null,
+          "fields": [
+            {
+              "name": "cents",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cents_usd",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "display",
+              "description": null,
+              "args": [
+                {
+                  "name": "format",
+                  "description": "Passes in to numeral, such as `'0.00'`",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": "\"\""
+                }
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -7492,7 +7403,8 @@
         {
           "kind": "SCALAR",
           "name": "FormattedNumber",
-          "description": "The `FormattedNumber` type represents a number that can optionally be returnedas a formatted String. It does not try to coerce the type.",
+          "description":
+            "The `FormattedNumber` type represents a number that can optionally be returnedas a formatted String. It does not try to coerce the type.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -12785,6 +12697,18 @@
               "deprecationReason": null
             },
             {
+              "name": "promoted_sale",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Sale",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "registration_ends_at",
               "description": null,
               "args": [
@@ -15349,6 +15273,18 @@
               "deprecationReason": null
             },
             {
+              "name": "promoted_sale",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Sale",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "registration_ends_at",
               "description": null,
               "args": [
@@ -17212,6 +17148,18 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Profile",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "promoted_sale",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Sale",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -24837,6 +24785,18 @@
               "deprecationReason": null
             },
             {
+              "name": "promoted_sale",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Sale",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "registration_ends_at",
               "description": null,
               "args": [
@@ -29144,7 +29104,8 @@
             },
             {
               "name": "reply_to_impulse_ids",
-              "description": "An array of Impulse IDs that correspond to all email addresses that messages should be sent to",
+              "description":
+                "An array of Impulse IDs that correspond to all email addresses that messages should be sent to",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -31546,6 +31507,16 @@
                     "ofType": null
                   },
                   "defaultValue": null
+                },
+                {
+                  "name": "recordsTrusted",
+                  "description": "When true, will only return records for whitelisted artists.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false"
                 },
                 {
                   "name": "after",
@@ -35010,7 +34981,8 @@
                 },
                 {
                   "name": "partner_categories",
-                  "description": "\n        Only return partners of the specified partner categories.\n        Accepts list of slugs.\n      ",
+                  "description":
+                    "\n        Only return partners of the specified partner categories.\n        Accepts list of slugs.\n      ",
                   "type": {
                     "kind": "LIST",
                     "name": null,
@@ -35712,6 +35684,16 @@
                     "ofType": null
                   },
                   "defaultValue": null
+                },
+                {
+                  "name": "recordsTrusted",
+                  "description": "When true, will only return records for whitelisted artists.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false"
                 },
                 {
                   "name": "after",
@@ -39921,7 +39903,8 @@
                 },
                 {
                   "name": "partner_categories",
-                  "description": "\n        Only return partners of the specified partner categories.\n        Accepts list of slugs.\n      ",
+                  "description":
+                    "\n        Only return partners of the specified partner categories.\n        Accepts list of slugs.\n      ",
                   "type": {
                     "kind": "LIST",
                     "name": null,
@@ -41132,7 +41115,8 @@
                 },
                 {
                   "name": "partner_categories",
-                  "description": "\n        Only return partners of the specified partner categories.\n        Accepts list of slugs.\n      ",
+                  "description":
+                    "\n        Only return partners of the specified partner categories.\n        Accepts list of slugs.\n      ",
                   "type": {
                     "kind": "LIST",
                     "name": null,
@@ -41681,6 +41665,20 @@
                   "defaultValue": null
                 },
                 {
+                  "name": "exclude_artist_ids",
+                  "description": "Exclude these ids from results, may result in all artists being excluded.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "size",
                   "description": "Number of results to return",
                   "type": {
@@ -42109,6 +42107,20 @@
                     "kind": "SCALAR",
                     "name": "Boolean",
                     "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "exclude_artist_ids",
+                  "description": "Exclude these ids from results, may result in all artists being excluded.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
                   },
                   "defaultValue": null
                 },
@@ -43541,7 +43553,8 @@
             },
             {
               "name": "metadata",
-              "description": "Additional JSON data to pass through gemini, should deiinitely contain an `id` and a `_type`",
+              "description":
+                "Additional JSON data to pass through gemini, should deiinitely contain an `id` and a `_type`",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -43571,7 +43584,8 @@
         {
           "kind": "SCALAR",
           "name": "JSON",
-          "description": "The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).",
+          "description":
+            "The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -44338,7 +44352,8 @@
         {
           "kind": "OBJECT",
           "name": "__Schema",
-          "description": "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
+          "description":
+            "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
           "fields": [
             {
               "name": "types",
@@ -44394,7 +44409,8 @@
             },
             {
               "name": "subscriptionType",
-              "description": "If this server support subscription, the type that subscription operations will be rooted at.",
+              "description":
+                "If this server support subscription, the type that subscription operations will be rooted at.",
               "args": [],
               "type": {
                 "kind": "OBJECT",
@@ -44437,7 +44453,8 @@
         {
           "kind": "OBJECT",
           "name": "__Type",
-          "description": "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
+          "description":
+            "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
           "fields": [
             {
               "name": "kind",
@@ -44681,7 +44698,8 @@
         {
           "kind": "OBJECT",
           "name": "__Field",
-          "description": "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
+          "description":
+            "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
           "fields": [
             {
               "name": "name",
@@ -44788,7 +44806,8 @@
         {
           "kind": "OBJECT",
           "name": "__InputValue",
-          "description": "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
+          "description":
+            "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
           "fields": [
             {
               "name": "name",
@@ -44855,7 +44874,8 @@
         {
           "kind": "OBJECT",
           "name": "__EnumValue",
-          "description": "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
+          "description":
+            "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
           "fields": [
             {
               "name": "name",
@@ -44922,7 +44942,8 @@
         {
           "kind": "OBJECT",
           "name": "__Directive",
-          "description": "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
+          "description":
+            "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
           "fields": [
             {
               "name": "name",
@@ -45057,7 +45078,8 @@
         {
           "kind": "ENUM",
           "name": "__DirectiveLocation",
-          "description": "A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.",
+          "description":
+            "A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -45178,11 +45200,7 @@
         {
           "name": "include",
           "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
-          "locations": [
-            "FIELD",
-            "FRAGMENT_SPREAD",
-            "INLINE_FRAGMENT"
-          ],
+          "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
           "args": [
             {
               "name": "if",
@@ -45203,11 +45221,7 @@
         {
           "name": "skip",
           "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
-          "locations": [
-            "FIELD",
-            "FRAGMENT_SPREAD",
-            "INLINE_FRAGMENT"
-          ],
+          "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
           "args": [
             {
               "name": "if",
@@ -45228,14 +45242,12 @@
         {
           "name": "deprecated",
           "description": "Marks an element of a GraphQL schema as no longer supported.",
-          "locations": [
-            "FIELD_DEFINITION",
-            "ENUM_VALUE"
-          ],
+          "locations": ["FIELD_DEFINITION", "ENUM_VALUE"],
           "args": [
             {
               "name": "reason",
-              "description": "Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted in [Markdown](https://daringfireball.net/projects/markdown/).",
+              "description":
+                "Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted in [Markdown](https://daringfireball.net/projects/markdown/).",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",

--- a/src/lib/Scenes/Home/Components/Sales/Components/__tests__/LotsByFollowedArtists-tests.tsx
+++ b/src/lib/Scenes/Home/Components/Sales/Components/__tests__/LotsByFollowedArtists-tests.tsx
@@ -22,7 +22,9 @@ describe("LotsByFollowedArtists", () => {
             {
               node: {
                 name: "TestName",
-                is_biddable: true,
+                sale: {
+                  is_open: true,
+                },
                 artwork: {
                   id: "foo",
                 },

--- a/src/lib/Scenes/Home/Components/Sales/__tests__/__snapshots__/index-tests.tsx.snap
+++ b/src/lib/Scenes/Home/Components/Sales/__tests__/__snapshots__/index-tests.tsx.snap
@@ -778,7 +778,57 @@ exports[`looks correct when rendered 1`] = `
     <View
       onLayout={[Function]}
       style={null}
-    />
+    >
+      <
+        title="Lots by Artists You Follow"
+        viewer={
+          Object {
+            "sale_artworks": Object {
+              "edges": Array [
+                Object {
+                  "node": Object {
+                    "id": "foo",
+                  },
+                },
+              ],
+              "pageInfo": Object {},
+            },
+            "sales": Array [
+              Object {
+                "cover_image": Object {
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/WV-7BYlETayN8MGkNjOGXw/source.jpg",
+                },
+                "display_timely_at": "In Progress",
+                "end_at": null,
+                "href": "/auction/wright-noma",
+                "id": "wright-noma",
+                "is_live_open": true,
+                "is_open": true,
+                "live_start_at": "2017-11-02T13:00:00+00:00",
+                "name": "Wright: noma",
+                "registration_ends_at": "2017-11-01T13:00:00+00:00",
+                "start_at": "2017-10-16T22:00:00+00:00",
+              },
+              Object {
+                "cover_image": Object {
+                  "url": "https://d32dm0rphc51dk.cloudfront.net/eeqLfwMMAYA8XOmeYEb7Rg/source.jpg",
+                },
+                "display_timely_at": "In Progress",
+                "end_at": null,
+                "href": "/auction/freemans-modern-and-contemporary-works-of-art",
+                "id": "freemans-modern-and-contemporary-works-of-art",
+                "is_live_open": false,
+                "is_open": true,
+                "live_start_at": "2017-11-02T17:00:00+00:00",
+                "name": "Freeman's: Modern & Contemporary Works of Art",
+                "registration_ends_at": "2017-11-01T17:00:00+00:00",
+                "start_at": "2017-10-17T15:00:00+00:00",
+              },
+            ],
+          }
+        }
+      />
+    </View>
     <View
       onLayout={[Function]}
       style={null}

--- a/src/lib/Scenes/Home/Components/Sales/__tests__/index-tests.tsx
+++ b/src/lib/Scenes/Home/Components/Sales/__tests__/index-tests.tsx
@@ -6,6 +6,7 @@ import Sales from "../index"
 
 jest.mock("WebView", () => "WebView")
 jest.mock("../Components/ZeroState/index.html", () => "")
+jest.mock("../Components/LotsByFollowedArtists", () => "")
 
 it("renders the ZeroState when there are no sales", () => {
   const auctions = shallow(<Sales {...Object.assign({}, props, { viewer: { sales: [] } })} />)


### PR DESCRIPTION
Fixes https://github.com/artsy/collector-experience/issues/904

Initially we were checking for `is_biddable` in returning sale works by followed artists but this only applied to lots that were _immediately_ biddable. What we should be checking is whether a sale `is_open`. 