### PR TITLE
[Analytics] Get rid of double fire upon entering background state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 * Fix loading indicator not hiding in Auctions tab of Home view - luc
 * Fix gene view pagination - alloy
+* Fix home page analytics double fire upon entering background - maxim
 
 ### 1.4.0-rc.4
 

--- a/src/lib/Scenes/Home/index.tsx
+++ b/src/lib/Scenes/Home/index.tsx
@@ -80,7 +80,7 @@ export default class Home extends React.Component<Props, State> {
     if (this.props.selectedArtist && this.state.appState.match(/inactive|background/) && nextAppState === "active") {
       this.tabView.goToPage(ArtistsWorksForYouTab)
     }
-    this.setState({ appState: nextAppState, selectedTab: ArtistsWorksForYouTab })
+    this.setState({ appState: nextAppState })
   }
 
   render() {

--- a/src/lib/Scenes/Home/index.tsx
+++ b/src/lib/Scenes/Home/index.tsx
@@ -80,7 +80,7 @@ export default class Home extends React.Component<Props, State> {
     if (this.props.selectedArtist && this.state.appState.match(/inactive|background/) && nextAppState === "active") {
       this.tabView.goToPage(ArtistsWorksForYouTab)
     }
-    this.setState({ appState: nextAppState, selectedTab: ArtistsWorksForYouTab }, this.fireHomeScreenViewAnalytics)
+    this.setState({ appState: nextAppState, selectedTab: ArtistsWorksForYouTab })
   }
 
   render() {


### PR DESCRIPTION
Fix https://github.com/artsy/collector-experience/issues/909

Issue was that when setting state, I was also calling analytics (and incorrectly setting the state of the tab). Actually, the `if` statement above takes care of it. If it goes to the Artists WFY page, then from that state change the analytics will fire anyway. No need to keep it in the `setState` below. 

