### PR TITLE
[Bugfix] Swap Home/Auctions sort order #trivial

### DIFF
--- a/src/lib/Scenes/Home/Components/Sales/index.tsx
+++ b/src/lib/Scenes/Home/Components/Sales/index.tsx
@@ -93,7 +93,7 @@ export default createRefetchContainer(
   Sales,
   graphql`
     fragment Sales_viewer on Viewer {
-      sales(live: true, is_auction: true, size: 100, sort: TIMELY_AT_NAME_DESC) {
+      sales(live: true, is_auction: true, size: 100, sort: TIMELY_AT_NAME_ASC) {
         ...SaleListItem_sale
         href
         live_start_at


### PR DESCRIPTION
Sorts Auction list by `TIMELY_AT_NAME_ASC` rather than `TIMELY_AT_NAME_DESC`:

Danger: #trivial

![sort](https://user-images.githubusercontent.com/236943/35127674-129f2f62-fc68-11e7-8622-2cd155d6e157.gif)
