### PR TITLE
Emulate how eigen handles status bars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 ## Master
 
 * Fixed the ordering of Home/Auctions - damassi
+* Fixes some top margins for iPhone X support - orta
+* [Dev] Emulates how Eigen handles status bars - orta
 
 ### 1.4.0
 

--- a/Example/Emission.xcodeproj/project.pbxproj
+++ b/Example/Emission.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		6011C24E1DAF697B00CE54E5 /* EigenLikeAdminViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 6011C24D1DAF697B00CE54E5 /* EigenLikeAdminViewController.m */; };
 		6011C2511DAF7B6D00CE54E5 /* UnroutedViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 6011C2501DAF7B6D00CE54E5 /* UnroutedViewController.m */; };
 		6011C2561DAF835900CE54E5 /* logo@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6011C2551DAF835900CE54E5 /* logo@2x.png */; };
+		60218E2920168D4E00A6C66B /* ARTopMenuViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 60218E2820168D4E00A6C66B /* ARTopMenuViewController.m */; };
 		605E32A51F3A0F0C00CFFE21 /* TakePhotoPromisable.m in Sources */ = {isa = PBXBuildFile; fileRef = 605E32A41F3A0F0C00CFFE21 /* TakePhotoPromisable.m */; };
 		608A60D61F75614700B6EF83 /* AppSetup.m in Sources */ = {isa = PBXBuildFile; fileRef = 608A60D51F75614700B6EF83 /* AppSetup.m */; };
 		608C6DBB1FA263290044E235 /* CommitNetworkModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 608C6DBA1FA263290044E235 /* CommitNetworkModel.m */; };
@@ -94,6 +95,8 @@
 		6011C2501DAF7B6D00CE54E5 /* UnroutedViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UnroutedViewController.m; sourceTree = "<group>"; };
 		6011C2551DAF835900CE54E5 /* logo@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "logo@2x.png"; sourceTree = "<group>"; };
 		60204ADD1D9D590900204628 /* Emission.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Emission.entitlements; sourceTree = "<group>"; };
+		60218E2720168D4E00A6C66B /* ARTopMenuViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ARTopMenuViewController.h; sourceTree = "<group>"; };
+		60218E2820168D4E00A6C66B /* ARTopMenuViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTopMenuViewController.m; sourceTree = "<group>"; };
 		605E32A31F3A0F0C00CFFE21 /* TakePhotoPromisable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = TakePhotoPromisable.h; path = Modules/TakePhotoPromisable.h; sourceTree = "<group>"; };
 		605E32A41F3A0F0C00CFFE21 /* TakePhotoPromisable.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = TakePhotoPromisable.m; path = Modules/TakePhotoPromisable.m; sourceTree = "<group>"; };
 		607673A21ECC4C9F005848B5 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
@@ -303,6 +306,8 @@
 				60A1A77A1DA3A230005E3357 /* Resources */,
 				51F3E9A21CF3B8A4004A2013 /* EigenLikeNavigationController.h */,
 				51F3E9A31CF3B8A4004A2013 /* EigenLikeNavigationController.m */,
+				60218E2720168D4E00A6C66B /* ARTopMenuViewController.h */,
+				60218E2820168D4E00A6C66B /* ARTopMenuViewController.m */,
 			);
 			name = Navigation;
 			sourceTree = "<group>";
@@ -616,6 +621,7 @@
 				6011C2461DAF61AF00CE54E5 /* ARTickedTableViewCell.m in Sources */,
 				60AE1D801EE7DF9C00FC800A /* PRNetworkModel.m in Sources */,
 				60E4ABF71EE7D85000E8C3B1 /* LoadingSpinner.m in Sources */,
+				60218E2920168D4E00A6C66B /* ARTopMenuViewController.m in Sources */,
 				60F61A8B1DAF982B00A72101 /* AuthenticationManager.m in Sources */,
 				608A60D61F75614700B6EF83 /* AppSetup.m in Sources */,
 				6011C2471DAF61AF00CE54E5 /* ARAnimatedTickView.m in Sources */,

--- a/Example/Emission/ARTopMenuViewController.h
+++ b/Example/Emission/ARTopMenuViewController.h
@@ -1,0 +1,7 @@
+#import <UIKit/UIKit.h>
+
+@interface ARTopMenuViewController : UIViewController
+
+- (instancetype) initWithNavigationController:(UINavigationController *)controller;
+
+@end

--- a/Example/Emission/ARTopMenuViewController.m
+++ b/Example/Emission/ARTopMenuViewController.m
@@ -1,0 +1,70 @@
+#import "ARTopMenuViewController.h"
+#import <FLKAutoLayout/FLKAutoLayout.h>
+
+@interface ARTopMenuViewController ()
+@property (nonatomic, strong) UINavigationController *nav;
+@property (nonatomic, strong) UIView *statusBarView;
+@property (nonatomic, strong) NSLayoutConstraint *statusBarVerticalConstraint;
+
+@end
+
+@implementation ARTopMenuViewController
+
+- (instancetype) initWithNavigationController:(UINavigationController *)controller
+{
+  self = [super init];
+  if (!self) { return nil; }
+
+  _nav = controller;
+  return self;
+}
+
+- (void)viewDidLoad
+{
+  [super viewDidLoad];
+
+  _statusBarView = [[UIView alloc] init];
+  _statusBarView.backgroundColor = UIColor.whiteColor;
+
+  [self.view addSubview:_statusBarView];
+
+  // Just a default value
+  _statusBarVerticalConstraint = [_statusBarView constrainHeight:@"20"];
+  [_statusBarView constrainWidthToView:self.view predicate:@"0"];
+  [_statusBarView alignTopEdgeWithView:self.view predicate:@"0"];
+  [_statusBarView alignLeadingEdgeWithView:self.view predicate:@"0"];
+
+  // Add the nav to our VC
+  [self.nav willMoveToParentViewController:self];
+  [self addChildViewController:self.nav];
+  [self.view addSubview:self.nav.view];
+  [self.nav didMoveToParentViewController:self];
+  [self addChildViewController:self.nav];
+
+  [self.nav.view constrainTopSpaceToView:_statusBarView predicate:@"0"];
+  [self.nav.view alignBottom:@"0" trailing:@"0" toView:self.view];
+  [self.nav.view constrainWidthToView:self.view predicate:@"0"];
+}
+
+- (CGFloat)statusBarHeight
+{
+  // iPhone X support
+  if (@available(iOS 11.0, *)) {
+    return self.view.safeAreaInsets.top;
+  } else {
+    return 20;
+  }
+}
+
+// safeAreaInsets for an iPhone X is null at viewDidLoad
+// so we use viewDidLayoutSubviews to get the value eventually
+
+- (void)viewDidLayoutSubviews
+{
+  [super viewDidLayoutSubviews];
+
+  if (_statusBarVerticalConstraint.constant != [self statusBarHeight]) {
+    _statusBarVerticalConstraint.constant = [self statusBarHeight];
+  }
+}
+@end

--- a/Example/Emission/AppDelegate.m
+++ b/Example/Emission/AppDelegate.m
@@ -4,6 +4,7 @@
 #import "ARDefaults.h"
 #import "AppSetup.h"
 
+#import "ARTopMenuViewController.h"
 #import "EigenLikeNavigationController.h"
 #import "ARRootViewController.h"
 #import "UnroutedViewController.h"
@@ -64,7 +65,7 @@ randomBOOL(void)
 
   self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
   self.window.backgroundColor = [UIColor whiteColor];
-  self.window.rootViewController = self.navigationController;
+  self.window.rootViewController = [[ARTopMenuViewController alloc] initWithNavigationController:self.navigationController];;
   [self.window makeKeyAndVisible];
   
   if ([auth isAuthenticated]) {

--- a/Example/Emission/EigenLikeNavigationController.m
+++ b/Example/Emission/EigenLikeNavigationController.m
@@ -21,7 +21,7 @@
   [backButton constrainWidth:@"40" height:@"40"];
   _backButton = backButton;
 
-  UIKeyCommand *command = [UIKeyCommand keyCommandWithInput:@" " modifierFlags:UIKeyModifierControl action:@selector(toggleNav)];
+  UIKeyCommand *command = [UIKeyCommand keyCommandWithInput:@"|" modifierFlags:UIKeyModifierControl action:@selector(toggleNav)];
   [self addKeyCommand: command];
 }
 

--- a/src/lib/Scenes/Home/index.tsx
+++ b/src/lib/Scenes/Home/index.tsx
@@ -19,9 +19,7 @@ import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
 import DarkNavigationButton from "lib/Components/Buttons/DarkNavigationButton"
 import TabBar, { Tab } from "lib/Components/TabBar"
 
-const TabBarContainer = styled.View`
-  margin-top: 20px;
-`
+const TabBarContainer = styled.View``
 
 interface Props {
   selectedArtist?: string


### PR DESCRIPTION
Now the status bar is provided at the root level of the VC hierarchy, so individual screens shouldn't have to care about it at all.

<img width="745" alt="screen shot 2018-01-22 at 4 42 00 pm" src="https://user-images.githubusercontent.com/49038/35246102-84e274f2-ff93-11e7-87a5-57b84e95365f.png">

Previous to this PR, there wouldn't be that white bar.