### PR TITLE
[Artist] Switch legacy analytics tracking to react-tracking.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * [Dev] Make it possible to impersonate a user given their ID and an access token - alloy
 * Re-instate the Relay Classic behaviour where any GraphQL response errors would lead to showing the ‘UNABLE TO LOAD’ view - alloy
 * Make sure ArtworkCarouselHeader queries for all required artist details regardless of what type of suggestion it’s showing - alloy
+* Possibly fix a crash that would occur when dispatching analytics events
 
 ### 1.4.1
 

--- a/src/lib/Containers/Gene.tsx
+++ b/src/lib/Containers/Gene.tsx
@@ -107,17 +107,6 @@ export class Gene extends React.Component<Props, State> {
     return this.availableTabs()[this.state.selectedTabIndex]
   }
 
-  // This is *not* called on the initial render, thus it will only post events for when the user actually taps a tab.
-  // TODO: This was getting called far more than expected.
-  // componentDidUpdate(previousProps, previousState) {
-  //   Events.postEvent({
-  //     name: 'Tapped gene view tab',
-  //     tab: this.selectedTabTitle().toLowerCase(),
-  //     gene_id: this.props.gene._id,
-  //     gene_slug: this.props.gene.id,
-  //   })
-  // }
-
   renderSectionForTab = () => {
     switch (this.selectedTabTitle()) {
       case TABS.ABOUT:

--- a/src/lib/Containers/__tests__/Artist-tests.tsx
+++ b/src/lib/Containers/__tests__/Artist-tests.tsx
@@ -43,14 +43,14 @@ describe("after rendering", () => {
     const worksTabIndex = artist.availableTabs().indexOf("WORKS")
 
     artist.componentWillMount()
-    expect(artist.state).toEqual({ selectedTabIndex: worksTabIndex })
+    expect(artist.state).toEqual({ selectedTabIndex: worksTabIndex, selectedTabTitle: "WORKS" })
   })
 
   it("mounts at the first tab index if artist has no works", () => {
     const artist = new Artist(artistProps(true, { partner_shows: 1 }))
 
     artist.componentWillMount()
-    expect(artist.state).toEqual({ selectedTabIndex: 0 })
+    expect(artist.state).toEqual({ selectedTabIndex: 0, selectedTabTitle: "ABOUT" })
   })
 })
 

--- a/src/lib/utils/track.ts
+++ b/src/lib/utils/track.ts
@@ -124,8 +124,11 @@ export namespace Schema {
     /**
      * Artist Page Events
      */
+    ArtistAbout = "artistAbout",
     ArtistFollow = "artistFollow",
     ArtistUnfollow = "artistUnfollow",
+    ArtistWorks = "artistWorks",
+    ArtistShows = "artistShows",
 
     /**
      * Gene Page Events


### PR DESCRIPTION
It’s not clear why `this.selectedTabTitle().toLowerCase` was causing crashes,
but in case it was related to `componentDidUpdate` that is now gone.

https://artsyproduct.atlassian.net/browse/IN-61 #resolve 🤞 

#skip_new_tests