### PR TITLE
[Messages] Allow blank-body messages, but filter for completely blank messages in fragment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ## Master
 
+* Allow blank Messages in Conversation - sarah
 * Removed unused imports that Relay no longer requires - sarah
 * Fixed the top margin for home - orta
 * Fixed the messages header when there's no convos - maxim

--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -271,7 +271,7 @@ type ArtistEdge {
 }
 
 type ArtistHighlights {
-  partners(represented_by: Boolean, partner_category: [String], after: String, first: Int, before: String, last: Int): PartnerArtistConnection
+  partners(represented_by: Boolean, partner_category: [String], display_on_partner_profile: Boolean, after: String, first: Int, before: String, last: Int): PartnerArtistConnection
 }
 
 type ArtistItem implements Node {
@@ -1916,7 +1916,7 @@ type Conversation implements Node {
   initial_message: String!
 
   # This is a snippet of text from the last message.
-  last_message: String!
+  last_message: String
   last_message_at(
     convert_to_utc: Boolean
     format: String
@@ -1944,7 +1944,7 @@ type Conversation implements Node {
   items: [ConversationItem]
 
   # A connection for all messages in a single conversation
-  messages(sort: sort, after: String, first: Int, before: String, last: Int): MessageConnection
+  messages(sort: sort, ignoreBlankMessages: Boolean, after: String, first: Int, before: String, last: Int): MessageConnection
 
   # True if there is an unread message by the user.
   unread: Boolean

--- a/data/schema.json
+++ b/data/schema.json
@@ -14629,6 +14629,16 @@
                   "defaultValue": null
                 },
                 {
+                  "name": "display_on_partner_profile",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "after",
                   "description": null,
                   "type": {
@@ -28730,13 +28740,9 @@
               "description": "This is a snippet of text from the last message.",
               "args": [],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -28874,6 +28880,16 @@
                   "type": {
                     "kind": "ENUM",
                     "name": "sort",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "ignoreBlankMessages",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
                     "ofType": null
                   },
                   "defaultValue": null

--- a/src/lib/Components/Inbox/Conversations/ConversationSnippet.tsx
+++ b/src/lib/Components/Inbox/Conversations/ConversationSnippet.tsx
@@ -27,7 +27,6 @@ const HorizontalLayout = styled.View`
 
 const Card = styled.View`
   height: 120px;
-  align-items: center;
   margin-left: 20px;
   margin-right: 20px;
 `
@@ -38,7 +37,7 @@ const CardContent = styled(HorizontalLayout)`
 
 const TextPreview = styled(VerticalLayout)`
   margin-left: 10;
-  height: 70px;
+  max-height: 70px;
   align-self: center;
 `
 
@@ -148,7 +147,7 @@ export class ConversationSnippet extends React.Component<Props, any> {
 
     const partnerName = conversation.to.name
 
-    const conversationText = conversation.last_message.replace(/\n/g, " ")
+    const conversationText = conversation.last_message && conversation.last_message.replace(/\n/g, " ")
     const date = moment(conversation.last_message_at).fromNow(true) + " ago"
     return (
       <TouchableWithoutFeedback onPress={() => this.conversationSelected()}>
@@ -161,7 +160,7 @@ export class ConversationSnippet extends React.Component<Props, any> {
                 <DateHeading>{conversation.unread && <UnreadIndicator />}</DateHeading>
               </HorizontalLayout>
               {this.renderTitleForItem(item)}
-              <P>{conversationText}</P>
+              {conversationText && <P>{conversationText}</P>}
               <MetadataText>{date}</MetadataText>
             </TextPreview>
           </CardContent>

--- a/src/lib/Components/Inbox/Conversations/Messages.tsx
+++ b/src/lib/Components/Inbox/Conversations/Messages.tsx
@@ -168,7 +168,8 @@ export default createPaginationContainer(
           initials
         }
         initial_message
-        messages(first: $count, after: $after, sort: DESC) @connection(key: "Messages_messages", filters: []) {
+        messages(first: $count, after: $after, sort: DESC, ignoreBlankMessages: true)
+          @connection(key: "Messages_messages", filters: []) {
           pageInfo {
             startCursor
             endCursor

--- a/src/lib/Components/Inbox/Conversations/__tests__/__snapshots__/ConversationSnippet-tests.tsx.snap
+++ b/src/lib/Components/Inbox/Conversations/__tests__/__snapshots__/ConversationSnippet-tests.tsx.snap
@@ -18,7 +18,6 @@ exports[`renders correctly with a show 1`] = `
   style={
     Array [
       Object {
-        "alignItems": "center",
         "height": 120,
         "marginLeft": 20,
         "marginRight": 20,
@@ -72,8 +71,8 @@ exports[`renders correctly with a show 1`] = `
           Array [
             Object {
               "alignSelf": "center",
-              "height": 70,
               "marginLeft": 10,
+              "maxHeight": 70,
             },
             undefined,
           ],
@@ -283,7 +282,6 @@ exports[`renders correctly with an artwork 1`] = `
   style={
     Array [
       Object {
-        "alignItems": "center",
         "height": 120,
         "marginLeft": 20,
         "marginRight": 20,
@@ -337,8 +335,8 @@ exports[`renders correctly with an artwork 1`] = `
           Array [
             Object {
               "alignSelf": "center",
-              "height": 70,
               "marginLeft": 10,
+              "maxHeight": 70,
             },
             undefined,
           ],

--- a/src/lib/Components/Inbox/Conversations/__tests__/__snapshots__/Conversations-tests.tsx.snap
+++ b/src/lib/Components/Inbox/Conversations/__tests__/__snapshots__/Conversations-tests.tsx.snap
@@ -142,7 +142,6 @@ exports[`messaging inbox looks correct when rendered 1`] = `
           style={
             Array [
               Object {
-                "alignItems": "center",
                 "height": 120,
                 "marginLeft": 20,
                 "marginRight": 20,
@@ -196,8 +195,8 @@ exports[`messaging inbox looks correct when rendered 1`] = `
                   Array [
                     Object {
                       "alignSelf": "center",
-                      "height": 70,
                       "marginLeft": 10,
+                      "maxHeight": 70,
                     },
                     undefined,
                   ],
@@ -433,7 +432,6 @@ exports[`messaging inbox looks correct when rendered 1`] = `
           style={
             Array [
               Object {
-                "alignItems": "center",
                 "height": 120,
                 "marginLeft": 20,
                 "marginRight": 20,
@@ -487,8 +485,8 @@ exports[`messaging inbox looks correct when rendered 1`] = `
                   Array [
                     Object {
                       "alignSelf": "center",
-                      "height": 70,
                       "marginLeft": 10,
+                      "maxHeight": 70,
                     },
                     undefined,
                   ],

--- a/src/lib/Components/Inbox/Conversations/index.tsx
+++ b/src/lib/Components/Inbox/Conversations/index.tsx
@@ -50,11 +50,7 @@ export class Conversations extends Component<Props, State> {
     let conversations = []
 
     if (me) {
-      conversations = me.conversations.edges
-        .filter(({ node }) => {
-          return node && node.last_message
-        })
-        .map(edge => edge.node)
+      conversations = me.conversations.edges.map(edge => edge.node)
     }
 
     return conversations


### PR DESCRIPTION
- [x] Adds `ignoreBlankMessages` parameter to `Messages` fragment
- [x] Renders messages with blank bodies

https://artsyproduct.atlassian.net/browse/IN-56 #resolve

We will be filtering for completely blank messages (i.e. no attachments or body) in metaphysics, but in a worst case, they look like this, which is acceptable IMO:

![blank messages](https://user-images.githubusercontent.com/2712962/35523822-091800d4-0520-11e8-943d-32c22cfa45f4.gif)
 
#skip_new_tests