### PR TITLE
Updates the tab bar to not overflow their contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@
 * [Dev] Make it possible to impersonate a user given their ID and an access token - alloy
 * Re-instate the Relay Classic behaviour where any GraphQL response errors would lead to showing the ‘UNABLE TO LOAD’ view - alloy
 * Make sure ArtworkCarouselHeader queries for all required artist details regardless of what type of suggestion it’s showing - alloy
-* Possibly fix a crash that would occur when dispatching analytics events
+* Possibly fix a crash that would occur when dispatching analytics events - alloy
+* The fairs rail is now constrained to just it's tab - orta
 
 ### 1.4.1
 

--- a/src/lib/Components/TabBar.tsx
+++ b/src/lib/Components/TabBar.tsx
@@ -47,7 +47,9 @@ const TabLabel: any = styled.Text`
   color: ${(props: TabLabelProps) => (props.active ? "black" : colors["gray-medium"])};
 `
 
-export const Tab: React.SFC<TabProps> = ({ children }) => <View style={{ flex: 1 }}>{children}</View>
+export const Tab: React.SFC<TabProps> = ({ children }) => (
+  <View style={{ flex: 1, overflow: "hidden" }}>{children}</View>
+)
 
 export default class TabBar extends React.Component<TabBarProps, null> {
   renderTab(name, page, isTabActive, onPressHandler) {


### PR DESCRIPTION
Looks good 

<img width="785" alt="screen shot 2018-01-29 at 2 19 37 pm" src="https://user-images.githubusercontent.com/49038/35529695-d0792430-04ff-11e8-9546-3ec288952ff5.png">

#skip_new_tests