### PR TITLE
[msg] Do not render messages without bodies or attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ## Master
 
+* Allow blank messages in Conversations, but only if they have attachments - sarah
+
 ### 1.4.2
 
 * Allow blank Messages in Conversation - sarah

--- a/src/lib/Components/Inbox/Conversations/Messages.tsx
+++ b/src/lib/Components/Inbox/Conversations/Messages.tsx
@@ -109,7 +109,11 @@ export class Messages extends React.Component<Props, State> {
   render() {
     const edges = (this.props.conversation.messages || { edges: [] }).edges
     const messageCount = edges.length
-    const messages = edges.map((edge, index) => {
+
+    const containsContent = edge =>
+      (edge.node.body && edge.node.body.length) || (edge.node.attachments && edge.node.attachments.length)
+
+    const messages = edges.filter(edge => containsContent(edge)).map((edge, index) => {
       const isFirstMessage = this.props.relay && !this.props.relay.hasMore() && index === messageCount - 1
       return { first_message: isFirstMessage, key: edge.cursor, ...edge.node }
     })
@@ -168,8 +172,7 @@ export default createPaginationContainer(
           initials
         }
         initial_message
-        messages(first: $count, after: $after, sort: DESC, ignoreBlankMessages: true)
-          @connection(key: "Messages_messages", filters: []) {
+        messages(first: $count, after: $after, sort: DESC) @connection(key: "Messages_messages", filters: []) {
           pageInfo {
             startCursor
             endCursor
@@ -183,6 +186,9 @@ export default createPaginationContainer(
               impulse_id
               is_from_user
               body
+              attachments {
+                id
+              }
               ...Message_message
             }
           }
@@ -259,6 +265,8 @@ interface RelayProps {
             __id: string
             impulse_id: string
             is_from_user: boolean
+            body: string
+            attachments: any
           } | null
         }>
       }


### PR DESCRIPTION
Related to https://artsyproduct.atlassian.net/browse/IN-56

- [x] Check for existence of body and/or attachments in messages before rendering them
- [x] Remove `ignoreBlankMessages` parameter