### PR TITLE
Add is_auction and set it to true for lots by followed artists

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -4425,7 +4425,7 @@ type Query {
   ): FilterArtworks
 
   # Sale Artworks Elastic Search results
-  filter_sale_artworks(aggregations: [SaleArtworkAggregation], artist_ids: [String], include_artworks_by_followed_artists: Boolean, live_sale: Boolean, gene_ids: [String], estimate_range: String, page: Int, sale_id: ID, size: Int, sort: String): FilterSaleArtworks @deprecated(reason: "This type has been superceded by `sale_artworks`")
+  filter_sale_artworks(aggregations: [SaleArtworkAggregation], artist_ids: [String], include_artworks_by_followed_artists: Boolean, live_sale: Boolean, is_auction: Boolean, gene_ids: [String], estimate_range: String, page: Int, sale_id: ID, size: Int, sort: String): FilterSaleArtworks @deprecated(reason: "This type has been superceded by `sale_artworks`")
   gene(
     # The slug or ID of the Gene
     id: String!
@@ -4574,7 +4574,7 @@ type Query {
   ): SaleArtwork
 
   # Sale Artworks search results
-  sale_artworks(aggregations: [SaleArtworkAggregation], artist_ids: [String], include_artworks_by_followed_artists: Boolean, live_sale: Boolean, gene_ids: [String], estimate_range: String, page: Int, sale_id: ID, size: Int, sort: String, after: String, first: Int, before: String, last: Int): SaleArtworksConnection
+  sale_artworks(aggregations: [SaleArtworkAggregation], artist_ids: [String], include_artworks_by_followed_artists: Boolean, live_sale: Boolean, is_auction: Boolean, gene_ids: [String], estimate_range: String, page: Int, sale_id: ID, size: Int, sort: String, after: String, first: Int, before: String, last: Int): SaleArtworksConnection
 
   # A list of Sales
   sales(
@@ -5709,7 +5709,7 @@ type Viewer {
   ): FilterArtworks
 
   # Sale Artworks Elastic Search results
-  filter_sale_artworks(aggregations: [SaleArtworkAggregation], artist_ids: [String], include_artworks_by_followed_artists: Boolean, live_sale: Boolean, gene_ids: [String], estimate_range: String, page: Int, sale_id: ID, size: Int, sort: String): FilterSaleArtworks @deprecated(reason: "This type has been superceded by `sale_artworks`")
+  filter_sale_artworks(aggregations: [SaleArtworkAggregation], artist_ids: [String], include_artworks_by_followed_artists: Boolean, live_sale: Boolean, is_auction: Boolean, gene_ids: [String], estimate_range: String, page: Int, sale_id: ID, size: Int, sort: String): FilterSaleArtworks @deprecated(reason: "This type has been superceded by `sale_artworks`")
   gene(
     # The slug or ID of the Gene
     id: String!
@@ -5858,7 +5858,7 @@ type Viewer {
   ): SaleArtwork
 
   # Sale Artworks search results
-  sale_artworks(aggregations: [SaleArtworkAggregation], artist_ids: [String], include_artworks_by_followed_artists: Boolean, live_sale: Boolean, gene_ids: [String], estimate_range: String, page: Int, sale_id: ID, size: Int, sort: String, after: String, first: Int, before: String, last: Int): SaleArtworksConnection
+  sale_artworks(aggregations: [SaleArtworkAggregation], artist_ids: [String], include_artworks_by_followed_artists: Boolean, live_sale: Boolean, is_auction: Boolean, gene_ids: [String], estimate_range: String, page: Int, sale_id: ID, size: Int, sort: String, after: String, first: Int, before: String, last: Int): SaleArtworksConnection
 
   # A list of Sales
   sales(

--- a/data/schema.json
+++ b/data/schema.json
@@ -993,6 +993,16 @@
                   "defaultValue": null
                 },
                 {
+                  "name": "is_auction",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "gene_ids",
                   "description": null,
                   "type": {
@@ -1958,6 +1968,16 @@
                 },
                 {
                   "name": "live_sale",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "is_auction",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
@@ -40381,6 +40401,16 @@
                   "defaultValue": null
                 },
                 {
+                  "name": "is_auction",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "gene_ids",
                   "description": null,
                   "type": {
@@ -41346,6 +41376,16 @@
                 },
                 {
                   "name": "live_sale",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "is_auction",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",

--- a/src/lib/Scenes/Home/Components/Sales/Components/LotsByFollowedArtists.tsx
+++ b/src/lib/Scenes/Home/Components/Sales/Components/LotsByFollowedArtists.tsx
@@ -64,6 +64,7 @@ export default createPaginationContainer(
         first: $count
         after: $cursor
         live_sale: true
+        is_auction: true
         include_artworks_by_followed_artists: true
       ) @connection(key: "LotsByFollowedArtists_sale_artworks") {
         pageInfo {


### PR DESCRIPTION
# Problem
Seeing unrelated lots in lots by followed artists page.

# Solution
Follow up on changes in [Gravity](https://github.com/artsy/gravity/pull/11539) and [MP](https://github.com/artsy/metaphysics/pull/923) we need to now set `is_auction` to `true` when asking for lots in live auctions by followed artists.

*Depends on https://github.com/artsy/metaphysics/pull/923* 