### PR TITLE
Update to latest React Native patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ## Master
 
-* Upgrade to React Native 0.54.0 - alloy
+* Upgrade to React Native 0.54.2 - alloy
 * Follow Force and reduce image quality to 80 - alloy
 * Inquiries use the same user-agent as emission - orta
 * Optimise the generic artwork grid for rotation - maxim

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -14,18 +14,21 @@ PODS:
   - Emission (1.4.6):
     - Artsy+UIColors
     - Artsy+UIFonts (>= 3.0.0)
+    - DoubleConversion (= 1.1.5)
     - Extraction (>= 1.2.1)
-    - React/Core (= 0.54.0)
-    - React/CxxBridge (= 0.54.0)
-    - React/RCTAnimation (= 0.54.0)
-    - React/RCTCameraRoll (= 0.54.0)
-    - React/RCTImage (= 0.54.0)
-    - React/RCTLinkingIOS (= 0.54.0)
-    - React/RCTNetwork (= 0.54.0)
-    - React/RCTText (= 0.54.0)
+    - Folly (= 2016.09.26.00)
+    - glog (= 0.3.4)
+    - React/Core (= 0.54.2)
+    - React/CxxBridge (= 0.54.2)
+    - React/RCTAnimation (= 0.54.2)
+    - React/RCTCameraRoll (= 0.54.2)
+    - React/RCTImage (= 0.54.2)
+    - React/RCTLinkingIOS (= 0.54.2)
+    - React/RCTNetwork (= 0.54.2)
+    - React/RCTText (= 0.54.2)
     - SDWebImage (< 4, >= 3.7.2)
     - SentryReactNative (= 0.30.3)
-    - yoga (= 0.54.0.React)
+    - yoga (= 0.54.2.React)
   - Extraction (1.2.3):
     - Extraction/ARAnimationContinuation (= 1.2.3)
     - Extraction/ARLoadFailureView (= 1.2.3)
@@ -70,45 +73,45 @@ PODS:
   - NSURL+QueryDictionary (1.2.0)
   - ORStackView (2.0.3):
     - FLKAutoLayout
-  - React (0.54.0):
-    - React/Core (= 0.54.0)
-  - React/Core (0.54.0):
-    - yoga (= 0.54.0.React)
-  - React/CxxBridge (0.54.0):
+  - React (0.54.2):
+    - React/Core (= 0.54.2)
+  - React/Core (0.54.2):
+    - yoga (= 0.54.2.React)
+  - React/CxxBridge (0.54.2):
     - Folly (= 2016.09.26.00)
     - React/Core
     - React/cxxreact
-  - React/cxxreact (0.54.0):
+  - React/cxxreact (0.54.2):
     - boost-for-react-native (= 1.63.0)
     - Folly (= 2016.09.26.00)
     - React/jschelpers
     - React/jsinspector
-  - React/DevSupport (0.54.0):
+  - React/DevSupport (0.54.2):
     - React/Core
     - React/RCTWebSocket
-  - React/fishhook (0.54.0)
-  - React/jschelpers (0.54.0):
+  - React/fishhook (0.54.2)
+  - React/jschelpers (0.54.2):
     - Folly (= 2016.09.26.00)
     - React/PrivateDatabase
-  - React/jsinspector (0.54.0)
-  - React/PrivateDatabase (0.54.0)
-  - React/RCTAnimation (0.54.0):
+  - React/jsinspector (0.54.2)
+  - React/PrivateDatabase (0.54.2)
+  - React/RCTAnimation (0.54.2):
     - React/Core
-  - React/RCTBlob (0.54.0):
+  - React/RCTBlob (0.54.2):
     - React/Core
-  - React/RCTCameraRoll (0.54.0):
+  - React/RCTCameraRoll (0.54.2):
     - React/Core
     - React/RCTImage
-  - React/RCTImage (0.54.0):
+  - React/RCTImage (0.54.2):
     - React/Core
     - React/RCTNetwork
-  - React/RCTLinkingIOS (0.54.0):
+  - React/RCTLinkingIOS (0.54.2):
     - React/Core
-  - React/RCTNetwork (0.54.0):
+  - React/RCTNetwork (0.54.2):
     - React/Core
-  - React/RCTText (0.54.0):
+  - React/RCTText (0.54.2):
     - React/Core
-  - React/RCTWebSocket (0.54.0):
+  - React/RCTWebSocket (0.54.2):
     - React/Core
     - React/fishhook
     - React/RCTBlob
@@ -127,7 +130,7 @@ PODS:
     - Sentry (~> 3.9.0)
     - Sentry/KSCrash (~> 3.9.0)
   - UIView+BooleanAnimations (1.0.2)
-  - yoga (0.54.0.React)
+  - yoga (0.54.2.React)
 
 DEPENDENCIES:
   - ARGenericTableViewController
@@ -180,7 +183,7 @@ SPEC CHECKSUMS:
   Artsy-UIButtons: cdcc3ccf4d0d31ee80f45c1d11ffd2d772695b74
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: ebb6747c5b66026ad4f97b789c3ceac6f18e57a6
-  Emission: 51505894af64d6fe128d94f3fa33785e9af4b086
+  Emission: f33ab6346f646146c54d2c260f436ae943bed0b8
   Extraction: 612cf0866f74d4c0dd616677ff24146efa200958
   FLKAutoLayout: 106b14dbae09d32c6730190f4e78a959759ba4a4
   Folly: 211775e49d8da0ca658aebc8eab89d642935755c

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -35,7 +35,9 @@ Relay will log debugging info for each query it performs in the ‘Console’ ta
 
 ![screen shot 2017-05-03 at 09 10 30](https://cloud.githubusercontent.com/assets/2320/25651038/1f313b84-2fe1-11e7-98ca-71c431946a53.png)
 
-However, like any other networking, the raw request/response information is also available from the ‘Network’ tab:
+However, like any other networking, the raw request/response information can be made available from the ‘Network’ tab by
+[enabling the Network Inspector](https://github.com/jhen0409/react-native-debugger/blob/master/docs/network-inspect-of-chrome-devtools.md)
+from the React Native Debugger app’s contextual menu:
 
 ![screen shot 2017-05-03 at 09 15 11](https://cloud.githubusercontent.com/assets/2320/25651045/293100c4-2fe1-11e7-83a6-728d2d3c14f9.png)
 

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "prop-types": "^15.5.10",
     "query-string": "^4.1.0",
     "react": "^16.3.0-alpha.1",
-    "react-native": "0.54.0",
+    "react-native": "0.54.2",
     "react-native-hyperlink": "0.0.11",
     "react-native-parallax-scroll-view": "https://github.com/orta/react-native-parallax-scroll-view",
     "react-native-scrollable-tab-view": "^0.8.0",

--- a/src/lib/relay/config.tsx
+++ b/src/lib/relay/config.tsx
@@ -14,20 +14,7 @@ if (Emission && Emission.gravityAPIHost && Emission.metaphysicsAPIHost) {
 
 export { metaphysicsURL, gravityURL }
 
-// Disable the native polyfill during development, which will make network requests show-up in the Chrome dev-tools.
-// Specifically, in our case, we get to see the Relay requests.
-//
-// It will be `undefined` unless running inside Chrome.
-//
-declare var global: any
-if (__DEV__ && global.originalXMLHttpRequest !== undefined) {
-  /**
-   * TODO: Recording network access in Chrome Dev Tools is disabled for now.
-   *
-   * @see https://github.com/jhen0409/react-native-debugger/issues/209
-   */
-  // global.XMLHttpRequest = global.originalXMLHttpRequest
-
+if (__DEV__) {
   // tslint:disable-next-line:no-var-requires
   require("react-relay/lib/RelayNetworkDebug").init()
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8737,9 +8737,9 @@ react-native-typescript-transformer@^1.2.3:
     semver "^5.4.1"
     source-map "^0.5.6"
 
-react-native@0.54.0:
-  version "0.54.0"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.54.0.tgz#1582cc2b2a639d46e39c44bcc50e051d0061820a"
+react-native@0.54.2:
+  version "0.54.2"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.54.2.tgz#73786e7bf3f80b0b060ca0bfe5b192f9c2f253da"
   dependencies:
     absolute-path "^0.0.0"
     art "^0.10.0"


### PR DESCRIPTION
This fixes an issue related to the new delta patcher, silences the new but alpha React life-cycle deprecation warnings, and removes the hardcoded polyfill in dev mode to inspect network activity in the debugger in favour of using the ‘Enable Network Inspector’ option in the React Native Debugger app’s contextual menu.