### PR TITLE
use ruby api to retrieve spec details

### DIFF
--- a/Emission.podspec
+++ b/Emission.podspec
@@ -49,8 +49,8 @@ podspec = Pod::Spec.new do |s|
     'node_modules/react-native/third-party-podspecs/glog.podspec'
   ]
   podspecs.each do |podspec_path|
-    podspec_json = JSON.parse(`pod ipc spec #{podspec_path}`)
-    s.dependency podspec_json['name'], podspec_json['version']
+    spec = Pod::Specification.from_file podspec_path
+    s.dependency spec.name, "#{spec.version}"
   end
 
   s.dependency 'SDWebImage', '>= 3.7.2', '< 4'


### PR DESCRIPTION
this is much faster than reaching out to the command line util, which has to spawn a new ruby process for each podspec.

Is has to be verified that this actually works as-is, because in my implementation I had to prefix the podspec files with the root variable (here from `EMISSION_ROOT`), because otherwise it couldn't find the them. But since the ipc method hadn't that either, I kept it without the root prefix for now.