### PR TITLE
Adds <SelectMaxBid> component

### DIFF
--- a/src/lib/Components/Bidding/Components/Button.tsx
+++ b/src/lib/Components/Bidding/Components/Button.tsx
@@ -1,0 +1,22 @@
+import React from "react"
+import { StyleSheet } from "react-native"
+
+import { ButtonProps, InvertedButton } from "../../Buttons"
+
+export class Button extends React.Component<ButtonProps> {
+  render() {
+    const { style, ...props } = this.props
+
+    return <InvertedButton style={[styles.default, style]} {...props} />
+  }
+}
+
+const styles = StyleSheet.create({
+  default: {
+    // fontSize: 14,
+    // fontWeight: 'normal',
+    // fontStyle: 'normal',
+    // letterSpacing: 1,
+    // color: '#ffffff'
+  },
+})

--- a/src/lib/Components/Bidding/Components/MaxBidPicker.tsx
+++ b/src/lib/Components/Bidding/Components/MaxBidPicker.tsx
@@ -1,0 +1,26 @@
+import React from "react"
+import { Picker, PickerProperties } from "react-native"
+import styled from "styled-components/native"
+
+interface Bid {
+  label: string
+  value: number
+}
+
+export interface MaxBidPickerProps extends PickerProperties {
+  bids: Bid[]
+}
+
+export class MaxBidPicker extends React.Component<MaxBidPickerProps> {
+  render() {
+    return (
+      <StyledPicker {...this.props}>
+        {this.props.bids.map((bid, index) => <Picker.Item key={index} {...bid} />)}
+      </StyledPicker>
+    )
+  }
+}
+
+const StyledPicker = styled.Picker`
+  width: 100%;
+`

--- a/src/lib/Components/Bidding/Components/Title.tsx
+++ b/src/lib/Components/Bidding/Components/Title.tsx
@@ -1,0 +1,19 @@
+import React from "react"
+import { TextProperties } from "react-native"
+import styled from "styled-components/native"
+
+import { Fonts } from "../../../data/fonts"
+
+export class Title extends React.Component<TextProperties> {
+  render() {
+    return <StyledText {...this.props}>{this.props.children}</StyledText>
+  }
+}
+
+const StyledText = styled.Text`
+  font-family: "${Fonts.GaramondRegular}";
+  margin: 10px;
+  font-weight: bold;
+  font-size: 20px;
+  text-align: center;
+`

--- a/src/lib/Components/Bidding/Screens/SelectMaxBid.tsx
+++ b/src/lib/Components/Bidding/Screens/SelectMaxBid.tsx
@@ -1,0 +1,55 @@
+import React from "react"
+import styled from "styled-components/native"
+
+import { Button } from "../Components/Button"
+import { MaxBidPicker } from "../Components/MaxBidPicker"
+import { Title } from "../Components/Title"
+
+interface SelectMaxBidProps {
+  saleArtworkID: string
+}
+
+// we are using hard-coded values for now.
+const Bids = [
+  {
+    label: "$35,000 USD",
+    value: 3500000,
+  },
+  {
+    label: "$40,000 USD",
+    value: 4000000,
+  },
+  {
+    label: "$45,000 USD",
+    value: 4500000,
+  },
+  {
+    label: "$50,000 USD",
+    value: 5000000,
+  },
+  {
+    label: "$55,000 USD",
+    value: 5500000,
+  },
+]
+
+export class SelectMaxBid extends React.Component<SelectMaxBidProps> {
+  render() {
+    return (
+      <Container>
+        <Title>Your max bid</Title>
+
+        <MaxBidPicker selectedValue={4500000} bids={Bids} />
+
+        <Button text="NEXT" />
+      </Container>
+    )
+  }
+}
+
+const Container = styled.View`
+  flex: 1;
+  flex-direction: column;
+  justify-content: space-between;
+  margin: 20px;
+`

--- a/src/lib/Components/Bidding/__stories__/BidFlow.story.tsx
+++ b/src/lib/Components/Bidding/__stories__/BidFlow.story.tsx
@@ -1,7 +1,13 @@
 import { storiesOf } from "@storybook/react-native"
 import React from "react"
-import BidFlow from "../Screens/BidFlow"
 
-storiesOf("Bidding").add("Show bid flow", () => {
-  return <BidFlow saleArtworkID="5aada729139b216c0bf18103" />
-})
+import BidFlow from "../Screens/BidFlow"
+import { SelectMaxBid } from "../Screens/SelectMaxBid"
+
+storiesOf("Bidding")
+  .add("Show bid flow", () => {
+    return <BidFlow saleArtworkID="5aada729139b216c0bf18103" />
+  })
+  .add("Select Max Bid", () => {
+    return <SelectMaxBid saleArtworkID="5aada729139b216c0bf18103" />
+  })


### PR DESCRIPTION
addresses https://artsyproduct.atlassian.net/browse/PURCHASE-42 and is possibly related to https://artsyproduct.atlassian.net/browse/PURCHASE-34

The goal of this PR is to set up a foundation where all the components for the new bidding flow lives, by actually building a component. I picked up the pattern used for the `Consignments` directory to get started, but wanted to make sure that this is the pattern we all feel comfortable with before I move forward too deeply.

In this PR there's only `<SelectMaxBid>`, but I'd imagine that the `Screens/` will grow as we implement more pages and add a `Components/` directory to organize smaller components. One interesting thing we are going to do is that a subclass of `UIViewController` may have to live in the Emission as well. so we'll have to think about how we are going about this.

This PR is basically just a conversation starter. I'm not really tied to any specific pattern at this point. We don't even have to follow the existing pattern if there's something that feels more organized. Any feedback is welcome!

### Directory structure:

```
src/lib/Components/Bidding/
├── Screens
│   └── SelectMaxBid.tsx
├── __stories__
│   └── Bidding.story.tsx
└── __tests__
```

### The `<SelectMaxBid>` component:

![screen shot 2018-04-11 at 2 29 03 pm](https://user-images.githubusercontent.com/386234/38635873-b2f5b3e2-3d94-11e8-9212-a78ec8ba9a99.png)

