### PR TITLE
Bid flow component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Cache queries on-disk for 1 day - alloy
 * Add persisted queries support to Relay - alloy
 * Add ability to preload queries - alloy
+* Adds (empty) BidFlow component and view controller - ashfurrow
 
 ## 1.4.6
 

--- a/Example/Emission/ARRootViewController.m
+++ b/Example/Emission/ARRootViewController.m
@@ -25,6 +25,7 @@
 #import <Emission/ARFavoritesComponentViewController.h>
 #import <Emission/ARMyProfileViewController.h>
 #import <Emission/ARShowConsignmentsFlowViewController.h>
+#import <Emission/ARBidFlowViewController.h>
 
 #import "ARStorybookComponentViewController.h"
 
@@ -94,6 +95,7 @@
   [sectionData addCellData:self.jumpToInbox];
   [sectionData addCellData:self.jumpToInquiry];
   [sectionData addCellData:self.jumpToFavorites];
+  [sectionData addCellData:self.jumpToBidFlow];
 
   return sectionData;
 }
@@ -269,6 +271,13 @@
   }
                                        preload:^NSArray<ARGraphQLQuery *> *{
     return [ARFavoritesComponentViewController preloadQueries];
+  }];
+}
+
+- (ARCellData *)jumpToBidFlow
+{
+  return [self tappableCellDataWithTitle:@"Bid Flow" selection: ^{
+    [self.navigationController pushViewController:[[ARBidFlowViewController alloc] initWithSaleArtworkID:@"5aada729139b216c0bf18103"] animated:YES];
   }];
 }
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -183,7 +183,7 @@ SPEC CHECKSUMS:
   Artsy-UIButtons: cdcc3ccf4d0d31ee80f45c1d11ffd2d772695b74
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: ebb6747c5b66026ad4f97b789c3ceac6f18e57a6
-  Emission: ad7828f594ad0ddb6a6f4e00d7654ec04258d0ce
+  Emission: f76136f6eaab1ba0f7c692b17727dbcceebfa856
   Extraction: 612cf0866f74d4c0dd616677ff24146efa200958
   FLKAutoLayout: 106b14dbae09d32c6730190f4e78a959759ba4a4
   Folly: 211775e49d8da0ca658aebc8eab89d642935755c

--- a/Pod/Classes/ViewControllers/ARBidFlowViewController.h
+++ b/Pod/Classes/ViewControllers/ARBidFlowViewController.h
@@ -1,0 +1,17 @@
+#import <Emission/ARComponentViewController.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ARBidFlowViewController : ARComponentViewController
+
+- (instancetype)initWithSaleArtworkID:(NSString *)saleArtworkID NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)initWithEmission:(nullable AREmission *)emission
+                      moduleName:(NSString *)moduleName
+               initialProperties:(nullable NSDictionary *)initialProperties NS_UNAVAILABLE;
+
+@property (nonatomic, copy) NSString *saleArtworkID;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Pod/Classes/ViewControllers/ARBidFlowViewController.m
+++ b/Pod/Classes/ViewControllers/ARBidFlowViewController.m
@@ -1,0 +1,15 @@
+#import "ARBidFlowViewController.h"
+
+@implementation ARBidFlowViewController
+
+- (instancetype)initWithSaleArtworkID:(NSString *)saleArtworkID
+{
+  if ((self = [super initWithEmission:nil
+                           moduleName:@"BidFlow"
+                    initialProperties:@{ @"saleArtworkID": saleArtworkID }])) {
+    _saleArtworkID = saleArtworkID;
+  }
+  return self;
+}
+
+@end

--- a/src/lib/AppRegistry.tsx
+++ b/src/lib/AppRegistry.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { AppRegistry, View } from "react-native"
 
+import BidFlow from "./Components/Bidding/Screens/BidFlow"
 import Consignments from "./Components/Consignments"
 import Containers from "./Containers/index"
 import {
@@ -99,3 +100,4 @@ AppRegistry.registerComponent("Inbox", () => Inbox)
 AppRegistry.registerComponent("Conversation", () => Conversation)
 AppRegistry.registerComponent("Inquiry", () => Inquiry)
 AppRegistry.registerComponent("Favorites", () => FavoritesScene)
+AppRegistry.registerComponent("BidFlow", () => BidFlow)

--- a/src/lib/Components/Bidding/Screens/BidFlow.tsx
+++ b/src/lib/Components/Bidding/Screens/BidFlow.tsx
@@ -1,0 +1,8 @@
+import React from "react"
+import SerifText from "../../../Components/Text/Serif"
+
+export class BidFlow extends React.Component {
+  render() {
+    return <SerifText>This will be the home of the new bidding flow.</SerifText>
+  }
+}

--- a/src/lib/Components/Bidding/Screens/BidFlow.tsx
+++ b/src/lib/Components/Bidding/Screens/BidFlow.tsx
@@ -1,7 +1,11 @@
 import React from "react"
 import SerifText from "../../../Components/Text/Serif"
 
-export class BidFlow extends React.Component {
+interface BidFlowProps {
+  saleArtworkID: string
+}
+
+export default class BidFlow extends React.Component<BidFlowProps> {
   render() {
     return <SerifText>This will be the home of the new bidding flow.</SerifText>
   }

--- a/src/lib/Components/Bidding/__stories__/BidFlow.story.tsx
+++ b/src/lib/Components/Bidding/__stories__/BidFlow.story.tsx
@@ -1,0 +1,7 @@
+import { storiesOf } from "@storybook/react-native"
+import React from "react"
+import { BidFlow } from "../Screens/BidFlow"
+
+storiesOf("Bidding").add("Show bid flow", () => {
+  return <BidFlow />
+})

--- a/src/lib/Components/Bidding/__stories__/BidFlow.story.tsx
+++ b/src/lib/Components/Bidding/__stories__/BidFlow.story.tsx
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/react-native"
 import React from "react"
-import { BidFlow } from "../Screens/BidFlow"
+import BidFlow from "../Screens/BidFlow"
 
 storiesOf("Bidding").add("Show bid flow", () => {
-  return <BidFlow />
+  return <BidFlow saleArtworkID="5aada729139b216c0bf18103" />
 })

--- a/storybook/storyLoader.js
+++ b/storybook/storyLoader.js
@@ -7,6 +7,7 @@
 function loadStories() {
   require('../src/lib/Components/Artist/__stories__/ArtistArticles.story.tsx');
   require('../src/lib/Components/Artist/__stories__/ArtistHeader.story.tsx');
+  require('../src/lib/Components/Bidding/__stories__/BidFlow.story.tsx');
   require('../src/lib/Components/Buttons/__stories__/Buttons.story.tsx');
   require('../src/lib/Components/Consignments/__stories__/BottomAligned.story.tsx');
   require('../src/lib/Components/Consignments/__stories__/Consignments.story.tsx');
@@ -40,6 +41,7 @@ function loadStories() {
 const stories = [
   '../src/lib/Components/Artist/__stories__/ArtistArticles.story.tsx',
   '../src/lib/Components/Artist/__stories__/ArtistHeader.story.tsx',
+  '../src/lib/Components/Bidding/__stories__/BidFlow.story.tsx',
   '../src/lib/Components/Buttons/__stories__/Buttons.story.tsx',
   '../src/lib/Components/Consignments/__stories__/BottomAligned.story.tsx',
   '../src/lib/Components/Consignments/__stories__/Consignments.story.tsx',


### PR DESCRIPTION
This creates an empty bid flow component and exports it as a `UIViewController` subclass for Eigen. Nothing fancy, and we'll probably move to something [like this](https://github.com/artsy/emission/blob/a9e835051d0373c789b0288f1fe45cbb3ee8c985/src/lib/Components/Consignments/index.tsx#L57-L70) in the near future but this is a good starting point.

Once this is merged, we can cut a release of Emission and update Eigen. 

Paired with @sepans on most of this.

Fixes https://artsyproduct.atlassian.net/browse/PURCHASE-34 and https://artsyproduct.atlassian.net/browse/PURCHASE-35

#skip_new_tests