### PR TITLE
Add the ability to specifically style the button headline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Cache queries on-disk for 1 day - alloy
 * Add persisted queries support to Relay - alloy
 * Add ability to preload queries - alloy
+* Add ability to specifically style the button headline - yuki24
 
 ## 1.4.6
 

--- a/src/lib/Components/Buttons/Button.tsx
+++ b/src/lib/Components/Buttons/Button.tsx
@@ -147,7 +147,9 @@ export default class Button extends React.Component<Props, State> {
       style: [styles.button, { backgroundColor, borderColor }, this.props.style],
     }
 
-    const headlineStyles = [styles.text, { opacity: this.state.textOpacity, color }]
+    const textStyle = this.props.textStyle || {}
+
+    const headlineStyles = [styles.text, textStyle, { opacity: this.state.textOpacity, color }]
 
     return (
       <TouchableWithoutFeedback onPress={this.onPress} onPressIn={this.startHighlight} onPressOut={this.endHighlight}>

--- a/src/lib/Components/Buttons/__stories__/Buttons.story.tsx
+++ b/src/lib/Components/Buttons/__stories__/Buttons.story.tsx
@@ -17,6 +17,15 @@ const style = {
   style: { margin: 10 },
 }
 
+const largeButtonStyle = {
+  height: 46,
+  margin: 10,
+}
+
+const textStyle = {
+  fontSize: 14,
+}
+
 const emptyFunc = () => ""
 
 storiesOf("App Style/Buttons")
@@ -25,6 +34,12 @@ storiesOf("App Style/Buttons")
     return [
       <GhostButton text="Disabled" {...style} key="1" />,
       <GhostButton text="Clickable" onPress={emptyFunc} {...style} key="2" />,
+    ]
+  })
+  .add("Button With Text Style", () => {
+    return [
+      <GhostButton text="Clickable" onPress={emptyFunc} style={largeButtonStyle} textStyle={textStyle} key="1" />,
+      <InvertedButton text="Clickable" onPress={emptyFunc} style={largeButtonStyle} textStyle={textStyle} key="2" />,
     ]
   })
   .add("Inverted Button", () => {

--- a/src/lib/Components/Buttons/__tests__/InvertedButton-tests.tsx
+++ b/src/lib/Components/Buttons/__tests__/InvertedButton-tests.tsx
@@ -3,9 +3,18 @@ import "react-native"
 import React from "react"
 import * as renderer from "react-test-renderer"
 
-import InvertedButton from "../InvertedButton"
+import { InvertedButton } from "../"
 
 it("renders properly", () => {
   const button = renderer.create(<InvertedButton text={"I am an inverted button"} />).toJSON()
+  expect(button).toMatchSnapshot()
+})
+
+it("accepts textStyle prop", () => {
+  const textStyle = {
+    fontSize: 20,
+  }
+
+  const button = renderer.create(<InvertedButton text={"I am an inverted button"} textStyle={textStyle} />).toJSON()
   expect(button).toMatchSnapshot()
 })

--- a/src/lib/Components/Buttons/__tests__/__snapshots__/InvertedButton-tests.tsx.snap
+++ b/src/lib/Components/Buttons/__tests__/__snapshots__/InvertedButton-tests.tsx.snap
@@ -1,14 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders properly 1`] = `
+exports[`accepts textStyle prop 1`] = `
 <View
   accessibilityComponentType={undefined}
   accessibilityLabel={undefined}
   accessibilityTraits={undefined}
   accessible={true}
-  hasTVPreferredFocus={undefined}
+  collapsable={undefined}
   hitSlop={undefined}
-  isTVSelectable={true}
   nativeID={undefined}
   onLayout={undefined}
   onResponderGrant={[Function]}
@@ -20,38 +19,90 @@ exports[`renders properly 1`] = `
   style={
     Object {
       "alignItems": "center",
-      "backgroundColor": "rgba(0, 0, 0, 1)",
-      "flex": 1,
+      "backgroundColor": "rgba(51, 51, 51, 1)",
+      "borderColor": "rgba(248, 248, 248, 1)",
+      "borderWidth": 1,
+      "height": 36,
       "justifyContent": "center",
     }
   }
   testID={undefined}
-  tvParallaxProperties={undefined}
 >
-  <View
-    style={null}
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "fontSize": 12,
+        },
+        Object {
+          "color": "rgba(204, 204, 204, 1)",
+          "fontFamily": "AGaramondPro-Regular",
+          "fontSize": 20,
+          "opacity": 1,
+        },
+        Object {
+          "fontFamily": "AvantGardeGothicITC",
+        },
+      ]
+    }
   >
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
-      style={
-        Array [
-          Object {
-            "fontSize": 12,
-          },
-          Object {
-            "color": "white",
-            "opacity": 1,
-          },
-          Object {
-            "fontFamily": "AvantGardeGothicITC",
-          },
-        ]
-      }
-    >
-      I AM AN INVERTED BUTTON
-    </Text>
-  </View>
+    I AM AN INVERTED BUTTON
+  </Text>
+</View>
+`;
+
+exports[`renders properly 1`] = `
+<View
+  accessibilityComponentType={undefined}
+  accessibilityLabel={undefined}
+  accessibilityTraits={undefined}
+  accessible={true}
+  collapsable={undefined}
+  hitSlop={undefined}
+  nativeID={undefined}
+  onLayout={undefined}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "rgba(51, 51, 51, 1)",
+      "borderColor": "rgba(248, 248, 248, 1)",
+      "borderWidth": 1,
+      "height": 36,
+      "justifyContent": "center",
+    }
+  }
+  testID={undefined}
+>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "fontSize": 12,
+        },
+        Object {
+          "color": "rgba(204, 204, 204, 1)",
+          "fontFamily": "AGaramondPro-Regular",
+          "opacity": 1,
+        },
+        Object {
+          "fontFamily": "AvantGardeGothicITC",
+        },
+      ]
+    }
+  >
+    I AM AN INVERTED BUTTON
+  </Text>
 </View>
 `;

--- a/src/lib/Components/Buttons/index.tsx
+++ b/src/lib/Components/Buttons/index.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Animated, ViewProperties } from "react-native"
+import { Animated, TextStyle, ViewProperties } from "react-native"
 
 import { Colors } from "lib/data/colors"
 
@@ -102,6 +102,8 @@ export interface ButtonProps extends ViewProperties {
   onPress?: React.TouchEventHandler<Button>
   /** Optional callback for when an animation is finished */
   onSelectionAnimationFinished?: Animated.EndCallback
+  /** CSS properties applied to the text of the button */
+  textStyle?: TextStyle
 }
 
 export const InvertedButton = (props: ButtonProps) => <Button {...props} stateColors={flatBlackTheme} />


### PR DESCRIPTION
Right now, the `<Button>` component accepts the `style` prop that allows for styling the button container. But since it is [passed into the `<AnimatedView>` component](https://github.com/artsy/emission/blob/7cfcbd3c6b550925bc59bce75a66d6f2d7c3e76b/src/lib/Components/Buttons/Button.tsx#L154), it actually doesn't allow for styling [the headline in the button](https://github.com/artsy/emission/blob/7cfcbd3c6b550925bc59bce75a66d6f2d7c3e76b/src/lib/Components/Buttons/Button.tsx#L150) (or the styles on the headline are taking the precedence so we cannot override them).

In the new bidding flow, we are going to have to [set the font size of the button to `14`](https://app.zeplin.io/project/5ab94282c124db8d58365b47/screen/5ac66d5c15dd161833080c10) (which is currently [set to `12`](https://github.com/artsy/emission/blob/7cfcbd3c6b550925bc59bce75a66d6f2d7c3e76b/src/lib/Components/Text/Headline.tsx#L16) anywhere). This PR adds the ability to specifically style the button headline so we will be able to re-use it in the new bidding flow.

![screen_shot_2018-04-13_at_4_39_54_pm](https://user-images.githubusercontent.com/386234/38757128-e01149ee-3f39-11e8-854d-3a3540776aa2.png)

(in the screenshot, I deliberately used `fontSize: 18` to make the visible change clear, but in the actual flow we will use `14`)

#skip_new_tests