### PR TITLE
Use a more appropriate type for textStyle in ButtonProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Add ability to preload queries - alloy
 * Add ability to specifically style the button headline - yuki24
 * Adds (empty) BidFlow component and view controller - ashfurrow
+* Use a more appropriate type for textStyle in ButtonProps - yuki24
 
 ## 1.4.6
 

--- a/src/lib/Components/Buttons/index.tsx
+++ b/src/lib/Components/Buttons/index.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Animated, TextStyle, ViewProperties } from "react-native"
+import { Animated, StyleProp, TextStyle, ViewProperties } from "react-native"
 
 import { Colors } from "lib/data/colors"
 
@@ -103,7 +103,7 @@ export interface ButtonProps extends ViewProperties {
   /** Optional callback for when an animation is finished */
   onSelectionAnimationFinished?: Animated.EndCallback
   /** CSS properties applied to the text of the button */
-  textStyle?: TextStyle
+  textStyle?: StyleProp<TextStyle>
 }
 
 export const InvertedButton = (props: ButtonProps) => <Button {...props} stateColors={flatBlackTheme} />


### PR DESCRIPTION
It seems that the correct type for `textStyle` is actually `StyleProp<TextStyle>`, not just `TextStyle`. Without this TS will complain about the `[style.default, textStyle]` syntax and errors out when running a type check:

```
src/lib/Components/Bidding/Components/Button.tsx(10,28): error TS2322: Type '{ children?: ReactNode; text: string; onPress?: (event: TouchEvent<Button>) => void; onSelectionA...' is not assignable to type 'IntrinsicAttributes & ButtonProps'.
  Type '{ children?: ReactNode; text: string; onPress?: (event: TouchEvent<Button>) => void; onSelectionA...' is not assignable to type 'ButtonProps'.
    Types of property 'textStyle' are incompatible.
      Type '(TextStyle | RegisteredStyle<{ fontSize: number; }>)[]' has no properties in common with type 'TextStyle'.

10     return <InvertedButton style={[styles.default, style]} textStyle={[styles.text, textStyle]} {...props} />
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Using `StyleProp<TextStyle>` as a type should fix the type error above.