### PR TITLE
Fixes bid picker not staying on selected index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Load Bid prices dynamically - sepans
 * Adds bid result screens - yuki24
 * Updates bid flow to consume preformatted bid increments - ash
+* Updates MaxBidPicker to maintain state of currently selected bid increment - ash
 
 ## 1.4.6
 

--- a/src/lib/Components/Bidding/Components/MaxBidPicker.tsx
+++ b/src/lib/Components/Bidding/Components/MaxBidPicker.tsx
@@ -9,18 +9,12 @@ interface Bid {
 
 export interface MaxBidPickerProps extends PickerProperties {
   bids: Bid[]
-  selectedBidIndex: number
-  onSelectNewBidIndex: (number) => void
 }
 
 export class MaxBidPicker extends React.Component<MaxBidPickerProps> {
   render() {
     return (
-      <StyledPicker
-        {...this.props}
-        onValueChange={(_, index) => this.props.onSelectNewBidIndex(index)}
-        selectedValue={this.props.selectedBidIndex}
-      >
+      <StyledPicker {...this.props} onValueChange={this.props.onValueChange} selectedValue={this.props.selectedValue}>
         {this.props.bids.map((bid, index) => <Picker.Item key={index} value={index} label={bid.label} />)}
       </StyledPicker>
     )

--- a/src/lib/Components/Bidding/Components/MaxBidPicker.tsx
+++ b/src/lib/Components/Bidding/Components/MaxBidPicker.tsx
@@ -9,13 +9,19 @@ interface Bid {
 
 export interface MaxBidPickerProps extends PickerProperties {
   bids: Bid[]
+  selectedBidIndex: number
+  onSelectNewBidIndex: (number) => void
 }
 
 export class MaxBidPicker extends React.Component<MaxBidPickerProps> {
   render() {
     return (
-      <StyledPicker {...this.props}>
-        {this.props.bids.map((bid, index) => <Picker.Item key={index} {...bid} />)}
+      <StyledPicker
+        {...this.props}
+        onValueChange={(_, index) => this.props.onSelectNewBidIndex(index)}
+        selectedValue={this.props.selectedBidIndex}
+      >
+        {this.props.bids.map((bid, index) => <Picker.Item key={index} value={index} label={bid.label} />)}
       </StyledPicker>
     )
   }

--- a/src/lib/Components/Bidding/Components/__tests__/MaxBidPicker-tests.tsx
+++ b/src/lib/Components/Bidding/Components/__tests__/MaxBidPicker-tests.tsx
@@ -16,6 +16,6 @@ const Bids = [
 ]
 
 it("renders properly", () => {
-  const bg = renderer.create(<MaxBidPicker bids={Bids} selectedBidIndex={0} onSelectNewBidIndex={jest.fn()} />).toJSON()
+  const bg = renderer.create(<MaxBidPicker bids={Bids} selectedValue={0} onValueChange={jest.fn()} />).toJSON()
   expect(bg).toMatchSnapshot()
 })

--- a/src/lib/Components/Bidding/Components/__tests__/MaxBidPicker-tests.tsx
+++ b/src/lib/Components/Bidding/Components/__tests__/MaxBidPicker-tests.tsx
@@ -16,6 +16,6 @@ const Bids = [
 ]
 
 it("renders properly", () => {
-  const bg = renderer.create(<MaxBidPicker bids={Bids} />).toJSON()
+  const bg = renderer.create(<MaxBidPicker bids={Bids} selectedBidIndex={0} onSelectNewBidIndex={jest.fn()} />).toJSON()
   expect(bg).toMatchSnapshot()
 })

--- a/src/lib/Components/Bidding/Components/__tests__/__snapshots__/MaxBidPicker-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Components/__tests__/__snapshots__/MaxBidPicker-tests.tsx.snap
@@ -17,12 +17,12 @@ exports[`renders properly 1`] = `
         Object {
           "label": "$35,000 USD",
           "textColor": undefined,
-          "value": 3500000,
+          "value": 0,
         },
         Object {
           "label": "$40,000 USD",
           "textColor": undefined,
-          "value": 4000000,
+          "value": 1,
         },
       ]
     }

--- a/src/lib/Components/Bidding/Screens/SelectMaxBid.tsx
+++ b/src/lib/Components/Bidding/Screens/SelectMaxBid.tsx
@@ -14,7 +14,14 @@ interface SelectMaxBidProps extends ViewProperties {
   sale_artwork: SelectMaxBid_sale_artwork
 }
 
-export class SelectMaxBid extends React.Component<SelectMaxBidProps> {
+interface SelectMaxBidState {
+  selectedBidIndex: number
+}
+
+export class SelectMaxBid extends React.Component<SelectMaxBidProps, SelectMaxBidState> {
+  state = {
+    selectedBidIndex: 0,
+  }
   render() {
     // TODO metaphysics should return formatted values
     const bids =
@@ -26,7 +33,11 @@ export class SelectMaxBid extends React.Component<SelectMaxBidProps> {
       <Container>
         <Title style={Margins.m1}>Your max bid</Title>
 
-        <MaxBidPicker bids={bids} />
+        <MaxBidPicker
+          bids={bids}
+          selectedBidIndex={this.state.selectedBidIndex}
+          onSelectNewBidIndex={index => this.setState({ selectedBidIndex: index })}
+        />
 
         <Button text="NEXT" onPress={() => null} />
       </Container>

--- a/src/lib/Components/Bidding/Screens/SelectMaxBid.tsx
+++ b/src/lib/Components/Bidding/Screens/SelectMaxBid.tsx
@@ -35,8 +35,8 @@ export class SelectMaxBid extends React.Component<SelectMaxBidProps, SelectMaxBi
 
         <MaxBidPicker
           bids={bids}
-          selectedBidIndex={this.state.selectedBidIndex}
-          onSelectNewBidIndex={index => this.setState({ selectedBidIndex: index })}
+          onValueChange={(_, index) => this.setState({ selectedBidIndex: index })}
+          selectedValue={this.state.selectedBidIndex}
         />
 
         <Button text="NEXT" onPress={() => null} />

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/SelectMaxBid-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/SelectMaxBid-tests.tsx.snap
@@ -55,27 +55,27 @@ exports[`renders properly 1`] = `
           Object {
             "label": "$35,000",
             "textColor": undefined,
-            "value": 3500000,
+            "value": 0,
           },
           Object {
             "label": "$40,000",
             "textColor": undefined,
-            "value": 4000000,
+            "value": 1,
           },
           Object {
             "label": "$45,000",
             "textColor": undefined,
-            "value": 4500000,
+            "value": 2,
           },
           Object {
             "label": "$50,000",
             "textColor": undefined,
-            "value": 5000000,
+            "value": 3,
           },
           Object {
             "label": "$55,000",
             "textColor": undefined,
-            "value": 5500000,
+            "value": 4,
           },
         ]
       }

--- a/src/lib/Containers/__tests__/__snapshots__/BidFlow-tests.tsx.snap
+++ b/src/lib/Containers/__tests__/__snapshots__/BidFlow-tests.tsx.snap
@@ -125,27 +125,27 @@ exports[`renders properly 1`] = `
                 Object {
                   "label": "$35,000",
                   "textColor": undefined,
-                  "value": 3500000,
+                  "value": 0,
                 },
                 Object {
                   "label": "$40,000",
                   "textColor": undefined,
-                  "value": 4000000,
+                  "value": 1,
                 },
                 Object {
                   "label": "$45,000",
                   "textColor": undefined,
-                  "value": 4500000,
+                  "value": 2,
                 },
                 Object {
                   "label": "$50,000",
                   "textColor": undefined,
-                  "value": 5000000,
+                  "value": 3,
                 },
                 Object {
                   "label": "$55,000",
                   "textColor": undefined,
-                  "value": 5500000,
+                  "value": 4,
                 },
               ]
             }


### PR DESCRIPTION
I noticed that after selecting a new bid increment, that the picker would always snap back. This PR adds state to the `SelectMaxBid` component. I think that it makes sense to put the state here, since we'll need to access it to forward on to the subsequent confirmation screen. But open to suggestions!

This work was done in the course of https://artsyproduct.atlassian.net/browse/PURCHASE-41 