### PR TITLE
Adds commonly used typefaces to storybook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Load Bid prices dynamically - sepans
 * Adds bid result screens - yuki24
 * Updates bid flow to consume preformatted bid increments - ash
+* Adds commonly used typefaces - yuki24
 
 ## 1.4.6
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
     - ISO8601DateFormatter
     - NSURL+QueryDictionary
   - Artsy+UIColors (3.1.0)
-  - Artsy+UIFonts (3.1.3)
+  - Artsy+UIFonts (3.2.0)
   - Artsy-UIButtons (2.1.0):
     - Artsy+UIColors (~> 3.0)
     - Artsy+UIFonts
@@ -179,7 +179,7 @@ SPEC CHECKSUMS:
   ARGenericTableViewController: 61a0897ba66c35111b5d1cc3b44884282bd3c1a5
   Artsy+Authentication: 3bf11ceca61c52e9e31490535bf5798f625406fa
   Artsy+UIColors: 31c03c4146f5e6618a9b950f37dfe02dd9ac09a6
-  Artsy+UIFonts: d38c82636e000b1dee31b7bec0268e1841dac17f
+  Artsy+UIFonts: d29579aa105e3709032651fb3145d24f8339e905
   Artsy-UIButtons: cdcc3ccf4d0d31ee80f45c1d11ffd2d772695b74
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: ebb6747c5b66026ad4f97b789c3ceac6f18e57a6

--- a/Pod/Classes/Core/AREmissionFontsLoader.m
+++ b/Pod/Classes/Core/AREmissionFontsLoader.m
@@ -25,6 +25,10 @@
   font = [UIFont serifFontWithSize:12];
   font = [UIFont serifItalicFontWithSize:12];
   font = [UIFont sansSerifFontWithSize:12];
+  font = [UIFont displaySansSerifFontWithSize:12];
+  font = [UIFont displayItalicSansSerifFontWithSize:12];
+  font = [UIFont displayMediumSansSerifFontWithSize:12];
+  font = [UIFont displayMediumItalicSansSerifFontWithSize:12];
 //  font = [UIFont smallCapsSerifFontWithSize:12];
 }
 

--- a/src/lib/Components/Text/__stories__/Typography.story.tsx
+++ b/src/lib/Components/Text/__stories__/Typography.story.tsx
@@ -1,6 +1,8 @@
 import { storiesOf } from "@storybook/react-native"
 import React from "react"
+import styled from "styled-components/native"
 
+import { Fonts } from "lib/data/fonts"
 import Headline from "../Headline"
 import Serif from "../Serif"
 
@@ -11,3 +13,83 @@ storiesOf("App Style/Typography")
   .add("App Serif Text", () => {
     return <Serif>This is a blank serif</Serif>
   })
+  .add("Typefaces", () => {
+    return (
+      <Container>
+        <GaramondBold>AGaramondPro Bold</GaramondBold>
+        <GaramondBoldItalic>AGaramondPro BoldItalic</GaramondBoldItalic>
+        <GaramondItalic>AGaramondPro Italic</GaramondItalic>
+        <GaramondRegular>AGaramondPro Regular</GaramondRegular>
+        <GaramondSemibold>AGaramondPro Semibold</GaramondSemibold>
+        <AvantGardeRegular>Avant Garde Gothic ITC</AvantGardeRegular>
+        <Unita77LLItalic>Unica77LL Italic</Unita77LLItalic>
+        <Unita77LLMedium>Unica77LL Medium</Unita77LLMedium>
+        <Unita77LLMediumItalic>Unica77LL MediumItalic</Unita77LLMediumItalic>
+        <Unita77LLRegular>Unica77LL Regular</Unita77LLRegular>
+      </Container>
+    )
+  })
+
+const Container = styled.View`
+  margin: 70px 10px 10px;
+`
+
+const GaramondBold = styled.Text`
+  font-family: "${Fonts.GaramondBold}";
+  font-size: 30px;
+  margin-bottom: 10px;
+`
+
+const GaramondBoldItalic = styled.Text`
+  font-family: "${Fonts.GaramondBoldItalic}";
+  font-size: 30px;
+  margin-bottom: 10px;
+`
+
+const GaramondItalic = styled.Text`
+  font-family: "${Fonts.GaramondItalic}";
+  font-size: 30px;
+  margin-bottom: 10px;
+`
+
+const GaramondRegular = styled.Text`
+  font-family: "${Fonts.GaramondRegular}";
+  font-size: 30px;
+  margin-bottom: 10px;
+`
+
+const GaramondSemibold = styled.Text`
+  font-family: "${Fonts.GaramondSemibold}";
+  font-size: 30px;
+  margin-bottom: 10px;
+`
+
+const AvantGardeRegular = styled.Text`
+  font-family: "${Fonts.AvantGardeRegular}";
+  font-size: 30px;
+  margin-bottom: 10px;
+`
+
+const Unita77LLItalic = styled.Text`
+  font-family: "${Fonts.Unica77LLItalic}";
+  font-size: 30px;
+  margin-bottom: 10px;
+`
+
+const Unita77LLMedium = styled.Text`
+  font-family: "${Fonts.Unica77LLMedium}";
+  font-size: 30px;
+  margin-bottom: 10px;
+`
+
+const Unita77LLMediumItalic = styled.Text`
+  font-family: "${Fonts.Unica77LLMediumItalic}";
+  font-size: 30px;
+  margin-bottom: 10px;
+`
+
+const Unita77LLRegular = styled.Text`
+  font-family: "${Fonts.Unica77LLRegular}";
+  font-size: 30px;
+  margin-bottom: 10px;
+`

--- a/src/lib/data/fonts.ts
+++ b/src/lib/data/fonts.ts
@@ -1,9 +1,16 @@
 // Prefer using this instead of the default export
 
 export enum Fonts {
-  GaramondRegular = "AGaramondPro-Regular",
+  GaramondBold = "AGaramondPro-Bold",
+  GaramondBoldItalic = "AGaramondPro-BoldItalic",
   GaramondItalic = "AGaramondPro-Italic",
+  GaramondRegular = "AGaramondPro-Regular",
+  GaramondSemibold = "AGaramondPro-Semibold",
   AvantGardeRegular = "AvantGardeGothicITC",
+  Unica77LLItalic = "Unica77LL-Italic",
+  Unica77LLMedium = "Unica77LL-Medium",
+  Unica77LLMediumItalic = "Unica77LL-MediumItalic",
+  Unica77LLRegular = "Unica77LL-Regular",
 }
 
 export default {


### PR DESCRIPTION
Previous PR: https://github.com/artsy/emission/pull/1020

This adds commonly used typefaces in the new bidding flow:

 * GaramondBold
 * GaramondBoldItalic
 * GaramondRegular
 * GaramondSemibold
 * Unica77LLItalic
 * Unica77LLMedium
 * Unica77LLMediumItalic
 * Unica77LLRegular

![screen shot 2018-04-23 at 5 09 25 pm](https://user-images.githubusercontent.com/386234/39153480-41d8c2c4-4719-11e8-9cd8-a0cbfab70304.png)

#skip_new_tests