### PR TITLE
Corrects Changelog header format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 -->
 
-## Master
+### Master
 
 * Adds Recently Viewed Works rail to Home - sarah
 * Upgrade to React Native 0.54.4 - alloy/orta
@@ -37,7 +37,7 @@
 * Transitions between the bid picker to the bid confirmation components - ash
 * Adds a more re-useable low-level components - yuki24
 
-## 1.4.6
+### 1.4.6
 
 * Scroll to last sent message upon send - sarah
 * Upgrade to latest Relay, including our custome Node ID and language plugin patches - alloy


### PR DESCRIPTION
The changelog has historically used an H2 for master and H3's for releases. But this convention was broken [in this release](https://github.com/artsy/emission/commit/eaebfb8e9d8066d80993478d487d848e02c1bca2), which our automated deploy script relies on:

https://github.com/artsy/emission-nebula/blob/f8bd8465cd6e2e13038020099119dfaef22c983d/fastlane/Fastfile#L61

This PR does two things:

- Corrects the 1.4.6 header.
- Changes master to use H3 too, so this won't be likely to happen again.

If merged, I'll make a corresponding change in emission-nebula to make sure this still works. 