### PR TITLE
Show conditions of sale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * Adds a confirmation screen for first-time bidders - yuki24
 * Adds a new color `red100` (`#F7625A`) to the theme - yuki24
 * Adds a `<CheckBox>` component - yuki24
+* Adds support for viewing conditions of sale - ash
 
 ### 1.4.6
 

--- a/Example/Emission/AppDelegate.m
+++ b/Example/Emission/AppDelegate.m
@@ -181,6 +181,7 @@ randomBOOL(void)
     }
     UIViewController *viewController = [self viewControllerForRoute:route];
     UINavigationController *navigationController = [[EigenLikeNavigationController alloc] initWithRootViewController:viewController];
+    navigationController.navigationBarHidden = NO;
     viewController.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone
                                                                                                     target:self
                                                                                                     action:@selector(dismissModalViewController)];
@@ -251,7 +252,7 @@ randomBOOL(void)
 - (void)dismissModalViewController;
 {
   UINavigationController *navigationController = (UINavigationController *)self.window.rootViewController;
-  [navigationController.visibleViewController.navigationController dismissViewControllerAnimated:YES completion:nil];
+  [navigationController dismissViewControllerAnimated:YES completion:nil];
 }
 
 - (void)downloadPRBuildAndLoginWithUserID:(NSString *)userID

--- a/Example/Emission/UnroutedViewController.m
+++ b/Example/Emission/UnroutedViewController.m
@@ -37,7 +37,7 @@
 
   BOOL useStaging = [[NSUserDefaults standardUserDefaults] boolForKey:ARUseStagingDefault];
   NSURL *url = [NSURL URLWithString: useStaging ? @"https://staging.artsy.net" : @"https://artsy.net"];
-  return [url URLByAppendingPathComponent:route];
+  return [NSURL URLWithString:route relativeToURL:url];
 }
 
 - (void)loadURL:(NSURL *)URL;

--- a/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
@@ -35,7 +35,7 @@ interface ConfirmBidProps extends ViewProperties {
 
 export class ConfirmBid extends React.Component<ConfirmBidProps> {
   onPressConditionsOfSale = () => {
-    SwitchBoard.presentModalViewController(this, "/conditions-of-sale")
+    SwitchBoard.presentModalViewController(this, "/conditions-of-sale?present_modally=true")
   }
   render() {
     return (

--- a/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
@@ -21,6 +21,8 @@ import { Divider } from "../Components/Divider"
 import { Margins } from "../Components/Margins"
 import { Title } from "../Components/Title"
 
+import SwitchBoard from "lib/NativeModules/SwitchBoard"
+
 import { ConfirmBid_sale_artwork } from "__generated__/ConfirmBid_sale_artwork.graphql"
 
 interface ConfirmBidProps extends ViewProperties {
@@ -32,6 +34,9 @@ interface ConfirmBidProps extends ViewProperties {
 }
 
 export class ConfirmBid extends React.Component<ConfirmBidProps> {
+  onPressConditionsOfSale = () => {
+    SwitchBoard.presentModalViewController(this, "/conditions-of-sale")
+  }
   render() {
     return (
       <BiddingThemeProvider>
@@ -64,7 +69,7 @@ export class ConfirmBid extends React.Component<ConfirmBidProps> {
 
           <View>
             <Serif14 mb={3} color="black60" textAlign="center">
-              You agree to <LinkText>Condition of Sale</LinkText>.
+              You agree to <LinkText onPress={this.onPressConditionsOfSale}>Conditions of Sale</LinkText>.
             </Serif14>
 
             <Button style={Margins.m2} text="Place Bid" onPress={() => null} />

--- a/src/lib/Components/Bidding/Screens/ConfirmFirstTimeBid.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmFirstTimeBid.tsx
@@ -19,6 +19,8 @@ import { Container } from "../Components/Containers"
 import { Divider } from "../Components/Divider"
 import { Title } from "../Components/Title"
 
+import SwitchBoard from "lib/NativeModules/SwitchBoard"
+
 import { ConfirmBid_sale_artwork } from "__generated__/ConfirmBid_sale_artwork.graphql"
 import { Checkbox } from "../Components/Checkbox"
 
@@ -31,6 +33,9 @@ interface ConfirmBidProps extends ViewProperties {
 }
 
 export class ConfirmFirstTimeBid extends React.Component<ConfirmBidProps> {
+  onPressConditionsOfSale = () => {
+    SwitchBoard.presentModalViewController(this, "/conditions-of-sale")
+  }
   render() {
     return (
       <BiddingThemeProvider>
@@ -86,7 +91,7 @@ export class ConfirmFirstTimeBid extends React.Component<ConfirmBidProps> {
           <View>
             <Checkbox alignSelf="center" m={3}>
               <Serif16 mt={2} textAlign="center" color="black60">
-                Agree to <LinkText>Condition of Sale</LinkText>.
+                Agree to <LinkText onPress={this.onPressConditionsOfSale}>Conditions of Sale</LinkText>.
               </Serif16>
             </Checkbox>
 

--- a/src/lib/Components/Bidding/Screens/ConfirmFirstTimeBid.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmFirstTimeBid.tsx
@@ -34,7 +34,7 @@ interface ConfirmBidProps extends ViewProperties {
 
 export class ConfirmFirstTimeBid extends React.Component<ConfirmBidProps> {
   onPressConditionsOfSale = () => {
-    SwitchBoard.presentModalViewController(this, "/conditions-of-sale")
+    SwitchBoard.presentModalViewController(this, "/conditions-of-sale?present_modally=true")
   }
   render() {
     return (

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmBid-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmBid-tests.tsx.snap
@@ -276,6 +276,7 @@ exports[`renders properly 1`] = `
         accessible={true}
         allowFontScaling={true}
         ellipsizeMode="tail"
+        onPress={[Function]}
         style={
           Array [
             Object {
@@ -285,7 +286,7 @@ exports[`renders properly 1`] = `
           ]
         }
       >
-        Condition of Sale
+        Conditions of Sale
       </Text>
       .
     </Text>

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmFirstTimeBid-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmFirstTimeBid-tests.tsx.snap
@@ -566,6 +566,7 @@ exports[`renders properly 1`] = `
               accessible={true}
               allowFontScaling={true}
               ellipsizeMode="tail"
+              onPress={[Function]}
               style={
                 Array [
                   Object {
@@ -575,7 +576,7 @@ exports[`renders properly 1`] = `
                 ]
               }
             >
-              Condition of Sale
+              Conditions of Sale
             </Text>
             .
           </Text>


### PR DESCRIPTION
This is one of two required pull requests for conditions of sale. The other is here: https://github.com/artsy/eigen/pull/2599 This is a WIP because we still need to scope the `/conditions-of-sale` route to _only_ condition of sale links from Emission components (we'll add a query string to avoid other links to `/conditions-of-sale` being presenting modally).

Work tracked against [PURCHASE-60](https://artsyproduct.atlassian.net/browse/PURCHASE-60).