### PR TITLE
Adds Map 🗺 to Emission

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This is a core [Artsy Mobile](https://github.com/artsy/mobile) OSS project, alon
 
 Don't know what Artsy is? Check out [this overview](https://github.com/artsy/meta/blob/master/meta/what_is_artsy.md) and [more](https://github.com/artsy/meta/blob/master/README.md), or read our objc.io on [team culture](https://www.objc.io/issues/22-scale/artsy).
 
-Want to know more about Emission? Read the [mobile](http://artsy.github.io/blog/categories/mobile/) blog posts, or [Emission's](http://artsy.github.io/blog/categories/emission/) / [React Native's](http://artsy.github.io/blog/categories/reactnative/) specifically.
+Want to know more about Emission? Read the [mobile](http://artsy.github.io/blog/categories/mobile/) blog posts, or [Emission's](http://artsy.github.io/blog/categories/emission/) / [React Native's](http://artsy.github.io/blog/categories/reactnative/) specifically. Also check out [the map to Emission](docs/map_to_emission.md) to oriented yourself to the codebase.
 
 ### Installation
 

--- a/docs/map_to_emission.md
+++ b/docs/map_to_emission.md
@@ -15,6 +15,7 @@ Links should point to specific commits, and not a branch (in case the branch or 
 
 * [Why Artsy uses React Native](http://artsy.github.io/blog/2016/08/15/React-Native-at-Artsy/)
 * [All React Native posts on Artsy's Engineering Blog](http://artsy.github.io/blog/categories/reactnative/)
+* TODO: What's our best React Native component? Which in-prod component exemplifies our state-of-the-art best practices?
 
 ### Relay
 
@@ -26,6 +27,38 @@ Links should point to specific commits, and not a branch (in case the branch or 
 
 * Our use of [styled-components](https://www.styled-components.com) was supplemented by [styled-system](https://github.com/jxnblk/styled-system) in [#1016](https://github.com/artsy/emission/pull/1016).
 * [Example pull request migrating a component from styled-components to styled-system](https://github.com/artsy/emission/pull/1031)
+
+### Storybooks
+
+We use storybooks for rapid prototyping and quick feedback when we change code.
+
+* [New Bid Flow stories](https://github.com/artsy/emission/blob/751d24306a2d6ace58b21491e25b37f345c7a206/src/lib/Components/Bidding/__stories__/BidFlow.story.tsx)
+
+### Unit Testing
+
+Unit testing on Emission is a bit all over the place. Here are some great examples of what tests and test coverage should look like.
+
+* [Tests for Gene component](https://github.com/artsy/emission/blob/751d24306a2d6ace58b21491e25b37f345c7a206/src/lib/Containers/__tests__/Gene-tests.tsx)
+* [Tests for Consignments submission flow](https://github.com/artsy/emission/blob/751d24306a2d6ace58b21491e25b37f345c7a206/src/lib/Components/Consignments/Screens/__tests__/Confirmation-tests.tsx)
+* [Tests for Consignments photo-selection component interactions](https://github.com/artsy/emission/blob/751d24306a2d6ace58b21491e25b37f345c7a206/src/lib/Components/Consignments/Screens/__tests__/SelectFromPhotoLibrary-tests.tsx).
+* Consignments Overview is a really complex component, so tests are broken into four test files:
+  * [General component tests](https://github.com/artsy/emission/blob/751d24306a2d6ace58b21491e25b37f345c7a206/src/lib/Components/Consignments/Screens/__tests__/Overview-tests.tsx)
+  * [Analytics tests](https://github.com/artsy/emission/blob/751d24306a2d6ace58b21491e25b37f345c7a206/src/lib/Components/Consignments/Screens/__tests__/Overview-analytics-tests.tsx)
+  * [Local storage tests](https://github.com/artsy/emission/blob/751d24306a2d6ace58b21491e25b37f345c7a206/src/lib/Components/Consignments/Screens/__tests__/Overview-local-storage-tests.tsx)
+  * [Image uploading tests](https://github.com/artsy/emission/blob/751d24306a2d6ace58b21491e25b37f345c7a206/src/lib/Components/Consignments/Screens/__tests__/Overview-uploading-tests.tsx)
+
+### Eigen Interop
+
+Emission is used by Eigen, our main app. The structure is [described in this blog post](http://artsy.github.io/blog/2016/08/24/On-Emission/). Interop between the JavaScript (Emission) and the Objective-C/Swift (Eigen) can be tricky.
+
+_Most_ interactions are made through a "switchboard" to open links. A switchboard exists in Eigen, which users see, and a switchboard exists in the Emission test app for our internal testing. This is key: the switchboard in Emission isn't actually used in production, only the Eigen one is.
+
+Other interactions are handled by the `APIModules`, for example when Eigen needs to invoke some kind of callback.
+
+* [Switchboard routes defined in Eigen](https://github.com/artsy/eigen/blob/e0567ffc3c9619c66890998ae3cadfc026a290ae/Artsy/App/ARSwitchBoard.m#L131-L255)
+* [Emission test app route-handling](https://github.com/artsy/emission/blob/751d24306a2d6ace58b21491e25b37f345c7a206/Example/Emission/AppDelegate.m#L160-L189)
+* [Emission switchboard to call out to Eigen](https://github.com/artsy/emission/blob/751d24306a2d6ace58b21491e25b37f345c7a206/Pod/Classes/Core/ARSwitchBoardModule.m)
+* [Callbacks between JS and native code are set up here](https://github.com/artsy/emission/blob/24c0fdaf91aa79654a33fd6e476405047819be5b/Pod/Classes/TemporaryAPI/ARTemporaryAPIModule.m).
 
 ### Miscellaneous
 

--- a/docs/map_to_emission.md
+++ b/docs/map_to_emission.md
@@ -1,0 +1,40 @@
+As we have built our React Native components, our understanding of how to build those components as evolved. As that understanding grows, newer components use newer techniques and older ones are often left un-updated. It can be difficult to orient oneself around what the current preferred practices are.
+
+This document is a map. Not of Emission at a specific time, but a map of how we got here and where we want to go next. This is a living document, expected to be updated regularly, of links to:
+
+- Example code.
+- Pull requests with interesting discussions.
+- Conversations on Slack.
+- Blog posts.
+
+Links should point to specific commits, and not a branch (in case the branch or file is deleted, these links should always work). But it's possible that a file is outdated, that our understanding has moved on since it was linked to; in that case, please update this document.
+
+## Current Preferred Practices
+
+### React Native
+
+- [Why Artsy uses React Native](http://artsy.github.io/blog/2016/08/15/React-Native-at-Artsy/)
+- [All React Native posts on Artsy's Engineering Blog](http://artsy.github.io/blog/categories/reactnative/)
+
+### Relay
+
+- [Why Artsy uses Relay](http://artsy.github.io/blog/2017/02/05/Front-end-JavaScript-at-Artsy-2017/#Relay)
+- [Artsy JavaScriptures seminar on Relay](https://github.com/artsy/javascriptures/tree/master/4_intro-to-relay)
+- [Example of using Relay in the Inbox component](https://github.com/artsy/emission/blob/019a106517b31cebfb1c5293891215cc7ebf7a4d/src/lib/Containers/Inbox.tsx)
+
+### styled-system
+
+- [styled-system was added in #1016](https://github.com/artsy/emission/pull/1016)
+- [Example pull request migrating a component from styled-components to styled-system](https://github.com/artsy/emission/pull/1031)
+
+### Miscellaneous 
+
+- [Making network requests outside of Relay](https://github.com/artsy/emission/blob/019a106517b31cebfb1c5293891215cc7ebf7a4d/src/lib/Components/Consignments/Screens/Overview.tsx#L135-L150)
+
+## Formerly Preferred Practices
+
+These are techniques or approaches that we _used_ to use, but which have been replaced with newer concepts above.
+
+### styled-components
+
+Our use of [styled-components](https://www.styled-components.com) was replaced by [styled-system](https://github.com/jxnblk/styled-system) in [#1016](https://github.com/artsy/emission/pull/1016).

--- a/docs/map_to_emission.md
+++ b/docs/map_to_emission.md
@@ -2,10 +2,10 @@ As we have built our React Native components, our understanding of how to build 
 
 This document is a map. Not of Emission at a specific time, but a map of how we got here and where we want to go next. This is a living document, expected to be updated regularly, of links to:
 
-- Example code.
-- Pull requests with interesting discussions.
-- Conversations on Slack.
-- Blog posts.
+* Example code.
+* Pull requests with interesting discussions.
+* Conversations on Slack.
+* Blog posts.
 
 Links should point to specific commits, and not a branch (in case the branch or file is deleted, these links should always work). But it's possible that a file is outdated, that our understanding has moved on since it was linked to; in that case, please update this document.
 
@@ -13,28 +13,24 @@ Links should point to specific commits, and not a branch (in case the branch or 
 
 ### React Native
 
-- [Why Artsy uses React Native](http://artsy.github.io/blog/2016/08/15/React-Native-at-Artsy/)
-- [All React Native posts on Artsy's Engineering Blog](http://artsy.github.io/blog/categories/reactnative/)
+* [Why Artsy uses React Native](http://artsy.github.io/blog/2016/08/15/React-Native-at-Artsy/)
+* [All React Native posts on Artsy's Engineering Blog](http://artsy.github.io/blog/categories/reactnative/)
 
 ### Relay
 
-- [Why Artsy uses Relay](http://artsy.github.io/blog/2017/02/05/Front-end-JavaScript-at-Artsy-2017/#Relay)
-- [Artsy JavaScriptures seminar on Relay](https://github.com/artsy/javascriptures/tree/master/4_intro-to-relay)
-- [Example of using Relay in the Inbox component](https://github.com/artsy/emission/blob/019a106517b31cebfb1c5293891215cc7ebf7a4d/src/lib/Containers/Inbox.tsx)
+* [Why Artsy uses Relay](http://artsy.github.io/blog/2017/02/05/Front-end-JavaScript-at-Artsy-2017/#Relay)
+* [Artsy JavaScriptures seminar on Relay](https://github.com/artsy/javascriptures/tree/master/4_intro-to-relay)
+* [Example of using Relay in the Inbox component](https://github.com/artsy/emission/blob/019a106517b31cebfb1c5293891215cc7ebf7a4d/src/lib/Containers/Inbox.tsx)
 
-### styled-system
+### styled-system / styled-components
 
-- [styled-system was added in #1016](https://github.com/artsy/emission/pull/1016)
-- [Example pull request migrating a component from styled-components to styled-system](https://github.com/artsy/emission/pull/1031)
+* Our use of [styled-components](https://www.styled-components.com) was supplemented by [styled-system](https://github.com/jxnblk/styled-system) in [#1016](https://github.com/artsy/emission/pull/1016).
+* [Example pull request migrating a component from styled-components to styled-system](https://github.com/artsy/emission/pull/1031)
 
-### Miscellaneous 
+### Miscellaneous
 
-- [Making network requests outside of Relay](https://github.com/artsy/emission/blob/019a106517b31cebfb1c5293891215cc7ebf7a4d/src/lib/Components/Consignments/Screens/Overview.tsx#L135-L150)
+* [Making network requests outside of Relay](https://github.com/artsy/emission/blob/019a106517b31cebfb1c5293891215cc7ebf7a4d/src/lib/Components/Consignments/Screens/Overview.tsx#L135-L150)
 
 ## Formerly Preferred Practices
 
-These are techniques or approaches that we _used_ to use, but which have been replaced with newer concepts above.
-
-### styled-components
-
-Our use of [styled-components](https://www.styled-components.com) was replaced by [styled-system](https://github.com/jxnblk/styled-system) in [#1016](https://github.com/artsy/emission/pull/1016).
+These are techniques or approaches that we _used_ to use, but which have been replaced with newer concepts above. It's an empty list so far, but will grow with time.

--- a/docs/map_to_emission.md
+++ b/docs/map_to_emission.md
@@ -60,6 +60,10 @@ Other interactions are handled by the `APIModules`, for example when Eigen needs
 * [Emission switchboard to call out to Eigen](https://github.com/artsy/emission/blob/751d24306a2d6ace58b21491e25b37f345c7a206/Pod/Classes/Core/ARSwitchBoardModule.m)
 * [Callbacks between JS and native code are set up here](https://github.com/artsy/emission/blob/24c0fdaf91aa79654a33fd6e476405047819be5b/Pod/Classes/TemporaryAPI/ARTemporaryAPIModule.m).
 
+### Analytics
+
+There is [extensive inline documentation](https://github.com/artsy/emission/blob/7a4eb922cee70c621c9938bfda1db460e65414fc/src/lib/utils/track.ts#L175-L359) in our tracking code, including examples.
+
 ### Miscellaneous
 
 * [Making network requests outside of Relay](https://github.com/artsy/emission/blob/019a106517b31cebfb1c5293891215cc7ebf7a4d/src/lib/Components/Consignments/Screens/Overview.tsx#L135-L150)


### PR DESCRIPTION
In a recent Purchase team retrospective, we identified an opportunity to better document Emission. Developers rely on existing code as a foundation for writing new code, but not knowing which code should be used as a foundation impacts developer confidence. 

This map's goal is to be a living document that will accumulate links to pull requests, discussions, blog posts, etc, that relate to Emission's development. This initial PR is only a very small start – I didn't even try to make this comprehensive, just a few things that came to mind immediately. 

@mennenia I'd like to know what else should be included – I'm happy to be delegated to, or we can pair, or you can take over.