### PR TITLE
[Home/ForYou] Fix crash when following artist from ‘related artist’ rail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * Adds a new color `red100` (`#F7625A`) to the theme - yuki24
 * Adds a `<CheckBox>` component - yuki24
 * Adds support for viewing conditions of sale - ash
+* Fixes crash when following an artist from the ‘related artist’ Home/ForYou rail - alloy
 
 ### 1.4.6
 

--- a/src/lib/Scenes/Home/Components/ForYou/Components/ArtworkCarouselHeader.tsx
+++ b/src/lib/Scenes/Home/Components/ForYou/Components/ArtworkCarouselHeader.tsx
@@ -99,7 +99,7 @@ class ArtworkCarouselHeader extends Component<Props, State> {
   }
 
   @track(props => {
-    const artist = props.rail.followedArtistContext.artist || props.rail.relatedArtistContext.artist
+    const artist = getSubjectArtist(props)
     return {
       action_name: Schema.ActionNames.HomeArtistArtworksBlockFollow,
       action_type: Schema.ActionTypes.Tap,
@@ -109,14 +109,18 @@ class ArtworkCarouselHeader extends Component<Props, State> {
     }
   })
   handleFollowChange() {
-    const context = this.props.rail.followedArtistContext || this.props.rail.relatedArtistContext
-    ARTemporaryAPIModule.setFollowArtistStatus(!this.state.following, context.artist.id, (error, following) => {
+    const artist = getSubjectArtist(this.props)
+    ARTemporaryAPIModule.setFollowArtistStatus(!this.state.following, artist.id, (error, following) => {
       if (error) {
         console.error("ArtworkCarouselHeader.tsx", error)
       }
       this.setState({ following })
     })
   }
+}
+
+export function getSubjectArtist(props: Props) {
+  return props.rail.followedArtistContext.artist || props.rail.relatedArtistContext.artist
 }
 
 interface Styles {

--- a/src/lib/Scenes/Home/Components/ForYou/Components/__tests__/ArtworkCarouselHeader-tests.tsx
+++ b/src/lib/Scenes/Home/Components/ForYou/Components/__tests__/ArtworkCarouselHeader-tests.tsx
@@ -1,0 +1,41 @@
+import { getSubjectArtist } from "../ArtworkCarouselHeader"
+
+describe("getSubjectArtist", () => {
+  function getProps({ followedArtistContext, relatedArtistContext }) {
+    return {
+      rail: {
+        title: "A followed artist rail",
+        key: "followed_artist",
+        followedArtistContext,
+        relatedArtistContext,
+      },
+      handleViewAll: () => null,
+    }
+  }
+
+  it("fetches the followed artist", () => {
+    const props = getProps({
+      followedArtistContext: {
+        artist: {
+          _id: "banksy",
+          id: "banksy",
+        },
+      },
+      relatedArtistContext: {},
+    })
+    expect(getSubjectArtist(props)).toEqual(props.rail.followedArtistContext.artist)
+  })
+
+  it("fetches the related artist", () => {
+    const props = getProps({
+      relatedArtistContext: {
+        artist: {
+          _id: "banksy",
+          id: "banksy",
+        },
+      },
+      followedArtistContext: {},
+    })
+    expect(getSubjectArtist(props)).toEqual(props.rail.relatedArtistContext.artist)
+  })
+})


### PR DESCRIPTION
EV-117 #merged

Due to some messy parts of our schema around the home page artwork modules and their context, we now have some context types that have the `__id` field for no good reason. However, our current Relay version will query for that regardless, if it exists, and this leads to `followedArtistContext` always being an object, albeit sometimes with nothing more than `{ __id: null }`.

There is no good way to fix this in MP without breaking schema compatibility, this will at least fix the issue going forward.