### PR TITLE
[git] Hide query maps from GitHub diffs.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 CHANGELOG.md merge=union
 src/__generated__/*.graphql.ts linguist-generated
+src/__generated__/*.queryMap.json linguist-generated


### PR DESCRIPTION
#trivial

Noticed these files showing diffs in #1025, so omitting those now too.