### PR TITLE
Simple native markdown renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * Adds support for viewing conditions of sale - ash
 * Fixes crash when following an artist from the ‘related artist’ Home/ForYou rail - alloy
 * Creates and verifies bidder position - sepans
+* Adds `<MarkdownRenderer>` component - sepans
 
 ### 1.4.6
 

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "react-tracking": "^5.0.0",
     "relay-runtime": "https://github.com/alloy/relay/releases/download/v1.5.0-artsy.5/relay-runtime-1.5.0-artsy.5.tgz",
     "remove-markdown": "0.1.0",
+    "simple-markdown": "^0.4.0",
     "styled-components": "^3.1.4",
     "styled-system": "^2.2.4"
   },

--- a/src/lib/Components/Bidding/Components/MarkdownRenderer.tsx
+++ b/src/lib/Components/Bidding/Components/MarkdownRenderer.tsx
@@ -1,0 +1,71 @@
+import React from "react"
+import { Text, View } from "react-native"
+import SimpleMarkdown from "simple-markdown"
+import styled from "styled-components/native"
+
+import { Row } from "../Elements/Grid"
+
+import SwitchBoard from "lib/NativeModules/SwitchBoard"
+
+// Rules for rendering parsed markdown. Currently only handles links and text. Add rules similar to
+// https://github.com/CharlesMangwa/react-native-simple-markdown/blob/next/src/rules.js for new functionalities.
+const rules = {
+  ...SimpleMarkdown.defaultRules,
+  link: {
+    ...SimpleMarkdown.defaultRules.link,
+    react: (node, output, state) => {
+      state.withinText = true
+      let element
+      const openUrl = url => {
+        SwitchBoard.presentModalViewController(element, url)
+      }
+      return (
+        <LinkText key={state.key} onPress={() => openUrl(node.target)} ref={el => (element = el)}>
+          {output(node.content, state)}
+        </LinkText>
+      )
+    },
+  },
+  text: {
+    ...SimpleMarkdown.defaultRules.text,
+    react: (node, _output, state) => {
+      return <Text key={state.key}>{node.content}</Text>
+    },
+  },
+  paragraph: {
+    ...SimpleMarkdown.defaultRules.paragraph,
+    react: (node, output, state) => {
+      return (
+        <Row style={{ flexDirection: "row" }} key={state.key}>
+          {output(node.content, state)}
+        </Row>
+      )
+    },
+  },
+}
+// Markdown parser setup
+const rawBuiltParser = SimpleMarkdown.parserFor(rules)
+const parser = source => {
+  const blockSource = source + "\n\n"
+  return rawBuiltParser(blockSource, { inline: false })
+}
+const reactOutput = SimpleMarkdown.reactFor(SimpleMarkdown.ruleOutput(rules, "react"))
+
+export const toReact = md => {
+  const syntaxTree = parser(md)
+  return reactOutput(syntaxTree)
+}
+
+interface NariveMarkdownProps {
+  md: string
+}
+
+export class MarkdownRenderer extends React.Component<NariveMarkdownProps> {
+  render() {
+    return <View key={0}>{reactOutput(parser(this.props.md))}</View>
+  }
+}
+
+const LinkText = styled.Text`
+  text-decoration-line: underline;
+`

--- a/src/lib/Components/Bidding/Components/MarkdownRenderer.tsx
+++ b/src/lib/Components/Bidding/Components/MarkdownRenderer.tsx
@@ -56,11 +56,11 @@ export const toReact = md => {
   return reactOutput(syntaxTree)
 }
 
-interface NariveMarkdownProps {
+interface NativeMarkdownProps {
   md: string
 }
 
-export class MarkdownRenderer extends React.Component<NariveMarkdownProps> {
+export class MarkdownRenderer extends React.Component<NativeMarkdownProps> {
   render() {
     return <View key={0}>{reactOutput(parser(this.props.md))}</View>
   }

--- a/src/lib/Components/Bidding/Components/__tests__/MarkdownRenderer-tests.tsx
+++ b/src/lib/Components/Bidding/Components/__tests__/MarkdownRenderer-tests.tsx
@@ -1,0 +1,12 @@
+import React from "react"
+import "react-native"
+import * as renderer from "react-test-renderer"
+import { MarkdownRenderer } from "../MarkdownRenderer"
+
+describe("Markdown parser", () => {
+  it("parses", () => {
+    const md = "text with some [link](http://example.com) in it"
+    const bg = renderer.create(<MarkdownRenderer md={md} />).toJSON()
+    expect(bg).toMatchSnapshot()
+  })
+})

--- a/src/lib/Components/Bidding/Components/__tests__/MarkdownRenderer-tests.tsx
+++ b/src/lib/Components/Bidding/Components/__tests__/MarkdownRenderer-tests.tsx
@@ -1,11 +1,58 @@
+import { shallow } from "enzyme"
 import React from "react"
 import "react-native"
 import * as renderer from "react-test-renderer"
 import { MarkdownRenderer } from "../MarkdownRenderer"
 
 describe("Markdown parser", () => {
-  it("parses", () => {
+  it("renders text", () => {
+    const md = "text without link"
+    const markdown = shallow(<MarkdownRenderer md={md} />)
+
+    expect(markdown.find("Text")).toHaveLength(1)
+    expect(markdown.find("Text").prop("children")).toMatch("text without link")
+
+    const bg = renderer.create(<MarkdownRenderer md={md} />).toJSON()
+    expect(bg).toMatchSnapshot()
+  })
+  it("renders text with link", () => {
     const md = "text with some [link](http://example.com) in it"
+    const markdown = shallow(<MarkdownRenderer md={md} />)
+
+    expect(markdown.find("Text")).toHaveLength(3)
+    expect(
+      markdown
+        .find("Text")
+        .at(1)
+        .prop("children")
+    ).toMatch("link")
+
+    const bg = renderer.create(<MarkdownRenderer md={md} />).toJSON()
+    expect(bg).toMatchSnapshot()
+  })
+
+  it("renders multiple paragraphs", () => {
+    const md = `paragraph 1 has some text
+
+paragraph 2 also has text`
+    const markdown = shallow(<MarkdownRenderer md={md} />)
+
+    expect(markdown.find("Text")).toHaveLength(2)
+
+    expect(
+      markdown
+        .find("Text")
+        .first()
+        .prop("children")
+    ).toMatch("paragraph 1 has some text")
+
+    expect(
+      markdown
+        .find("Text")
+        .last()
+        .prop("children")
+    ).toMatch("paragraph 2 also has text")
+
     const bg = renderer.create(<MarkdownRenderer md={md} />).toJSON()
     expect(bg).toMatchSnapshot()
   })

--- a/src/lib/Components/Bidding/Components/__tests__/__snapshots__/MarkdownRenderer-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Components/__tests__/__snapshots__/MarkdownRenderer-tests.tsx.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Markdown parser parses 1`] = `
+<View>
+  <View
+    flexDirection="row"
+    justifyContent="space-between"
+    style={
+      Array [
+        Object {},
+        Object {
+          "flexDirection": "row",
+        },
+      ]
+    }
+  >
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+    >
+      text with some 
+    </Text>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      onPress={[Function]}
+      style={
+        Array [
+          Object {
+            "textDecorationLine": "underline",
+          },
+          undefined,
+        ]
+      }
+    >
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+      >
+        link
+      </Text>
+    </Text>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+    >
+       in it
+    </Text>
+  </View>
+</View>
+`;

--- a/src/lib/Components/Bidding/Components/__tests__/__snapshots__/MarkdownRenderer-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Components/__tests__/__snapshots__/MarkdownRenderer-tests.tsx.snap
@@ -1,6 +1,76 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Markdown parser parses 1`] = `
+exports[`Markdown parser renders multiple paragraphs 1`] = `
+<View>
+  <View
+    flexDirection="row"
+    justifyContent="space-between"
+    style={
+      Array [
+        Object {},
+        Object {
+          "flexDirection": "row",
+        },
+      ]
+    }
+  >
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+    >
+      paragraph 1 has some text
+    </Text>
+  </View>
+  <View
+    flexDirection="row"
+    justifyContent="space-between"
+    style={
+      Array [
+        Object {},
+        Object {
+          "flexDirection": "row",
+        },
+      ]
+    }
+  >
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+    >
+      paragraph 2 also has text
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`Markdown parser renders text 1`] = `
+<View>
+  <View
+    flexDirection="row"
+    justifyContent="space-between"
+    style={
+      Array [
+        Object {},
+        Object {
+          "flexDirection": "row",
+        },
+      ]
+    }
+  >
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+    >
+      text without link
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`Markdown parser renders text with link 1`] = `
 <View>
   <View
     flexDirection="row"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9749,6 +9749,10 @@ signedsource@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/signedsource/-/signedsource-1.0.0.tgz#1ddace4981798f93bd833973803d80d52e93ad6a"
 
+simple-markdown@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/simple-markdown/-/simple-markdown-0.4.0.tgz#86ec1344c7747a3ca120f5e4325be88cb4a67cc3"
+
 simple-plist@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/simple-plist/-/simple-plist-0.2.1.tgz#71766db352326928cf3a807242ba762322636723"


### PR DESCRIPTION
Parses and renders markdown to handle markdown messages from [metaphysics](https://github.com/artsy/metaphysics/pull/1031).

Currently only works for **text (paragraphs)** and **links** to avoid over generalization.

<img width="412" alt="screen shot 2018-05-07 at 2 06 59 pm" src="https://user-images.githubusercontent.com/687513/39717695-0af5815e-5202-11e8-8ede-61299530faf3.png">


Markdown is parsed using [Simple Markdown](https://github.com/Khan/simple-markdown) which allows overriding markdown rendering rules to customize it for emission native components. Also unlike other markdown parsers it can return react object instead of string which is very useful here since react native doesn't have something like `dangerouslySetInnerHTML`. 