### PR TITLE
Replace smart quotes with normal quotes

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -66,7 +66,7 @@ post_install do |installer|
   emission = installer.pods_project.targets.find { |target| target.name == 'Emission' }
   emission.build_configurations.each do |config|
     config.build_settings['GCC_TREAT_WARNINGS_AS_ERRORS'] = 'YES'
-    # Work around https://github.com/rs/SDWebImage/issues/2022, because we don’t want to upgrade to SDWebImage 4 atm.
+    # Work around https://github.com/rs/SDWebImage/issues/2022, because we don't want to upgrade to SDWebImage 4 atm.
     config.build_settings['CLANG_WARN_STRICT_PROTOTYPES'] = 'NO'
     # Use dynamic queries by default in development mode.
     if config.name == 'Debug'


### PR DESCRIPTION
Because we don't want smart quotes to be too smart and take over the entire earth 😉

Also, `pod install` was suggesting removing it:

<img width="1501" alt="screen shot 2018-05-09 at 10 36 21" src="https://user-images.githubusercontent.com/386234/39821038-46ab1ffa-5375-11e8-8bca-ec6034436a45.png">

#trivial