### PR TITLE
Show checkbox if you are unregistered (and verify copy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Upcoming
 
+* Adds a checkbox to the confirm your bid screen - yuki24
+
 ### 1.5.1
 
 * Adds Recently Viewed Works rail to Home - sarah

--- a/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
@@ -27,6 +27,7 @@ import { BidResult } from "./BidResult"
 
 import { ConfirmBid_sale_artwork } from "__generated__/ConfirmBid_sale_artwork.graphql"
 import { Checkbox } from "../Components/Checkbox"
+import { Timer } from "../Components/Timer"
 
 interface ConfirmBidProps extends ViewProperties {
   sale_artwork: ConfirmBid_sale_artwork
@@ -161,7 +162,10 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConformBidState
     return (
       <BiddingThemeProvider>
         <Container m={0}>
-          <Title>Confirm your bid</Title>
+          <Flex alignItems="center">
+            <Title mb={3}>Confirm your bid</Title>
+            <Timer timeLeftInMilliseconds={1000 * 60 * 20} />
+          </Flex>
 
           <View>
             <Flex m={4} alignItems="center">

--- a/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
@@ -26,6 +26,7 @@ import { metaphysics } from "../../../metaphysics"
 import { BidResult } from "./BidResult"
 
 import { ConfirmBid_sale_artwork } from "__generated__/ConfirmBid_sale_artwork.graphql"
+import { Checkbox } from "../Components/Checkbox"
 
 interface ConfirmBidProps extends ViewProperties {
   sale_artwork: ConfirmBid_sale_artwork
@@ -40,6 +41,7 @@ interface ConfirmBidProps extends ViewProperties {
 interface ConformBidState {
   pollCount: number
   intervalToken: number
+  conditionsOfSaleChecked: boolean
 }
 
 const MAX_POLL_ATTEMPTS = 20
@@ -63,6 +65,7 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConformBidState
   state = {
     pollCount: 0,
     intervalToken: 0,
+    conditionsOfSaleChecked: false,
   }
 
   onPressConditionsOfSale = () => {
@@ -148,6 +151,12 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConformBidState
     })
   }
 
+  conditionsOfSalePressed() {
+    this.setState({
+      conditionsOfSaleChecked: !this.state.conditionsOfSaleChecked,
+    })
+  }
+
   render() {
     return (
       <BiddingThemeProvider>
@@ -179,9 +188,11 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConformBidState
           </View>
 
           <View>
-            <Serif14 mb={3} color="black60" textAlign="center">
-              You agree to <LinkText onPress={this.onPressConditionsOfSale}>Conditions of Sale</LinkText>.
-            </Serif14>
+            <Checkbox pl={3} pb={1} justifyContent="center" onPress={() => this.conditionsOfSalePressed()}>
+              <Serif14 mt={2} color="black60">
+                You agree to <LinkText onPress={this.onPressConditionsOfSale}>Conditions of Sale</LinkText>.
+              </Serif14>
+            </Checkbox>
 
             <Flex m={4}>
               <Button text="Place Bid" onPress={this.state.conditionsOfSaleChecked && (() => this.placeBid())} />

--- a/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
@@ -183,12 +183,9 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConformBidState
               You agree to <LinkText onPress={this.onPressConditionsOfSale}>Conditions of Sale</LinkText>.
             </Serif14>
 
-            <Button
-              text="Place Bid"
-              onPress={() => {
-                this.placeBid()
-              }}
-            />
+            <Flex m={4}>
+              <Button text="Place Bid" onPress={this.state.conditionsOfSaleChecked && (() => this.placeBid())} />
+            </Flex>
           </View>
         </Container>
       </BiddingThemeProvider>

--- a/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
@@ -168,11 +168,11 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConformBidState
           </Flex>
 
           <View>
-            <Flex m={4} alignItems="center">
+            <Flex m={4} mt={0} alignItems="center">
               <SerifSemibold18>{this.props.sale_artwork.artwork.artist_names}</SerifSemibold18>
               <SerifSemibold14>Lot {this.props.sale_artwork.lot_label}</SerifSemibold14>
 
-              <SerifItalic14 color="black60">
+              <SerifItalic14 color="black60" textAlign="center">
                 {this.props.sale_artwork.artwork.title}, <Serif14>{this.props.sale_artwork.artwork.date}</Serif14>
               </SerifItalic14>
             </Flex>
@@ -188,7 +188,7 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConformBidState
               </Col>
             </Row>
 
-            <Divider />
+            <Divider mb={9} />
           </View>
 
           <View>

--- a/src/lib/Components/Bidding/Screens/__tests__/ConfirmBid-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/ConfirmBid-tests.tsx
@@ -5,6 +5,8 @@ import * as renderer from "react-test-renderer"
 import { ConfirmBid } from "../ConfirmBid"
 
 it("renders properly", () => {
+  jest.useFakeTimers()
+
   const saleArtwork = {
     artwork: {
       id: "meteor shower",
@@ -17,8 +19,10 @@ it("renders properly", () => {
     },
     lot_label: "538",
   }
-  const bg = renderer
+
+  const component = renderer
     .create(<ConfirmBid sale_artwork={saleArtwork} bid={{ cents: 450000, display: "$45,000" }} />)
     .toJSON()
-  expect(bg).toMatchSnapshot()
+
+  expect(component).toMatchSnapshot()
 })

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmBid-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmBid-tests.tsx.snap
@@ -252,46 +252,108 @@ exports[`renders properly 1`] = `
     />
   </View>
   <View>
-    <Text
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
       accessible={true}
-      allowFontScaling={true}
-      color="black60"
-      ellipsizeMode="tail"
-      fontSize={2}
-      mb={3}
+      alignItems="center"
+      flexDirection="row"
+      hitSlop={undefined}
+      justifyContent="center"
+      nativeID={undefined}
+      onLayout={undefined}
+      onPress={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      pb={1}
+      pl={3}
       style={
         Array [
           Object {
-            "color": "#666",
-            "fontFamily": "AGaramondPro-Regular",
-            "fontSize": 14,
-            "marginBottom": 10,
-            "textAlign": "center",
+            "paddingBottom": 3,
+            "paddingLeft": 10,
           },
           undefined,
         ]
       }
-      textAlign="center"
+      testID={undefined}
     >
-      You agree to 
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-        onPress={[Function]}
+      <View
+        animate={
+          Array [
+            "backgroundColor",
+            "borderColor",
+          ]
+        }
+        collapsable={undefined}
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "rgba(255, 255, 255, 1)",
+            "borderColor": "rgba(229, 229, 229, 1)",
+            "borderStyle": "solid",
+            "borderWidth": 2,
+            "display": "flex",
+            "height": 20,
+            "justifyContent": "center",
+            "marginRight": 10,
+            "width": 20,
+          }
+        }
+      />
+      <View
         style={
           Array [
-            Object {
-              "textDecorationLine": "underline",
-            },
+            Object {},
             undefined,
           ]
         }
       >
-        Conditions of Sale
-      </Text>
-      .
-    </Text>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          color="black60"
+          ellipsizeMode="tail"
+          fontSize={2}
+          mt={2}
+          style={
+            Array [
+              Object {
+                "color": "#666",
+                "fontFamily": "AGaramondPro-Regular",
+                "fontSize": 14,
+                "marginTop": 5,
+              },
+              undefined,
+            ]
+          }
+        >
+          You agree to 
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            onPress={[Function]}
+            style={
+              Array [
+                Object {
+                  "textDecorationLine": "underline",
+                },
+                undefined,
+              ]
+            }
+          >
+            Conditions of Sale
+          </Text>
+          .
+        </Text>
+      </View>
+    </View>
     <View
       m={4}
       style={

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmBid-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmBid-tests.tsx.snap
@@ -21,30 +21,68 @@ exports[`renders properly 1`] = `
     ]
   }
 >
-  <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
-    fontSize={5}
-    m={4}
+  <View
+    alignItems="center"
     style={
       Array [
-        Object {
-          "fontFamily": "AGaramondPro-Semibold",
-          "fontSize": 22,
-          "marginBottom": 20,
-          "marginLeft": 20,
-          "marginRight": 20,
-          "marginTop": 20,
-          "textAlign": "center",
-        },
+        Object {},
         undefined,
       ]
     }
-    textAlign="center"
   >
-    Confirm your bid
-  </Text>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      fontSize={5}
+      m={4}
+      mb={3}
+      style={
+        Array [
+          Object {
+            "fontFamily": "AGaramondPro-Semibold",
+            "fontSize": 22,
+            "marginBottom": 10,
+            "marginLeft": 20,
+            "marginRight": 20,
+            "marginTop": 20,
+            "textAlign": "center",
+          },
+          undefined,
+        ]
+      }
+      textAlign="center"
+    >
+      Confirm your bid
+    </Text>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      fontSize={2}
+      style={
+        Array [
+          Object {
+            "fontFamily": "Unica77LL-Medium",
+            "fontSize": 14,
+          },
+          undefined,
+        ]
+      }
+    >
+      00
+      d
+        
+      00
+      h
+        
+      20
+      m
+        
+      00
+      s
+    </Text>
+  </View>
   <View>
     <View
       alignItems="center"

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmBid-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmBid-tests.tsx.snap
@@ -293,55 +293,70 @@ exports[`renders properly 1`] = `
       .
     </Text>
     <View
-      accessibilityComponentType={undefined}
-      accessibilityLabel={undefined}
-      accessibilityTraits={undefined}
-      accessible={true}
-      collapsable={undefined}
-      hitSlop={undefined}
-      nativeID={undefined}
-      onLayout={undefined}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
+      m={4}
       style={
-        Object {
-          "alignItems": "center",
-          "backgroundColor": "rgba(0, 0, 0, 1)",
-          "borderColor": "rgba(0, 0, 0, 1)",
-          "borderWidth": 1,
-          "height": 46,
-          "justifyContent": "center",
-        }
+        Array [
+          Object {
+            "marginBottom": 20,
+            "marginLeft": 20,
+            "marginRight": 20,
+            "marginTop": 20,
+          },
+          undefined,
+        ]
       }
-      testID={undefined}
     >
-      <Text
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
         accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
+        collapsable={undefined}
+        hitSlop={undefined}
+        nativeID={undefined}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
-          Array [
-            Object {
-              "fontSize": 12,
-            },
-            Object {
-              "color": "rgba(255, 255, 255, 1)",
-              "fontFamily": "AGaramondPro-Regular",
-              "fontSize": 14,
-              "opacity": 1,
-            },
-            Object {
-              "fontFamily": "AvantGardeGothicITC",
-            },
-          ]
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "rgba(51, 51, 51, 1)",
+            "borderColor": "rgba(248, 248, 248, 1)",
+            "borderWidth": 1,
+            "height": 46,
+            "justifyContent": "center",
+          }
         }
+        testID={undefined}
       >
-        PLACE BID
-      </Text>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Array [
+              Object {
+                "fontSize": 12,
+              },
+              Object {
+                "color": "rgba(204, 204, 204, 1)",
+                "fontFamily": "AGaramondPro-Regular",
+                "fontSize": 14,
+                "opacity": 1,
+              },
+              Object {
+                "fontFamily": "AvantGardeGothicITC",
+              },
+            ]
+          }
+        >
+          PLACE BID
+        </Text>
+      </View>
     </View>
   </View>
 </View>

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmBid-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmBid-tests.tsx.snap
@@ -87,13 +87,14 @@ exports[`renders properly 1`] = `
     <View
       alignItems="center"
       m={4}
+      mt={0}
       style={
         Array [
           Object {
             "marginBottom": 20,
             "marginLeft": 20,
             "marginRight": 20,
-            "marginTop": 20,
+            "marginTop": 0,
           },
           undefined,
         ]
@@ -146,10 +147,12 @@ exports[`renders properly 1`] = `
               "color": "#666",
               "fontFamily": "AGaramondPro-Italic",
               "fontSize": 14,
+              "textAlign": "center",
             },
             undefined,
           ]
         }
+        textAlign="center"
       >
         Meteor Shower
         , 
@@ -275,12 +278,14 @@ exports[`renders properly 1`] = `
       border={1}
       borderBottomWidth={0}
       borderColor="black10"
+      mb={9}
       style={
         Array [
           Object {
             "borderColor": "#E5E5E5",
             "borderStyle": "solid",
             "borderWidth": 1,
+            "marginBottom": 120,
             "width": "100%",
           },
           undefined,


### PR DESCRIPTION
finishes https://artsyproduct.atlassian.net/browse/PURCHASE-114

This PR adds a checkbox to the "Confirm your bid" screen.

 * Right now it doesn't persist the flag so the checkbox will always show up, let me know if there's already a mutation endpoint we could use to do so.
 * The button is disabled by default and enabled once the user checks it off, not sure if the animation is appropriate here though. cc: @briansw
 * This also includes minor style tweaks

## Sceenshot

![screen_shot_2018-05-14_at_4_08_39_pm](https://user-images.githubusercontent.com/386234/40020845-25887bc2-5791-11e8-8f13-231c9e2154ea.png)
