### PR TITLE
[Home] Add support for changing tabs from native code (for 1.4.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### 1.4.8
 
 * Fixing broken previous deploy, no changes - alloy
+* Add support for changing tabs of the home vc - maxim
 
 ### 1.4.7
 

--- a/Pod/Classes/ViewControllers/ARComponentViewController.h
+++ b/Pod/Classes/ViewControllers/ARComponentViewController.h
@@ -1,10 +1,13 @@
 #import <UIKit/UIKit.h>
 
 @class AREmission;
+@class RCTRootView;
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface ARComponentViewController : UIViewController
+
+@property (nonatomic, strong) RCTRootView *rootView;
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithNibName:(nullable NSString *)nibNameOrNil bundle:(nullable NSBundle *)nibBundleOrNil NS_UNAVAILABLE;

--- a/Pod/Classes/ViewControllers/ARComponentViewController.m
+++ b/Pod/Classes/ViewControllers/ARComponentViewController.m
@@ -7,7 +7,6 @@
 @property (nonatomic, strong, readonly) AREmission *emission;
 @property (nonatomic, strong, readonly) NSString *moduleName;
 @property (nonatomic, strong, readonly) NSDictionary *initialProperties;
-@property (nonatomic, strong) RCTRootView *rootView;
 @end
 
 @implementation ARComponentViewController

--- a/Pod/Classes/ViewControllers/ARHomeComponentViewController.h
+++ b/Pod/Classes/ViewControllers/ARHomeComponentViewController.h
@@ -12,6 +12,8 @@ typedef enum ARHomeTabType {
 
 @property (nonatomic, strong, readonly) NSString *selectedArtist;
 
+- (void)changeHomeTabTo:(ARHomeTabType)tab;
+
 - (instancetype)initWithSelectedArtist:(nullable NSString *)artistID
                                    tab:(ARHomeTabType)selectedTab
                               emission:(nullable AREmission*)emission NS_DESIGNATED_INITIALIZER;

--- a/Pod/Classes/ViewControllers/ARHomeComponentViewController.m
+++ b/Pod/Classes/ViewControllers/ARHomeComponentViewController.m
@@ -15,7 +15,7 @@
     NSDictionary *initialProperties = artistID ? @{ @"selectedArtist": artistID, @"initialTab": @(selectedTab) } : @{ @"initialTab": @(selectedTab) };
     if ((self = [super initWithEmission:emission
                              moduleName:@"Home"
-                      initialProperties:initialProps])) {
+                      initialProperties:initialProperties])) {
         _selectedArtist = artistID;
     }
     return self;

--- a/Pod/Classes/ViewControllers/ARHomeComponentViewController.m
+++ b/Pod/Classes/ViewControllers/ARHomeComponentViewController.m
@@ -3,9 +3,16 @@
 
 @implementation ARHomeComponentViewController
 
+- (void)changeHomeTabTo:(ARHomeTabType)tab
+{
+    NSMutableDictionary *appProperties = [self.rootView.appProperties mutableCopy];
+    appProperties[@"selectedTab"] = @(tab);
+    self.rootView.appProperties = appProperties;
+}
+
 - (instancetype)initWithSelectedArtist:(nullable NSString *)artistID tab:(ARHomeTabType)selectedTab emission:(nullable AREmission*)emission;
 {
-    NSDictionary *initialProps = artistID ? @{ @"selectedArtist": artistID, @"selectedTab": @(selectedTab) } : @{ @"selectedTab": @(selectedTab) };
+    NSDictionary *initialProperties = artistID ? @{ @"selectedArtist": artistID, @"initialTab": @(selectedTab) } : @{ @"initialTab": @(selectedTab) };
     if ((self = [super initWithEmission:emission
                              moduleName:@"Home"
                       initialProperties:initialProps])) {

--- a/src/lib/Scenes/Home/index.tsx
+++ b/src/lib/Scenes/Home/index.tsx
@@ -24,6 +24,7 @@ const TabBarContainer = styled.View``
 interface Props {
   selectedArtist?: string
   selectedTab?: number
+  initialTab?: number
   tracking: any
 }
 
@@ -71,6 +72,9 @@ export default class Home extends React.Component<Props, State> {
     if (newProps.isVisible) {
       this.fireHomeScreenViewAnalytics()
     }
+    if (this.props.selectedTab !== newProps.selectedTab) {
+      this.setState({ selectedTab: newProps.selectedTab })
+    }
   }
 
   _handleAppStateChange = nextAppState => {
@@ -85,7 +89,8 @@ export default class Home extends React.Component<Props, State> {
     return (
       <View style={{ flex: 1 }}>
         <ScrollableTabView
-          initialPage={this.props.selectedTab || ArtistsWorksForYouTab}
+          initialPage={this.props.initialTab || ArtistsWorksForYouTab}
+          page={this.state.selectedTab || ArtistsWorksForYouTab}
           ref={tabView => (this.tabView = tabView)}
           onChangeTab={selectedTab => this.setSelectedTab(selectedTab)}
           renderTabBar={props => (


### PR DESCRIPTION
Using the `page` prop of `ScrollableTabView` to set the page upon prop changes.

(Now branched off the right version)