### PR TITLE
Add the ability to style the text in the inverted button with spinner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Upcoming
 
 * Adds a checkbox to the confirm your bid screen - yuki24
+* Adds the ability to style the text in the inverted button with a spinner - yuki24
 
 ### 1.5.1
 

--- a/src/lib/Components/Buttons/InvertedButton.tsx
+++ b/src/lib/Components/Buttons/InvertedButton.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Animated, StyleSheet, TouchableHighlight, View } from "react-native"
+import { Animated, StyleProp, StyleSheet, TextStyle, TouchableHighlight, View } from "react-native"
 
 import colors from "lib/data/colors"
 import Spinner from "../Spinner"
@@ -11,6 +11,7 @@ const AnimatedHeadline = Animated.createAnimatedComponent(Headline)
 
 interface InvertedButtonProps extends React.Props<InvertedButton> {
   text: string
+  textStyle?: StyleProp<TextStyle>
   selected?: boolean
   inProgress?: boolean
   onPress?: React.TouchEventHandler<InvertedButton>
@@ -60,7 +61,8 @@ export default class InvertedButton extends React.Component<InvertedButtonProps,
     if (this.props.inProgress) {
       content = <Spinner spinnerColor="white" style={{ backgroundColor: "transparent" }} />
     } else {
-      const headlineStyles = [styles.text, { opacity: this.state.textOpacity }]
+      const customStyle = this.props.textStyle || {}
+      const headlineStyles = [styles.text, customStyle, { opacity: this.state.textOpacity }]
       content = <AnimatedHeadline style={headlineStyles}>{this.props.text}</AnimatedHeadline>
     }
     return (

--- a/src/lib/Components/Buttons/__tests__/InvertedButton-tests.tsx
+++ b/src/lib/Components/Buttons/__tests__/InvertedButton-tests.tsx
@@ -4,17 +4,38 @@ import React from "react"
 import * as renderer from "react-test-renderer"
 
 import { InvertedButton } from "../"
+import InvertedButtonWithSpinner from "../InvertedButton"
 
-it("renders properly", () => {
-  const button = renderer.create(<InvertedButton text={"I am an inverted button"} />).toJSON()
-  expect(button).toMatchSnapshot()
+describe("InvertedButton", () => {
+  it("renders properly", () => {
+    const button = renderer.create(<InvertedButton text={"I am an inverted button"} />).toJSON()
+    expect(button).toMatchSnapshot()
+  })
+
+  it("accepts textStyle prop", () => {
+    const textStyle = {
+      fontSize: 20,
+    }
+
+    const button = renderer.create(<InvertedButton text={"I am an inverted button"} textStyle={textStyle} />).toJSON()
+    expect(button).toMatchSnapshot()
+  })
 })
 
-it("accepts textStyle prop", () => {
-  const textStyle = {
-    fontSize: 20,
-  }
+describe("InvertedButtonWithSpinner", () => {
+  it("renders properly", () => {
+    const button = renderer.create(<InvertedButtonWithSpinner text={"I am an inverted button"} />).toJSON()
+    expect(button).toMatchSnapshot()
+  })
 
-  const button = renderer.create(<InvertedButton text={"I am an inverted button"} textStyle={textStyle} />).toJSON()
-  expect(button).toMatchSnapshot()
+  it("accepts textStyle prop", () => {
+    const textStyle = {
+      fontSize: 20,
+    }
+
+    const button = renderer
+      .create(<InvertedButtonWithSpinner text={"I am an inverted button"} textStyle={textStyle} />)
+      .toJSON()
+    expect(button).toMatchSnapshot()
+  })
 })

--- a/src/lib/Components/Buttons/__tests__/__snapshots__/InvertedButton-tests.tsx.snap
+++ b/src/lib/Components/Buttons/__tests__/__snapshots__/InvertedButton-tests.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`accepts textStyle prop 1`] = `
+exports[`InvertedButton accepts textStyle prop 1`] = `
 <View
   accessibilityComponentType={undefined}
   accessibilityLabel={undefined}
@@ -54,7 +54,7 @@ exports[`accepts textStyle prop 1`] = `
 </View>
 `;
 
-exports[`renders properly 1`] = `
+exports[`InvertedButton renders properly 1`] = `
 <View
   accessibilityComponentType={undefined}
   accessibilityLabel={undefined}
@@ -104,5 +104,118 @@ exports[`renders properly 1`] = `
   >
     I AM AN INVERTED BUTTON
   </Text>
+</View>
+`;
+
+exports[`InvertedButtonWithSpinner accepts textStyle prop 1`] = `
+<View
+  accessibilityComponentType={undefined}
+  accessibilityLabel={undefined}
+  accessibilityTraits={undefined}
+  accessible={true}
+  hasTVPreferredFocus={undefined}
+  hitSlop={undefined}
+  isTVSelectable={true}
+  nativeID={undefined}
+  onLayout={undefined}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "rgba(0, 0, 0, 1)",
+      "flex": 1,
+      "justifyContent": "center",
+    }
+  }
+  testID={undefined}
+  tvParallaxProperties={undefined}
+>
+  <View
+    style={null}
+  >
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "fontSize": 12,
+          },
+          Object {
+            "color": "white",
+            "fontSize": 20,
+            "opacity": 1,
+          },
+          Object {
+            "fontFamily": "AvantGardeGothicITC",
+          },
+        ]
+      }
+    >
+      I AM AN INVERTED BUTTON
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`InvertedButtonWithSpinner renders properly 1`] = `
+<View
+  accessibilityComponentType={undefined}
+  accessibilityLabel={undefined}
+  accessibilityTraits={undefined}
+  accessible={true}
+  hasTVPreferredFocus={undefined}
+  hitSlop={undefined}
+  isTVSelectable={true}
+  nativeID={undefined}
+  onLayout={undefined}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "rgba(0, 0, 0, 1)",
+      "flex": 1,
+      "justifyContent": "center",
+    }
+  }
+  testID={undefined}
+  tvParallaxProperties={undefined}
+>
+  <View
+    style={null}
+  >
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "fontSize": 12,
+          },
+          Object {
+            "color": "white",
+            "opacity": 1,
+          },
+          Object {
+            "fontFamily": "AvantGardeGothicITC",
+          },
+        ]
+      }
+    >
+      I AM AN INVERTED BUTTON
+    </Text>
+  </View>
 </View>
 `;


### PR DESCRIPTION
This is similar to https://github.com/artsy/emission/pull/1006, but there seems to be two different `<InvertedButton>`s, one with the ability to show a spinner and the other without. This PR adds the ability to style the text to the one with the spinner.


![screen_shot_2018-04-13_at_4_39_54_pm](https://user-images.githubusercontent.com/386234/38757128-e01149ee-3f39-11e8-854d-3a3540776aa2.png)