### PR TITLE
[Analytics] Update home analytics for tab changes and inital tab props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 * Fixing broken previous deploy, no changes - alloy
 * Add support for changing tabs of the home vc - maxim
+* Update home analytics for tab changes and inital tab props - maxim
 
 ### 1.4.7
 

--- a/src/lib/Scenes/Home/__stories__/Home.story.tsx
+++ b/src/lib/Scenes/Home/__stories__/Home.story.tsx
@@ -9,7 +9,7 @@ import Sales from "../Components/Sales"
 import { SalesRenderer } from "../Components/Sales/Relay/SalesRenderer"
 
 storiesOf("Home/Relay")
-  .add("Root", () => <Home tracking={trackingData => console.log(trackingData)} />)
+  .add("Root", () => <Home initialTab={0} isVisible={true} tracking={trackingData => console.log(trackingData)} />)
   .add("Artists", () => <WorksForYouRenderer render={renderWithLoadProgress(WorksForYou)} />)
   .add("For You", () => <ForYouRenderer render={renderWithLoadProgress(ForYou)} />)
   .add("Auctions", () => <SalesRenderer render={renderWithLoadProgress(Sales)} />)

--- a/src/lib/Scenes/Home/__tests__/index-tests.tsx
+++ b/src/lib/Scenes/Home/__tests__/index-tests.tsx
@@ -4,6 +4,6 @@ import React from "react"
 import Home from "../index"
 
 it("has the correct number of tabs", () => {
-  const wrapper = shallow(<Home tracking={null} />)
+  const wrapper = shallow(<Home initialTab={0} isVisible={true} tracking={null} />)
   expect(wrapper.find(Tab)).toHaveLength(3)
 })

--- a/src/lib/Scenes/Home/index.tsx
+++ b/src/lib/Scenes/Home/index.tsx
@@ -24,8 +24,9 @@ const TabBarContainer = styled.View``
 interface Props {
   selectedArtist?: string
   selectedTab?: number
-  initialTab?: number
+  initialTab: number
   tracking: any
+  isVisible: boolean
 }
 
 interface State {
@@ -37,13 +38,27 @@ const ArtistsWorksForYouTab = 0
 const ForYouTab = 1
 const AuctionsTab = 2
 
+const screenSchemaForCurrentTab = currentSelectedTab => {
+  let screenType
+
+  if (currentSelectedTab === ArtistsWorksForYouTab) {
+    screenType = Schema.PageNames.HomeArtistsWorksForYou
+  } else if (currentSelectedTab === ForYouTab) {
+    screenType = Schema.PageNames.HomeForYou
+  } else if (currentSelectedTab === AuctionsTab) {
+    screenType = Schema.PageNames.HomeAuctions
+  }
+
+  return screenType
+}
+
 // This kills two birds with one stone:
 // It's necessary to wrap all tracks nested in this component, so they dispatch properly
 // Also, it'll only fire when the home screen is mounted, the only event we would otherwise miss with our own callbacks
-@screenTrack({
-  context_screen: Schema.PageNames.HomeArtistsWorksForYou,
+@screenTrack((props: Props) => ({
+  context_screen: screenSchemaForCurrentTab(props.initialTab),
   context_screen_owner_type: null,
-})
+}))
 export default class Home extends React.Component<Props, State> {
   tabView?: ScrollableTabView | any
 
@@ -52,7 +67,7 @@ export default class Home extends React.Component<Props, State> {
 
     this.state = {
       appState: AppState.currentState,
-      selectedTab: ArtistsWorksForYouTab, // default to the WorksForYou view
+      selectedTab: this.props.initialTab,
     }
   }
 
@@ -69,7 +84,8 @@ export default class Home extends React.Component<Props, State> {
   // This is called when the overall home component appears in Eigen
   // We use it to dispatch screen events at that point
   componentWillReceiveProps(newProps) {
-    if (newProps.isVisible) {
+    // Only if we weren't visible, but we are now, should we fire analytics for this.
+    if (newProps.isVisible && !this.props.isVisible) {
       this.fireHomeScreenViewAnalytics()
     }
     if (this.props.selectedTab !== newProps.selectedTab) {
@@ -133,17 +149,8 @@ export default class Home extends React.Component<Props, State> {
   }
 
   fireHomeScreenViewAnalytics = () => {
-    let screenType
-
-    if (this.state.selectedTab === ArtistsWorksForYouTab) {
-      screenType = Schema.PageNames.HomeArtistsWorksForYou
-    } else if (this.state.selectedTab === ForYouTab) {
-      screenType = Schema.PageNames.HomeForYou
-    } else if (this.state.selectedTab === AuctionsTab) {
-      screenType = Schema.PageNames.HomeAuctions
-    }
     this.props.tracking.trackEvent({
-      context_screen: screenType,
+      context_screen: screenSchemaForCurrentTab(this.state.selectedTab),
       context_screen_owner_type: null,
     })
   }


### PR DESCRIPTION
Making sure that we: 
- are dispatching analytics at the right time (when tabs are changed, and when `viewDidAppear` happens after the VC wasn't visible)
- set the right `PageName` prop by adding a separate method used by `screenTrack` and `fireHomeScreenAnalytics`



