### PR TITLE
Adds prop-setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### 1.4.8
 
 * Fixing broken previous deploy, no changes - alloy
+* Adds setProperty:forKey: to ARComponentViewController - ash&maxim
 * Add support for changing tabs of the home vc - maxim
 
 ### 1.4.7

--- a/Pod/Classes/ViewControllers/ARComponentViewController.h
+++ b/Pod/Classes/ViewControllers/ARComponentViewController.h
@@ -17,6 +17,9 @@ NS_ASSUME_NONNULL_BEGIN
                       moduleName:(NSString *)moduleName
                initialProperties:(nullable NSDictionary *)initialProperties NS_DESIGNATED_INITIALIZER;
 
+/// This sets a prop on the rootView, or sets a prop to be passed in on rootView initialization.
+- (void)setProperty:(id)value forKey:(NSString *)key;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Pod/Classes/ViewControllers/ARComponentViewController.m
+++ b/Pod/Classes/ViewControllers/ARComponentViewController.m
@@ -6,7 +6,7 @@
 @interface ARComponentViewController ()
 @property (nonatomic, strong, readonly) AREmission *emission;
 @property (nonatomic, strong, readonly) NSString *moduleName;
-@property (nonatomic, strong, readonly) NSDictionary *initialProperties;
+@property (nonatomic, strong) NSDictionary *initialProperties;
 @end
 
 @implementation ARComponentViewController
@@ -101,6 +101,19 @@
 - (UIStatusBarStyle)preferredStatusBarStyle
 {
     return UIStatusBarStyleDefault;
+}
+
+- (void)setProperty:(id)value forKey:(NSString *)key
+{
+    if (self.isViewLoaded) {
+        NSMutableDictionary *appProperties = [self.rootView.appProperties mutableCopy];
+        appProperties[key] = value;
+        self.rootView.appProperties = appProperties;
+    } else {
+        NSMutableDictionary *appProperties = [self.initialProperties mutableCopy];
+        appProperties[key] = value;
+        self.initialProperties = appProperties;
+    }
 }
 
 @end

--- a/Pod/Classes/ViewControllers/ARHomeComponentViewController.m
+++ b/Pod/Classes/ViewControllers/ARHomeComponentViewController.m
@@ -5,9 +5,7 @@
 
 - (void)changeHomeTabTo:(ARHomeTabType)tab
 {
-    NSMutableDictionary *appProperties = [self.rootView.appProperties mutableCopy];
-    appProperties[@"selectedTab"] = @(tab);
-    self.rootView.appProperties = appProperties;
+    [self setProperty:@(tab) forKey:(self.isViewLoaded ? @"selectedTab" : @"initialTab")];
 }
 
 - (instancetype)initWithSelectedArtist:(nullable NSString *)artistID tab:(ARHomeTabType)selectedTab emission:(nullable AREmission*)emission;


### PR DESCRIPTION
This adds a new method to `ARComponentViewController` that sets the props of the `rootView` if the view is loaded, _or_ sets the `initialProps` for the `rootView` if it hasn't been loaded yet. I don't see any Objective-C tests for Emission so I didn't add any, but something to think about longer term.

This is useful for when we want to switch tabs on the home component controller when the app is launching (for example, from a push notification).