### PR TITLE
[Home] Update home tab switching method 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Adds setProperty:forKey: to ARComponentViewController - ash&maxim
 * Add support for changing tabs of the home vc - maxim
 * Update home analytics for tab changes and inital tab props - maxim
+* Update switching for home tabs - ash&maxim
 
 ### 1.4.8
 

--- a/src/lib/Scenes/Home/index.tsx
+++ b/src/lib/Scenes/Home/index.tsx
@@ -89,7 +89,7 @@ export default class Home extends React.Component<Props, State> {
       this.fireHomeScreenViewAnalytics()
     }
     if (this.props.selectedTab !== newProps.selectedTab) {
-      this.setState({ selectedTab: newProps.selectedTab })
+      this.setState({ selectedTab: newProps.selectedTab }, () => this.tabView.goToPage(this.state.selectedTab))
     }
   }
 
@@ -106,7 +106,6 @@ export default class Home extends React.Component<Props, State> {
       <View style={{ flex: 1 }}>
         <ScrollableTabView
           initialPage={this.props.initialTab || ArtistsWorksForYouTab}
-          page={this.state.selectedTab || ArtistsWorksForYouTab}
           ref={tabView => (this.tabView = tabView)}
           onChangeTab={selectedTab => this.setSelectedTab(selectedTab)}
           renderTabBar={props => (


### PR DESCRIPTION
Based off [@ashfurrow's comment](https://github.com/artsy/eigen/pull/2612#issuecomment-390775648), using the `Page` prop is indeed cautioned against. 

Originally we went for this, as changing tab through just the `initialPage` prop wasn't working, however we are now switching to the recommended `goToPage` function. (thanks @ashfurrow!) 

🎉 

