### PR TITLE
The <Input> component should update the border color when the parent component updates the error prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Adds a checkbox to the confirm your bid screen - yuki24
 * Adds the ability to style the text in the inverted button with a spinner - yuki24
 * Now the `<ConfirmBid>` component shows a spinner while loading - yuki24
+* Now the `<Input>` component updates the border color when the parent component updates the `error` prop - yuki24
 
 ### 1.5.1
 

--- a/src/lib/Components/Bidding/Components/Input.tsx
+++ b/src/lib/Components/Bidding/Components/Input.tsx
@@ -19,6 +19,12 @@ export class Input extends Component<InputProps, InputState> {
     }
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.error) {
+      this.setState({ borderColor: "red100" })
+    }
+  }
+
   onBlur() {
     this.setState({
       borderColor: this.props.error ? "red100" : "black10",

--- a/src/lib/Components/Bidding/Components/__tests__/Input-tests.tsx
+++ b/src/lib/Components/Bidding/Components/__tests__/Input-tests.tsx
@@ -53,3 +53,24 @@ it("shows a red border if error is true", () => {
 
   expect(component.toJSON().props.style[0].borderColor).toEqual(theme.colors.red100)
 })
+
+it("updates the borde color when the parent component updates the props", () => {
+  class TestFormForInput extends React.Component {
+    state = { error: false }
+
+    render() {
+      return (
+        <BiddingThemeProvider>
+          <Input error={this.state.error} />
+        </BiddingThemeProvider>
+      )
+    }
+  }
+
+  const component = renderer.create(<TestFormForInput />)
+
+  // Explicitly calling setState to force-render the Input component
+  component.root.instance.setState({ error: true })
+
+  expect(component.toJSON().props.style[0].borderColor).toEqual(theme.colors.red100)
+})


### PR DESCRIPTION
This PR addresses an edge case where the parent component of an `<Input>` component updates the `error` prop but the border color wasn't updated properly.

I tried to use [the new `getDerivedStateFromProps` callback](https://reactjs.org/docs/react-component.html#static-getderivedstatefromprops) but seems like we aren't on the latest version of React Native, so I just used the `componentWillReceiveProps()`. The new test does not depend on the internals of the component, so it should not be difficult to migrate to `getDerivedStateFromProps` after react upgrade.