### PR TITLE
[WIP] Enable graphql-crunch

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "relay-runtime": "https://github.com/alloy/relay/releases/download/v1.5.0-artsy.5/relay-runtime-1.5.0-artsy.5.tgz"
   },
   "dependencies": {
+    "graphql-crunch": "^1.1.2",
     "lodash": "^4.17.4",
     "moment": "^2.19.4",
     "prop-types": "^15.5.10",

--- a/src/lib/__tests__/metaphysics-tests.ts
+++ b/src/lib/__tests__/metaphysics-tests.ts
@@ -20,7 +20,7 @@ it("Adds a user agent for reaction", () => {
   return metaphysics("query {}").then(() => {
     expect(global.fetch).toBeCalledWith("https://metaphysics-production.artsy.net", {
       body: '{"query":"query {}"}',
-      headers: { "Content-Type": "application/json", "User-Agent": "Emission" },
+      headers: expect.objectContaining({ "Content-Type": "application/json", "User-Agent": "Emission" }),
       method: "POST",
     })
   })

--- a/src/lib/metaphysics.ts
+++ b/src/lib/metaphysics.ts
@@ -1,11 +1,11 @@
-import { NativeModules } from "react-native"
 import { uncrunch } from "graphql-crunch"
+import { NativeModules } from "react-native"
 const Emission = NativeModules.Emission || {}
 
 import { metaphysicsURL } from "./relay/config"
 import { NetworkError } from "./utils/errors"
 
-const enableCrunch = Emission.crunch || "true"
+const enableCrunch = Emission.crunch != null ? Emission.crunch : "true"
 
 type Payload = { query: string; variables?: object } | { documentID: string; variables?: object }
 

--- a/src/lib/metaphysics.ts
+++ b/src/lib/metaphysics.ts
@@ -14,6 +14,7 @@ export function request(payload: Payload, checkStatus: boolean = true): Promise<
       "User-Agent": Emission.userAgent,
       "X-USER-ID": Emission.userID,
       "X-ACCESS-TOKEN": Emission.authenticationToken,
+      "X-CRUNCH": "true"
     },
     body: JSON.stringify(payload),
   }).then(response => {

--- a/src/lib/metaphysics.ts
+++ b/src/lib/metaphysics.ts
@@ -5,8 +5,6 @@ const Emission = NativeModules.Emission || {}
 import { metaphysicsURL } from "./relay/config"
 import { NetworkError } from "./utils/errors"
 
-const enableCrunch = Emission.crunch != null ? Emission.crunch : "true"
-
 type Payload = { query: string; variables?: object } | { documentID: string; variables?: object }
 
 export function request(payload: Payload, checkStatus: boolean = true): Promise<Response> {
@@ -17,7 +15,7 @@ export function request(payload: Payload, checkStatus: boolean = true): Promise<
       "User-Agent": Emission.userAgent,
       "X-USER-ID": Emission.userID,
       "X-ACCESS-TOKEN": Emission.authenticationToken,
-      "X-CRUNCH": enableCrunch,
+      "X-CRUNCH": "true",
     },
     body: JSON.stringify(payload),
   }).then(response => {

--- a/src/lib/metaphysics.ts
+++ b/src/lib/metaphysics.ts
@@ -35,7 +35,8 @@ export function metaphysics<T>(payload: Payload, checkStatus: boolean = true): P
   return (
     request(payload, checkStatus)
       .then<T & { errors: any[] }>(
-        response => (response.headers["x-crunch"] === "true" ? uncrunch(response.json()) : response.json())
+        response =>
+          response.headers && response.headers["x-crunch"] === "true" ? uncrunch(response.json()) : response.json()
       )
       // TODO: This is here because existing callers may rely on this, but it’s now duplicated here and in fetchQuery.ts
       .then(json => {

--- a/src/lib/metaphysics.ts
+++ b/src/lib/metaphysics.ts
@@ -34,8 +34,9 @@ export function request(payload: Payload, checkStatus: boolean = true): Promise<
 export function metaphysics<T>(payload: Payload, checkStatus: boolean = true): Promise<T> {
   return (
     request(payload, checkStatus)
-      .then<T & { errors: any[] }>(response => response.json())
-      .then(json => (enableCrunch ? uncrunch(json) : json))
+      .then<T & { errors: any[] }>(
+        response => (response.headers["x-crunch"] === "true" ? uncrunch(response.json()) : response.json())
+      )
       // TODO: This is here because existing callers may rely on this, but it’s now duplicated here and in fetchQuery.ts
       .then(json => {
         if (json.errors) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4766,6 +4766,10 @@ graphql-config-parser@^1.2.1:
     node-fetch "^1.6.3"
     valid-url "^1.0.9"
 
+graphql-crunch@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/graphql-crunch/-/graphql-crunch-1.1.2.tgz#8c8e686d1cb92b55f779fdf902c99ac644280c15"
+
 graphql-language-service-config@0.0.11:
   version "0.0.11"
   resolved "https://registry.yarnpkg.com/graphql-language-service-config/-/graphql-language-service-config-0.0.11.tgz#edf593ee7d0b6d8f9cbc8fe5d958b8607c75cea4"


### PR DESCRIPTION
This enables graphql-crunch which results in smaller over-the-wire playloads. This change is dependent on https://github.com/artsy/metaphysics/pull/1061.

