### PR TITLE
[Input] Fixes an edge case where input border color does not get updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 * Adds a billing address screen - yuki24
 * Reflect style updates for the `<Checkbox>` component - yuki24
 * Load Real values into `BidResult` screen + reimplement `<MarkdownRenderer>` - sepans
+* Fixes an edge case where the border color of an `<Input>` component does not get updated properly - yuki24
 
 ### 1.5.0
 

--- a/src/lib/Components/Bidding/Components/Input.tsx
+++ b/src/lib/Components/Bidding/Components/Input.tsx
@@ -20,9 +20,9 @@ export class Input extends Component<InputProps, InputState> {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.error) {
-      this.setState({ borderColor: "red100" })
-    }
+    this.setState({
+      borderColor: nextProps.error ? "red100" : "black10",
+    })
   }
 
   onBlur() {

--- a/src/lib/Components/Bidding/Components/__tests__/Input-tests.tsx
+++ b/src/lib/Components/Bidding/Components/__tests__/Input-tests.tsx
@@ -54,7 +54,7 @@ it("shows a red border if error is true", () => {
   expect(component.toJSON().props.style[0].borderColor).toEqual(theme.colors.red100)
 })
 
-it("updates the borde color when the parent component updates the props", () => {
+it("updates the border color when the parent component updates the error prop", () => {
   class TestFormForInput extends React.Component {
     state = { error: false }
 
@@ -69,8 +69,14 @@ it("updates the borde color when the parent component updates the props", () => 
 
   const component = renderer.create(<TestFormForInput />)
 
+  expect(component.toJSON().props.style[0].borderColor).toEqual(theme.colors.black10)
+
   // Explicitly calling setState to force-render the Input component
   component.root.instance.setState({ error: true })
 
   expect(component.toJSON().props.style[0].borderColor).toEqual(theme.colors.red100)
+
+  component.root.instance.setState({ error: false })
+
+  expect(component.toJSON().props.style[0].borderColor).toEqual(theme.colors.black10)
 })


### PR DESCRIPTION
This commit updates the `<Input>` component to always update the border color when the error prop gets updated by the parent component. Without this change, the border color would stay `red100` when the props transitions from `{ error: true }` to `{ error: false }`.

## Before

![input-error-to-valid-border-color-before](https://user-images.githubusercontent.com/386234/40669748-ad044c48-6335-11e8-94f8-7ae6732446c7.gif)

## After

![input-error-to-valid-border-color-after](https://user-images.githubusercontent.com/386234/40669747-acf8bc2a-6335-11e8-9ecc-f51c84b41947.gif)

merge on green