### PR TITLE
Corrects problem with AROpaqueImageView showing empty images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * `dismissModalViewController` now returns a promise - ash&sarah
 * Continue button now dismisses BidFlow, opens LAI if appropriate - ash&sarah
 * Shows correct message when reserve is not met - sepans
+* Corrects problem with AROpaqueImageView showing empty images - ash
 
 ### 1.5.2
 

--- a/Pod/Classes/OpaqueImageViewComponent/AROpaqueImageView.m
+++ b/Pod/Classes/OpaqueImageViewComponent/AROpaqueImageView.m
@@ -18,16 +18,16 @@ LoadImage(UIImage *image, CGSize destinationSize, CGFloat scaleFactor, UIColor *
                                                  width,
                                                  height,
                                                  8,
-                                                 width * 4,
+                                                 0,
                                                  colourSpace,
                                                  kCGImageAlphaNoneSkipFirst | kCGBitmapByteOrder32Host);
     CGColorSpaceRelease(colourSpace);
-      
+
     // Ensure there's no background fill weirdness for non-rectangular shapes
     CGContextSetFillColorWithColor(context, backgroundColor.CGColor);
     CGContextFillRect(context, CGRectMake(0, 0, width, height));
 
-      
+
     CGContextDrawImage(context, CGRectMake(0, 0, width, height), image.CGImage);
 
     CGImageRef outputImage = CGBitmapContextCreateImage(context);


### PR DESCRIPTION
On-device, the latest 1.5.2 of Emission fails to load a lot of the images on screen:

![img_1026](https://user-images.githubusercontent.com/498212/40746170-ac32b6d6-6427-11e8-83a0-afedb94813ba.jpg)

I took a look at the logs with the `CG_CONTEXT_SHOW_BACKTRACE` and `CGBITMAP_CONTEXT_LOG_ERRORS` environment variables set and it showed the following error:

```
2018-05-30 16:27:35.166254-0400 Artsy[9156:3906813] [Unknown process name] 
CGBitmapContextCreate: unsupported parameter combination:
 	8 bits/component; integer;
 	32 bits/pixel;
	RGB color space model; kCGImageAlphaNoneSkipFirst;
	kCGImageByteOrder32Little byte order;
	1631 bytes/row.
Valid parameters for RGB color space model are:
	16  bits per pixel,		 5  bits per component,		 kCGImageAlphaNoneSkipFirst
	32  bits per pixel,		 8  bits per component,		 kCGImageAlphaNoneSkipFirst
	32  bits per pixel,		 8  bits per component,		 kCGImageAlphaNoneSkipLast
	32  bits per pixel,		 8  bits per component,		 kCGImageAlphaPremultipliedFirst
	32  bits per pixel,		 8  bits per component,		 kCGImageAlphaPremultipliedLast
	64  bits per pixel,		 16 bits per component,		 kCGImageAlphaPremultipliedLast
	64  bits per pixel,		 16 bits per component,		 kCGImageAlphaNoneSkipLast
	64  bits per pixel,		 16 bits per component,		 kCGImageAlphaPremultipliedLast|kCGBitmapFloatComponents
	64  bits per pixel,		 16 bits per component,		 kCGImageAlphaNoneSkipLast|kCGBitmapFloatComponents
	128 bits per pixel,		 32 bits per component,		 kCGImageAlphaPremultipliedLast|kCGBitmapFloatComponents
	128 bits per pixel,		 32 bits per component,		 kCGImageAlphaNoneSkipLast|kCGBitmapFloatComponents
See Quartz 2D Programming Guide (available online) for more information.
2018-05-30 16:27:35.168729-0400 Artsy[9156:3906813] [Unknown process name] CGContextSetFillColorWithColor: invalid context 0x0. Backtrace:
  <__LoadImage_block_invoke+616>
   <_dispatch_call_block_and_release+24>
    <_dispatch_client_callout+16>
     <_dispatch_root_queue_drain+1172>
      <_dispatch_worker_thread3+136>
       <_pthread_wqthread+1176>        <start_wqthread+4>
```

`AROpaqueImageView` has a block to decode images off the main thread, and it looks like this is the cause of our problems. The fourth argument to `CGBitmapContextCreate`, `bytesPerRow`, looked funny to me, since the image excludes alpha I'd expect to see it be `width * 3`. However, the docs say:

> The number of bytes of memory to use per row of the bitmap. If the data parameter is NULL, passing a value of 0 causes the value to be calculated automatically.

I changed it to zero and everything worked again!

Marking this as #native_no_changes because we haven't released a new version of Emission since the last native change. 