### PR TITLE
[Analytics] For the new bidflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Corrects problem with AROpaqueImageView showing empty images - ash
 * Adds the ability for first-time bidders to add thier billing address - erikdstock and yuki24
 * Display "Credit card" and "Billing address" to users without qualified credit cards - yuki24
+* Add first round analytics for the bidflow - maxim&erik
 
 ### 1.5.2
 

--- a/src/lib/Components/Bidding/Screens/BillingAddress.tsx
+++ b/src/lib/Components/Bidding/Screens/BillingAddress.tsx
@@ -1,4 +1,7 @@
 import React from "react"
+
+import { Schema, screenTrack, track } from "../../../utils/track"
+
 import { NavigatorIOS, ScrollView } from "react-native"
 
 import { Flex } from "../Elements/Flex"
@@ -32,6 +35,10 @@ interface BillingAddressState {
   }
 }
 
+@screenTrack({
+  context_screen: Schema.PageNames.BidFlowBillingAddressPage,
+  context_screen_owner_type: null,
+})
 export class BillingAddress extends React.Component<BillingAddressProps, BillingAddressState> {
   constructor(props) {
     super(props)
@@ -66,9 +73,16 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
     if (Object.keys(errors).filter(key => errors[key]).length > 0) {
       this.setState({ errors })
     } else {
-      this.props.onSubmit(this.state.values)
-      this.props.navigator.pop()
+      this.submitValidAddress()
     }
+  }
+  @track({
+    action_type: Schema.ActionTypes.Success,
+    action_name: Schema.ActionNames.BidFlowSaveBillingAddress,
+  })
+  submitValidAddress() {
+    this.props.onSubmit(this.state.values)
+    this.props.navigator.pop()
   }
 
   render() {

--- a/src/lib/Components/Bidding/Screens/ConfirmFirstTimeBid.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmFirstTimeBid.tsx
@@ -3,6 +3,8 @@ import { TouchableWithoutFeedback, View } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components/native"
 
+import { Schema, screenTrack, track } from "../../../utils/track"
+
 import { Flex } from "../Elements/Flex"
 import { Col, Row } from "../Elements/Grid"
 import {
@@ -44,6 +46,10 @@ interface ConformBidState {
   isLoading: boolean
 }
 
+@screenTrack({
+  context_screen: Schema.PageNames.BidFlowConfirmBidPage,
+  context_screen_owner_type: null,
+})
 export class ConfirmFirstTimeBid extends React.Component<ConfirmBidProps, ConformBidState> {
   state = {
     billingAddress: undefined,
@@ -75,6 +81,14 @@ export class ConfirmFirstTimeBid extends React.Component<ConfirmBidProps, Confor
 
   onBillingAddressAdded = (values: Address) => {
     this.setState({ billingAddress: values })
+  }
+
+  @track({
+    action_type: Schema.ActionTypes.Tap,
+    action_name: Schema.ActionNames.BidFlowPlaceBid,
+  })
+  placeBid() {
+    return null
   }
 
   render() {
@@ -156,7 +170,7 @@ export class ConfirmFirstTimeBid extends React.Component<ConfirmBidProps, Confor
             </Checkbox>
 
             <Flex m={4}>
-              <Button text="Place Bid" onPress={() => null} />
+              <Button text="Place Bid" onPress={() => this.placeBid()} />
             </Flex>
           </View>
         </Container>

--- a/src/lib/Components/Bidding/Screens/SelectMaxBid.tsx
+++ b/src/lib/Components/Bidding/Screens/SelectMaxBid.tsx
@@ -15,6 +15,8 @@ import { SelectMaxBid_sale_artwork } from "__generated__/SelectMaxBid_sale_artwo
 import { BiddingThemeProvider } from "../Components/BiddingThemeProvider"
 import { ConfirmFirstTimeBidScreen } from "./ConfirmFirstTimeBid"
 
+import { Schema, screenTrack } from "../../../utils/track"
+
 interface SelectMaxBidProps extends ViewProperties {
   sale_artwork: SelectMaxBid_sale_artwork
   me: SelectMaxBid_me
@@ -25,6 +27,10 @@ interface SelectMaxBidState {
   selectedBidIndex: number
 }
 
+@screenTrack({
+  context_screen: Schema.PageNames.BidFlowMaxBidPage,
+  context_screen_owner_type: null,
+})
 export class SelectMaxBid extends React.Component<SelectMaxBidProps, SelectMaxBidState> {
   state = {
     selectedBidIndex: 0,

--- a/src/lib/utils/track.ts
+++ b/src/lib/utils/track.ts
@@ -81,6 +81,9 @@ export namespace Schema {
 
   export enum PageNames {
     ArtistPage = "Artist",
+    BidFlowMaxBidPage = "YourMaxBid",
+    BidFlowConfirmBidPage = "ConfirmYourBid",
+    BidFlowBillingAddressPage = "YourBillingAddress",
     ConversationPage = "Conversation",
     ConsignmentsWelcome = "ConsignmentsWelcome",
     ConsignmentsOverView = "ConsignmentsOverview",
@@ -169,6 +172,13 @@ export namespace Schema {
      */
     ConsignmentDraftCreated = "consignmentDraftCreated",
     ConsignmentSubmitted = "consignmentSubmitted",
+
+    /**
+     * Bid flow
+     */
+    BidFlowAddBillingAddress = "addBillingAddress",
+    BidFlowPlaceBid = "placeBid",
+    BidFlowSaveBillingAddress = "saveBillingAddress",
   }
 }
 


### PR DESCRIPTION
First round! 

Includes screen events for Max Bid, Confirm Bid, and Billing Address. 
Also has place bid events. 

@erikdstock I realised we had forgotten the other confirm bid screen (`ConfirmBid.tsx`), so I added events there, and seeing as it already had some network code, there's a success track also :).

