### PR TITLE
Adds line-height to the type system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Master
 
 * Adds going back to max bid when selecting edit bid from confirmation screen - maxim
+* Adds line-height to the type system - sepans
 
 ### 1.5.3
 

--- a/src/lib/Components/Bidding/Components/__tests__/__snapshots__/MarkdownRenderer-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Components/__tests__/__snapshots__/MarkdownRenderer-tests.tsx.snap
@@ -7,6 +7,7 @@ exports[`Markdown parser component renders multiple paragraphs matches the snaps
   color="black60"
   ellipsizeMode="tail"
   fontSize={3}
+  lineHeight={3}
   maxWidth={280}
   mb={5}
   style={
@@ -15,6 +16,7 @@ exports[`Markdown parser component renders multiple paragraphs matches the snaps
         "color": "#666",
         "fontFamily": "AGaramondPro-Regular",
         "fontSize": 16,
+        "lineHeight": 20,
         "marginBottom": 30,
         "maxWidth": 280,
         "textAlign": "center",
@@ -43,6 +45,7 @@ exports[`Markdown parser component renders text matches the snapshot 1`] = `
   color="black60"
   ellipsizeMode="tail"
   fontSize={3}
+  lineHeight={3}
   maxWidth={280}
   mb={5}
   style={
@@ -51,6 +54,7 @@ exports[`Markdown parser component renders text matches the snapshot 1`] = `
         "color": "#666",
         "fontFamily": "AGaramondPro-Regular",
         "fontSize": 16,
+        "lineHeight": 20,
         "marginBottom": 30,
         "maxWidth": 280,
         "textAlign": "center",
@@ -77,6 +81,7 @@ exports[`Markdown parser component renders text with link matches the snapshot 1
   color="black60"
   ellipsizeMode="tail"
   fontSize={3}
+  lineHeight={3}
   maxWidth={280}
   mb={5}
   style={
@@ -85,6 +90,7 @@ exports[`Markdown parser component renders text with link matches the snapshot 1
         "color": "#666",
         "fontFamily": "AGaramondPro-Regular",
         "fontSize": 16,
+        "lineHeight": 20,
         "marginBottom": 30,
         "maxWidth": 280,
         "textAlign": "center",

--- a/src/lib/Components/Bidding/Components/__tests__/__snapshots__/MarkdownRenderer-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Components/__tests__/__snapshots__/MarkdownRenderer-tests.tsx.snap
@@ -7,7 +7,7 @@ exports[`Markdown parser component renders multiple paragraphs matches the snaps
   color="black60"
   ellipsizeMode="tail"
   fontSize={3}
-  lineHeight={3}
+  lineHeight={5}
   maxWidth={280}
   mb={5}
   style={
@@ -16,7 +16,7 @@ exports[`Markdown parser component renders multiple paragraphs matches the snaps
         "color": "#666",
         "fontFamily": "AGaramondPro-Regular",
         "fontSize": 16,
-        "lineHeight": 20,
+        "lineHeight": 24,
         "marginBottom": 30,
         "maxWidth": 280,
         "textAlign": "center",
@@ -45,7 +45,7 @@ exports[`Markdown parser component renders text matches the snapshot 1`] = `
   color="black60"
   ellipsizeMode="tail"
   fontSize={3}
-  lineHeight={3}
+  lineHeight={5}
   maxWidth={280}
   mb={5}
   style={
@@ -54,7 +54,7 @@ exports[`Markdown parser component renders text matches the snapshot 1`] = `
         "color": "#666",
         "fontFamily": "AGaramondPro-Regular",
         "fontSize": 16,
-        "lineHeight": 20,
+        "lineHeight": 24,
         "marginBottom": 30,
         "maxWidth": 280,
         "textAlign": "center",
@@ -81,7 +81,7 @@ exports[`Markdown parser component renders text with link matches the snapshot 1
   color="black60"
   ellipsizeMode="tail"
   fontSize={3}
-  lineHeight={3}
+  lineHeight={5}
   maxWidth={280}
   mb={5}
   style={
@@ -90,7 +90,7 @@ exports[`Markdown parser component renders text with link matches the snapshot 1
         "color": "#666",
         "fontFamily": "AGaramondPro-Regular",
         "fontSize": 16,
-        "lineHeight": 20,
+        "lineHeight": 24,
         "marginBottom": 30,
         "maxWidth": 280,
         "textAlign": "center",

--- a/src/lib/Components/Bidding/Components/__tests__/__snapshots__/Title-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Components/__tests__/__snapshots__/Title-tests.tsx.snap
@@ -6,12 +6,14 @@ exports[`renders properly 1`] = `
   allowFontScaling={true}
   ellipsizeMode="tail"
   fontSize={5}
+  lineHeight={9}
   m={4}
   style={
     Array [
       Object {
         "fontFamily": "AGaramondPro-Semibold",
         "fontSize": 32,
+        "lineHeight": 9,
         "marginBottom": 32,
         "marginLeft": 32,
         "marginRight": 32,

--- a/src/lib/Components/Bidding/Elements/Theme.tsx
+++ b/src/lib/Components/Bidding/Elements/Theme.tsx
@@ -24,5 +24,7 @@ export const theme = {
   // https://www.notion.so/artsy/Typography-d1f9f6731f3d47c78003d6d016c30221
   fontSizes: [10, 12, 14, 16, 18, 22, 28, 42, 64, 80, 100],
 
+  lineHeights: [14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 36, 38, 50, 66, 84, 104],
+
   borders: [0, "1px solid"],
 }

--- a/src/lib/Components/Bidding/Elements/Typography.tsx
+++ b/src/lib/Components/Bidding/Elements/Typography.tsx
@@ -51,16 +51,16 @@ export const Sans18 = props => <Sans fontSize={4} lineHeight={8} {...props} />
 
 export const Serif12 = props => <Serif fontSize={1} lineHeight={1} {...props} />
 export const Serif14 = props => <Serif fontSize={2} lineHeight={2} {...props} />
-export const Serif16 = props => <Serif fontSize={3} lineHeight={3} {...props} />
+export const Serif16 = props => <Serif fontSize={3} lineHeight={5} {...props} />
 export const Serif18 = props => <Serif fontSize={4} lineHeight={6} {...props} />
 
 export const SerifSemibold12 = props => <SerifSemibold fontSize={1} lineHeight={1} {...props} />
 export const SerifSemibold14 = props => <SerifSemibold fontSize={2} lineHeight={2} {...props} />
-export const SerifSemibold16 = props => <SerifSemibold fontSize={3} lineHeight={3} {...props} />
+export const SerifSemibold16 = props => <SerifSemibold fontSize={3} lineHeight={5} {...props} />
 export const SerifSemibold18 = props => <SerifSemibold fontSize={4} lineHeight={6} {...props} />
 export const SerifSemibold22 = props => <SerifSemibold fontSize={5} lineHeight={9} {...props} />
 
 export const SerifItalic12 = props => <SerifItalic fontSize={1} lineHeight={1} {...props} />
 export const SerifItalic14 = props => <SerifItalic fontSize={2} lineHeight={2} {...props} />
-export const SerifItalic16 = props => <SerifItalic fontSize={3} lineHeight={3} {...props} />
+export const SerifItalic16 = props => <SerifItalic fontSize={3} lineHeight={5} {...props} />
 export const SerifItalic18 = props => <SerifItalic fontSize={4} lineHeight={6} {...props} />

--- a/src/lib/Components/Bidding/Elements/Typography.tsx
+++ b/src/lib/Components/Bidding/Elements/Typography.tsx
@@ -44,23 +44,23 @@ const SerifItalic = styled.Text`
   ${maxWidth}
 `
 
-export const Sans12 = props => <Sans fontSize={1} {...props} />
-export const Sans14 = props => <Sans fontSize={2} {...props} />
-export const Sans16 = props => <Sans fontSize={3} {...props} />
-export const Sans18 = props => <Sans fontSize={4} {...props} />
+export const Sans12 = props => <Sans fontSize={1} lineHeight={1} {...props} />
+export const Sans14 = props => <Sans fontSize={2} lineHeight={5} {...props} />
+export const Sans16 = props => <Sans fontSize={3} lineHeight={6} {...props} />
+export const Sans18 = props => <Sans fontSize={4} lineHeight={8} {...props} />
 
-export const Serif12 = props => <Serif fontSize={1} {...props} />
-export const Serif14 = props => <Serif fontSize={2} {...props} />
-export const Serif16 = props => <Serif fontSize={3} {...props} />
-export const Serif18 = props => <Serif fontSize={4} {...props} />
+export const Serif12 = props => <Serif fontSize={1} lineHeight={1} {...props} />
+export const Serif14 = props => <Serif fontSize={2} lineHeight={2} {...props} />
+export const Serif16 = props => <Serif fontSize={3} lineHeight={3} {...props} />
+export const Serif18 = props => <Serif fontSize={4} lineHeight={6} {...props} />
 
-export const SerifSemibold12 = props => <SerifSemibold fontSize={1} {...props} />
-export const SerifSemibold14 = props => <SerifSemibold fontSize={2} {...props} />
-export const SerifSemibold16 = props => <SerifSemibold fontSize={3} {...props} />
-export const SerifSemibold18 = props => <SerifSemibold fontSize={4} {...props} />
-export const SerifSemibold22 = props => <SerifSemibold fontSize={5} {...props} />
+export const SerifSemibold12 = props => <SerifSemibold fontSize={1} lineHeight={1} {...props} />
+export const SerifSemibold14 = props => <SerifSemibold fontSize={2} lineHeight={2} {...props} />
+export const SerifSemibold16 = props => <SerifSemibold fontSize={3} lineHeight={3} {...props} />
+export const SerifSemibold18 = props => <SerifSemibold fontSize={4} lineHeight={6} {...props} />
+export const SerifSemibold22 = props => <SerifSemibold fontSize={5} lineHeight={9} {...props} />
 
-export const SerifItalic12 = props => <SerifItalic fontSize={1} {...props} />
-export const SerifItalic14 = props => <SerifItalic fontSize={2} {...props} />
-export const SerifItalic16 = props => <SerifItalic fontSize={3} {...props} />
-export const SerifItalic18 = props => <SerifItalic fontSize={4} {...props} />
+export const SerifItalic12 = props => <SerifItalic fontSize={1} lineHeight={1} {...props} />
+export const SerifItalic14 = props => <SerifItalic fontSize={2} lineHeight={2} {...props} />
+export const SerifItalic16 = props => <SerifItalic fontSize={3} lineHeight={3} {...props} />
+export const SerifItalic18 = props => <SerifItalic fontSize={4} lineHeight={6} {...props} />

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/BidResult-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/BidResult-tests.tsx.snap
@@ -55,12 +55,14 @@ exports[`BidResult component high bidder renders winning screen properly 1`] = `
         allowFontScaling={true}
         ellipsizeMode="tail"
         fontSize={5}
+        lineHeight={9}
         m={4}
         style={
           Array [
             Object {
               "fontFamily": "AGaramondPro-Semibold",
               "fontSize": 22,
+              "lineHeight": 32,
               "marginBottom": 20,
               "marginLeft": 20,
               "marginRight": 20,
@@ -88,11 +90,13 @@ exports[`BidResult component high bidder renders winning screen properly 1`] = `
           allowFontScaling={true}
           ellipsizeMode="tail"
           fontSize={1}
+          lineHeight={1}
           style={
             Array [
               Object {
                 "fontFamily": "Unica77LL-Medium",
                 "fontSize": 12,
+                "lineHeight": 16,
               },
               undefined,
             ]
@@ -107,11 +111,13 @@ exports[`BidResult component high bidder renders winning screen properly 1`] = `
           allowFontScaling={true}
           ellipsizeMode="tail"
           fontSize={2}
+          lineHeight={5}
           style={
             Array [
               Object {
                 "fontFamily": "Unica77LL-Medium",
                 "fontSize": 14,
+                "lineHeight": 24,
               },
               undefined,
             ]
@@ -241,12 +247,14 @@ exports[`BidResult component live bidding has started doesn't render timer 1`] =
         allowFontScaling={true}
         ellipsizeMode="tail"
         fontSize={5}
+        lineHeight={9}
         m={4}
         style={
           Array [
             Object {
               "fontFamily": "AGaramondPro-Semibold",
               "fontSize": 22,
+              "lineHeight": 32,
               "marginBottom": 20,
               "marginLeft": 20,
               "marginRight": 20,
@@ -266,6 +274,7 @@ exports[`BidResult component live bidding has started doesn't render timer 1`] =
         color="black60"
         ellipsizeMode="tail"
         fontSize={3}
+        lineHeight={3}
         maxWidth={280}
         mb={5}
         style={
@@ -274,6 +283,7 @@ exports[`BidResult component live bidding has started doesn't render timer 1`] =
               "color": "#666",
               "fontFamily": "AGaramondPro-Regular",
               "fontSize": 16,
+              "lineHeight": 20,
               "marginBottom": 30,
               "maxWidth": 280,
               "textAlign": "center",
@@ -425,12 +435,14 @@ exports[`BidResult component low bidder renders timer and error message 1`] = `
         allowFontScaling={true}
         ellipsizeMode="tail"
         fontSize={5}
+        lineHeight={9}
         m={4}
         style={
           Array [
             Object {
               "fontFamily": "AGaramondPro-Semibold",
               "fontSize": 22,
+              "lineHeight": 32,
               "marginBottom": 20,
               "marginLeft": 20,
               "marginRight": 20,
@@ -450,6 +462,7 @@ exports[`BidResult component low bidder renders timer and error message 1`] = `
         color="black60"
         ellipsizeMode="tail"
         fontSize={3}
+        lineHeight={3}
         maxWidth={280}
         mb={5}
         style={
@@ -458,6 +471,7 @@ exports[`BidResult component low bidder renders timer and error message 1`] = `
               "color": "#666",
               "fontFamily": "AGaramondPro-Regular",
               "fontSize": 16,
+              "lineHeight": 20,
               "marginBottom": 30,
               "maxWidth": 280,
               "textAlign": "center",
@@ -481,6 +495,7 @@ exports[`BidResult component low bidder renders timer and error message 1`] = `
         color="black60"
         ellipsizeMode="tail"
         fontSize={3}
+        lineHeight={3}
         maxWidth={280}
         mb={5}
         style={
@@ -489,6 +504,7 @@ exports[`BidResult component low bidder renders timer and error message 1`] = `
               "color": "#666",
               "fontFamily": "AGaramondPro-Regular",
               "fontSize": 16,
+              "lineHeight": 20,
               "marginBottom": 30,
               "maxWidth": 280,
               "textAlign": "center",
@@ -520,11 +536,13 @@ exports[`BidResult component low bidder renders timer and error message 1`] = `
           allowFontScaling={true}
           ellipsizeMode="tail"
           fontSize={1}
+          lineHeight={1}
           style={
             Array [
               Object {
                 "fontFamily": "Unica77LL-Medium",
                 "fontSize": 12,
+                "lineHeight": 16,
               },
               undefined,
             ]
@@ -539,11 +557,13 @@ exports[`BidResult component low bidder renders timer and error message 1`] = `
           allowFontScaling={true}
           ellipsizeMode="tail"
           fontSize={2}
+          lineHeight={5}
           style={
             Array [
               Object {
                 "fontFamily": "Unica77LL-Medium",
                 "fontSize": 14,
+                "lineHeight": 24,
               },
               undefined,
             ]

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/BidResult-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/BidResult-tests.tsx.snap
@@ -274,7 +274,7 @@ exports[`BidResult component live bidding has started doesn't render timer 1`] =
         color="black60"
         ellipsizeMode="tail"
         fontSize={3}
-        lineHeight={3}
+        lineHeight={5}
         maxWidth={280}
         mb={5}
         style={
@@ -283,7 +283,7 @@ exports[`BidResult component live bidding has started doesn't render timer 1`] =
               "color": "#666",
               "fontFamily": "AGaramondPro-Regular",
               "fontSize": 16,
-              "lineHeight": 20,
+              "lineHeight": 24,
               "marginBottom": 30,
               "maxWidth": 280,
               "textAlign": "center",
@@ -462,7 +462,7 @@ exports[`BidResult component low bidder renders timer and error message 1`] = `
         color="black60"
         ellipsizeMode="tail"
         fontSize={3}
-        lineHeight={3}
+        lineHeight={5}
         maxWidth={280}
         mb={5}
         style={
@@ -471,7 +471,7 @@ exports[`BidResult component low bidder renders timer and error message 1`] = `
               "color": "#666",
               "fontFamily": "AGaramondPro-Regular",
               "fontSize": 16,
-              "lineHeight": 20,
+              "lineHeight": 24,
               "marginBottom": 30,
               "maxWidth": 280,
               "textAlign": "center",
@@ -495,7 +495,7 @@ exports[`BidResult component low bidder renders timer and error message 1`] = `
         color="black60"
         ellipsizeMode="tail"
         fontSize={3}
-        lineHeight={3}
+        lineHeight={5}
         maxWidth={280}
         mb={5}
         style={
@@ -504,7 +504,7 @@ exports[`BidResult component low bidder renders timer and error message 1`] = `
               "color": "#666",
               "fontFamily": "AGaramondPro-Regular",
               "fontSize": 16,
-              "lineHeight": 20,
+              "lineHeight": 24,
               "marginBottom": 30,
               "maxWidth": 280,
               "textAlign": "center",

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/BillingAddress-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/BillingAddress-tests.tsx.snap
@@ -28,6 +28,7 @@ exports[`renders properly 1`] = `
         allowFontScaling={true}
         ellipsizeMode="tail"
         fontSize={5}
+        lineHeight={9}
         m={4}
         mb={6}
         mt={0}
@@ -36,6 +37,7 @@ exports[`renders properly 1`] = `
             Object {
               "fontFamily": "AGaramondPro-Semibold",
               "fontSize": 22,
+              "lineHeight": 32,
               "marginBottom": 40,
               "marginLeft": 20,
               "marginRight": 20,
@@ -65,12 +67,14 @@ exports[`renders properly 1`] = `
           allowFontScaling={true}
           ellipsizeMode="tail"
           fontSize={3}
+          lineHeight={3}
           mb={2}
           style={
             Array [
               Object {
                 "fontFamily": "AGaramondPro-Regular",
                 "fontSize": 16,
+                "lineHeight": 20,
                 "marginBottom": 5,
               },
               undefined,
@@ -129,12 +133,14 @@ exports[`renders properly 1`] = `
           allowFontScaling={true}
           ellipsizeMode="tail"
           fontSize={3}
+          lineHeight={3}
           mb={2}
           style={
             Array [
               Object {
                 "fontFamily": "AGaramondPro-Regular",
                 "fontSize": 16,
+                "lineHeight": 20,
                 "marginBottom": 5,
               },
               undefined,
@@ -193,12 +199,14 @@ exports[`renders properly 1`] = `
           allowFontScaling={true}
           ellipsizeMode="tail"
           fontSize={3}
+          lineHeight={3}
           mb={2}
           style={
             Array [
               Object {
                 "fontFamily": "AGaramondPro-Regular",
                 "fontSize": 16,
+                "lineHeight": 20,
                 "marginBottom": 5,
               },
               undefined,
@@ -257,12 +265,14 @@ exports[`renders properly 1`] = `
           allowFontScaling={true}
           ellipsizeMode="tail"
           fontSize={3}
+          lineHeight={3}
           mb={2}
           style={
             Array [
               Object {
                 "fontFamily": "AGaramondPro-Regular",
                 "fontSize": 16,
+                "lineHeight": 20,
                 "marginBottom": 5,
               },
               undefined,
@@ -321,12 +331,14 @@ exports[`renders properly 1`] = `
           allowFontScaling={true}
           ellipsizeMode="tail"
           fontSize={3}
+          lineHeight={3}
           mb={2}
           style={
             Array [
               Object {
                 "fontFamily": "AGaramondPro-Regular",
                 "fontSize": 16,
+                "lineHeight": 20,
                 "marginBottom": 5,
               },
               undefined,
@@ -385,12 +397,14 @@ exports[`renders properly 1`] = `
           allowFontScaling={true}
           ellipsizeMode="tail"
           fontSize={3}
+          lineHeight={3}
           mb={2}
           style={
             Array [
               Object {
                 "fontFamily": "AGaramondPro-Regular",
                 "fontSize": 16,
+                "lineHeight": 20,
                 "marginBottom": 5,
               },
               undefined,

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/BillingAddress-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/BillingAddress-tests.tsx.snap
@@ -67,14 +67,14 @@ exports[`renders properly 1`] = `
           allowFontScaling={true}
           ellipsizeMode="tail"
           fontSize={3}
-          lineHeight={3}
+          lineHeight={5}
           mb={2}
           style={
             Array [
               Object {
                 "fontFamily": "AGaramondPro-Regular",
                 "fontSize": 16,
-                "lineHeight": 20,
+                "lineHeight": 24,
                 "marginBottom": 5,
               },
               undefined,
@@ -133,14 +133,14 @@ exports[`renders properly 1`] = `
           allowFontScaling={true}
           ellipsizeMode="tail"
           fontSize={3}
-          lineHeight={3}
+          lineHeight={5}
           mb={2}
           style={
             Array [
               Object {
                 "fontFamily": "AGaramondPro-Regular",
                 "fontSize": 16,
-                "lineHeight": 20,
+                "lineHeight": 24,
                 "marginBottom": 5,
               },
               undefined,
@@ -199,14 +199,14 @@ exports[`renders properly 1`] = `
           allowFontScaling={true}
           ellipsizeMode="tail"
           fontSize={3}
-          lineHeight={3}
+          lineHeight={5}
           mb={2}
           style={
             Array [
               Object {
                 "fontFamily": "AGaramondPro-Regular",
                 "fontSize": 16,
-                "lineHeight": 20,
+                "lineHeight": 24,
                 "marginBottom": 5,
               },
               undefined,
@@ -265,14 +265,14 @@ exports[`renders properly 1`] = `
           allowFontScaling={true}
           ellipsizeMode="tail"
           fontSize={3}
-          lineHeight={3}
+          lineHeight={5}
           mb={2}
           style={
             Array [
               Object {
                 "fontFamily": "AGaramondPro-Regular",
                 "fontSize": 16,
-                "lineHeight": 20,
+                "lineHeight": 24,
                 "marginBottom": 5,
               },
               undefined,
@@ -331,14 +331,14 @@ exports[`renders properly 1`] = `
           allowFontScaling={true}
           ellipsizeMode="tail"
           fontSize={3}
-          lineHeight={3}
+          lineHeight={5}
           mb={2}
           style={
             Array [
               Object {
                 "fontFamily": "AGaramondPro-Regular",
                 "fontSize": 16,
-                "lineHeight": 20,
+                "lineHeight": 24,
                 "marginBottom": 5,
               },
               undefined,
@@ -397,14 +397,14 @@ exports[`renders properly 1`] = `
           allowFontScaling={true}
           ellipsizeMode="tail"
           fontSize={3}
-          lineHeight={3}
+          lineHeight={5}
           mb={2}
           style={
             Array [
               Object {
                 "fontFamily": "AGaramondPro-Regular",
                 "fontSize": 16,
-                "lineHeight": 20,
+                "lineHeight": 24,
                 "marginBottom": 5,
               },
               undefined,

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmBid-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmBid-tests.tsx.snap
@@ -254,13 +254,13 @@ exports[`renders properly 1`] = `
           allowFontScaling={true}
           ellipsizeMode="tail"
           fontSize={3}
-          lineHeight={3}
+          lineHeight={5}
           style={
             Array [
               Object {
                 "fontFamily": "AGaramondPro-Semibold",
                 "fontSize": 16,
-                "lineHeight": 20,
+                "lineHeight": 24,
               },
               undefined,
             ]
@@ -288,14 +288,14 @@ exports[`renders properly 1`] = `
           allowFontScaling={true}
           ellipsizeMode="tail"
           fontSize={3}
-          lineHeight={3}
+          lineHeight={5}
           numberOfLines={1}
           style={
             Array [
               Object {
                 "fontFamily": "AGaramondPro-Regular",
                 "fontSize": 16,
-                "lineHeight": 20,
+                "lineHeight": 24,
               },
               undefined,
             ]

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmBid-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmBid-tests.tsx.snap
@@ -35,6 +35,7 @@ exports[`renders properly 1`] = `
       allowFontScaling={true}
       ellipsizeMode="tail"
       fontSize={5}
+      lineHeight={9}
       m={4}
       mb={3}
       style={
@@ -42,6 +43,7 @@ exports[`renders properly 1`] = `
           Object {
             "fontFamily": "AGaramondPro-Semibold",
             "fontSize": 22,
+            "lineHeight": 32,
             "marginBottom": 10,
             "marginLeft": 20,
             "marginRight": 20,
@@ -60,11 +62,13 @@ exports[`renders properly 1`] = `
       allowFontScaling={true}
       ellipsizeMode="tail"
       fontSize={2}
+      lineHeight={5}
       style={
         Array [
           Object {
             "fontFamily": "Unica77LL-Medium",
             "fontSize": 14,
+            "lineHeight": 24,
           },
           undefined,
         ]
@@ -105,11 +109,13 @@ exports[`renders properly 1`] = `
         allowFontScaling={true}
         ellipsizeMode="tail"
         fontSize={4}
+        lineHeight={6}
         style={
           Array [
             Object {
               "fontFamily": "AGaramondPro-Semibold",
               "fontSize": 18,
+              "lineHeight": 26,
             },
             undefined,
           ]
@@ -122,11 +128,13 @@ exports[`renders properly 1`] = `
         allowFontScaling={true}
         ellipsizeMode="tail"
         fontSize={2}
+        lineHeight={2}
         style={
           Array [
             Object {
               "fontFamily": "AGaramondPro-Semibold",
               "fontSize": 14,
+              "lineHeight": 18,
             },
             undefined,
           ]
@@ -141,12 +149,14 @@ exports[`renders properly 1`] = `
         color="black60"
         ellipsizeMode="tail"
         fontSize={2}
+        lineHeight={2}
         style={
           Array [
             Object {
               "color": "#666",
               "fontFamily": "AGaramondPro-Italic",
               "fontSize": 14,
+              "lineHeight": 18,
               "textAlign": "center",
             },
             undefined,
@@ -161,11 +171,13 @@ exports[`renders properly 1`] = `
           allowFontScaling={true}
           ellipsizeMode="tail"
           fontSize={2}
+          lineHeight={2}
           style={
             Array [
               Object {
                 "fontFamily": "AGaramondPro-Regular",
                 "fontSize": 14,
+                "lineHeight": 18,
               },
               undefined,
             ]
@@ -242,11 +254,13 @@ exports[`renders properly 1`] = `
           allowFontScaling={true}
           ellipsizeMode="tail"
           fontSize={3}
+          lineHeight={3}
           style={
             Array [
               Object {
                 "fontFamily": "AGaramondPro-Semibold",
                 "fontSize": 16,
+                "lineHeight": 20,
               },
               undefined,
             ]
@@ -274,12 +288,14 @@ exports[`renders properly 1`] = `
           allowFontScaling={true}
           ellipsizeMode="tail"
           fontSize={3}
+          lineHeight={3}
           numberOfLines={1}
           style={
             Array [
               Object {
                 "fontFamily": "AGaramondPro-Regular",
                 "fontSize": 16,
+                "lineHeight": 20,
               },
               undefined,
             ]
@@ -307,6 +323,7 @@ exports[`renders properly 1`] = `
           color="purple100"
           ellipsizeMode="tail"
           fontSize={1}
+          lineHeight={1}
           mb={2}
           ml={3}
           style={
@@ -315,6 +332,7 @@ exports[`renders properly 1`] = `
                 "color": "#6E1EFF",
                 "fontFamily": "Unica77LL-Medium",
                 "fontSize": 12,
+                "lineHeight": 16,
                 "marginBottom": 5,
                 "marginLeft": 10,
               },
@@ -410,6 +428,7 @@ exports[`renders properly 1`] = `
           color="black60"
           ellipsizeMode="tail"
           fontSize={2}
+          lineHeight={2}
           mt={2}
           style={
             Array [
@@ -417,6 +436,7 @@ exports[`renders properly 1`] = `
                 "color": "#666",
                 "fontFamily": "AGaramondPro-Regular",
                 "fontSize": 14,
+                "lineHeight": 18,
                 "marginTop": 5,
               },
               undefined,

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmFirstTimeBid-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmFirstTimeBid-tests.tsx.snap
@@ -35,6 +35,7 @@ exports[`renders properly 1`] = `
       allowFontScaling={true}
       ellipsizeMode="tail"
       fontSize={5}
+      lineHeight={9}
       m={4}
       mb={3}
       style={
@@ -42,6 +43,7 @@ exports[`renders properly 1`] = `
           Object {
             "fontFamily": "AGaramondPro-Semibold",
             "fontSize": 22,
+            "lineHeight": 32,
             "marginBottom": 10,
             "marginLeft": 20,
             "marginRight": 20,
@@ -60,11 +62,13 @@ exports[`renders properly 1`] = `
       allowFontScaling={true}
       ellipsizeMode="tail"
       fontSize={2}
+      lineHeight={5}
       style={
         Array [
           Object {
             "fontFamily": "Unica77LL-Medium",
             "fontSize": 14,
+            "lineHeight": 24,
           },
           undefined,
         ]
@@ -105,11 +109,13 @@ exports[`renders properly 1`] = `
         allowFontScaling={true}
         ellipsizeMode="tail"
         fontSize={4}
+        lineHeight={6}
         style={
           Array [
             Object {
               "fontFamily": "AGaramondPro-Semibold",
               "fontSize": 18,
+              "lineHeight": 26,
             },
             undefined,
           ]
@@ -122,11 +128,13 @@ exports[`renders properly 1`] = `
         allowFontScaling={true}
         ellipsizeMode="tail"
         fontSize={2}
+        lineHeight={2}
         style={
           Array [
             Object {
               "fontFamily": "AGaramondPro-Semibold",
               "fontSize": 14,
+              "lineHeight": 18,
             },
             undefined,
           ]
@@ -141,12 +149,14 @@ exports[`renders properly 1`] = `
         color="black60"
         ellipsizeMode="tail"
         fontSize={2}
+        lineHeight={2}
         style={
           Array [
             Object {
               "color": "#666",
               "fontFamily": "AGaramondPro-Italic",
               "fontSize": 14,
+              "lineHeight": 18,
             },
             undefined,
           ]
@@ -159,11 +169,13 @@ exports[`renders properly 1`] = `
           allowFontScaling={true}
           ellipsizeMode="tail"
           fontSize={2}
+          lineHeight={2}
           style={
             Array [
               Object {
                 "fontFamily": "AGaramondPro-Regular",
                 "fontSize": 14,
+                "lineHeight": 18,
               },
               undefined,
             ]
@@ -240,11 +252,13 @@ exports[`renders properly 1`] = `
           allowFontScaling={true}
           ellipsizeMode="tail"
           fontSize={3}
+          lineHeight={3}
           style={
             Array [
               Object {
                 "fontFamily": "AGaramondPro-Semibold",
                 "fontSize": 16,
+                "lineHeight": 20,
               },
               undefined,
             ]
@@ -272,12 +286,14 @@ exports[`renders properly 1`] = `
           allowFontScaling={true}
           ellipsizeMode="tail"
           fontSize={3}
+          lineHeight={3}
           numberOfLines={1}
           style={
             Array [
               Object {
                 "fontFamily": "AGaramondPro-Regular",
                 "fontSize": 16,
+                "lineHeight": 20,
               },
               undefined,
             ]
@@ -305,6 +321,7 @@ exports[`renders properly 1`] = `
           color="purple100"
           ellipsizeMode="tail"
           fontSize={1}
+          lineHeight={1}
           mb={2}
           ml={3}
           style={
@@ -313,6 +330,7 @@ exports[`renders properly 1`] = `
                 "color": "#6E1EFF",
                 "fontFamily": "Unica77LL-Medium",
                 "fontSize": 12,
+                "lineHeight": 16,
                 "marginBottom": 5,
                 "marginLeft": 10,
               },
@@ -391,11 +409,13 @@ exports[`renders properly 1`] = `
           allowFontScaling={true}
           ellipsizeMode="tail"
           fontSize={3}
+          lineHeight={3}
           style={
             Array [
               Object {
                 "fontFamily": "AGaramondPro-Semibold",
                 "fontSize": 16,
+                "lineHeight": 20,
               },
               undefined,
             ]
@@ -437,6 +457,7 @@ exports[`renders properly 1`] = `
           color="purple100"
           ellipsizeMode="tail"
           fontSize={1}
+          lineHeight={1}
           mb={2}
           ml={3}
           style={
@@ -445,6 +466,7 @@ exports[`renders properly 1`] = `
                 "color": "#6E1EFF",
                 "fontFamily": "Unica77LL-Medium",
                 "fontSize": 12,
+                "lineHeight": 16,
                 "marginBottom": 5,
                 "marginLeft": 10,
               },
@@ -523,11 +545,13 @@ exports[`renders properly 1`] = `
           allowFontScaling={true}
           ellipsizeMode="tail"
           fontSize={3}
+          lineHeight={3}
           style={
             Array [
               Object {
                 "fontFamily": "AGaramondPro-Semibold",
                 "fontSize": 16,
+                "lineHeight": 20,
               },
               undefined,
             ]
@@ -569,6 +593,7 @@ exports[`renders properly 1`] = `
           color="purple100"
           ellipsizeMode="tail"
           fontSize={1}
+          lineHeight={1}
           mb={2}
           ml={3}
           style={
@@ -577,6 +602,7 @@ exports[`renders properly 1`] = `
                 "color": "#6E1EFF",
                 "fontFamily": "Unica77LL-Medium",
                 "fontSize": 12,
+                "lineHeight": 16,
                 "marginBottom": 5,
                 "marginLeft": 10,
               },
@@ -669,6 +695,7 @@ exports[`renders properly 1`] = `
           color="black60"
           ellipsizeMode="tail"
           fontSize={2}
+          lineHeight={2}
           mt={2}
           style={
             Array [
@@ -676,6 +703,7 @@ exports[`renders properly 1`] = `
                 "color": "#666",
                 "fontFamily": "AGaramondPro-Regular",
                 "fontSize": 14,
+                "lineHeight": 18,
                 "marginTop": 5,
               },
               undefined,

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmFirstTimeBid-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmFirstTimeBid-tests.tsx.snap
@@ -252,13 +252,13 @@ exports[`renders properly 1`] = `
           allowFontScaling={true}
           ellipsizeMode="tail"
           fontSize={3}
-          lineHeight={3}
+          lineHeight={5}
           style={
             Array [
               Object {
                 "fontFamily": "AGaramondPro-Semibold",
                 "fontSize": 16,
-                "lineHeight": 20,
+                "lineHeight": 24,
               },
               undefined,
             ]
@@ -286,14 +286,14 @@ exports[`renders properly 1`] = `
           allowFontScaling={true}
           ellipsizeMode="tail"
           fontSize={3}
-          lineHeight={3}
+          lineHeight={5}
           numberOfLines={1}
           style={
             Array [
               Object {
                 "fontFamily": "AGaramondPro-Regular",
                 "fontSize": 16,
-                "lineHeight": 20,
+                "lineHeight": 24,
               },
               undefined,
             ]
@@ -409,13 +409,13 @@ exports[`renders properly 1`] = `
           allowFontScaling={true}
           ellipsizeMode="tail"
           fontSize={3}
-          lineHeight={3}
+          lineHeight={5}
           style={
             Array [
               Object {
                 "fontFamily": "AGaramondPro-Semibold",
                 "fontSize": 16,
-                "lineHeight": 20,
+                "lineHeight": 24,
               },
               undefined,
             ]
@@ -545,13 +545,13 @@ exports[`renders properly 1`] = `
           allowFontScaling={true}
           ellipsizeMode="tail"
           fontSize={3}
-          lineHeight={3}
+          lineHeight={5}
           style={
             Array [
               Object {
                 "fontFamily": "AGaramondPro-Semibold",
                 "fontSize": 16,
-                "lineHeight": 20,
+                "lineHeight": 24,
               },
               undefined,
             ]

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/SelectMaxBid-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/SelectMaxBid-tests.tsx.snap
@@ -26,12 +26,14 @@ exports[`renders properly 1`] = `
     allowFontScaling={true}
     ellipsizeMode="tail"
     fontSize={5}
+    lineHeight={9}
     m={4}
     style={
       Array [
         Object {
           "fontFamily": "AGaramondPro-Semibold",
           "fontSize": 22,
+          "lineHeight": 32,
           "marginBottom": 20,
           "marginLeft": 20,
           "marginRight": 20,

--- a/src/lib/Containers/__tests__/__snapshots__/BidFlow-tests.tsx.snap
+++ b/src/lib/Containers/__tests__/__snapshots__/BidFlow-tests.tsx.snap
@@ -99,12 +99,14 @@ exports[`renders properly 1`] = `
           allowFontScaling={true}
           ellipsizeMode="tail"
           fontSize={5}
+          lineHeight={9}
           m={4}
           style={
             Array [
               Object {
                 "fontFamily": "AGaramondPro-Semibold",
                 "fontSize": 22,
+                "lineHeight": 32,
                 "marginBottom": 20,
                 "marginLeft": 20,
                 "marginRight": 20,


### PR DESCRIPTION
Fixes: https://artsyproduct.atlassian.net/browse/PURCHASE-95

Source: [Artsy type system](https://www.notion.so/artsy/Typography-d1f9f6731f3d47c78003d6d016c30221)

Styled system uses line heights relative to the font size in [this example](https://github.com/jxnblk/styled-system/blob/462283dcc7d819c38f7419991e6a0fd29ae182c8/docs/theming.md) but it appears to be working with absolute pixel values. Used absolute pixel values to make it consistent with Artsy's type system above.

#skip_new_tests