### PR TITLE
Register flow infrastructure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 * Adds going back to max bid when selecting edit bid from confirmation screen - maxim
 * Adds line-height to the type system - sepans
+* Adds `intent` to `ARBidFlowViewController` and `<BidFlow>` component - ash
 
 ### 1.5.3
 

--- a/Pod/Classes/ViewControllers/ARBidFlowViewController.h
+++ b/Pod/Classes/ViewControllers/ARBidFlowViewController.h
@@ -9,8 +9,8 @@ typedef enum : NSUInteger {
 
 @interface ARBidFlowViewController : ARComponentViewController
 
-- (instancetype)initWithArtworkID:(NSString *)artworkID saleID:(NSString *)saleID; /// Defaults to bid.
-- (instancetype)initWithArtworkID:(NSString *)artworkID saleID:(NSString *)saleID intent:(ARBidFlowViewControllerIntent)intent;
+- (instancetype)initWithArtworkID:(nullable NSString *)artworkID saleID:(NSString *)saleID; /// Defaults to bid.
+- (instancetype)initWithArtworkID:(nullable NSString *)artworkID saleID:(NSString *)saleID intent:(ARBidFlowViewControllerIntent)intent;
 
 - (instancetype)initWithEmission:(nullable AREmission *)emission
                       moduleName:(NSString *)moduleName

--- a/Pod/Classes/ViewControllers/ARBidFlowViewController.h
+++ b/Pod/Classes/ViewControllers/ARBidFlowViewController.h
@@ -2,16 +2,23 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef enum : NSUInteger {
+    ARBidFlowViewControllerIntentBid,
+    ARBidFlowViewControllerIntentRegister,
+} ARBidFlowViewControllerIntent;
+
 @interface ARBidFlowViewController : ARComponentViewController
 
-- (instancetype)initWithArtworkID:(NSString *)artworkID saleID:(NSString *)saleID;
+- (instancetype)initWithArtworkID:(NSString *)artworkID saleID:(NSString *)saleID; /// Defaults to bid.
+- (instancetype)initWithArtworkID:(NSString *)artworkID saleID:(NSString *)saleID intent:(ARBidFlowViewControllerIntent)intent;
 
 - (instancetype)initWithEmission:(nullable AREmission *)emission
                       moduleName:(NSString *)moduleName
                initialProperties:(nullable NSDictionary *)initialProperties NS_UNAVAILABLE;
 
-@property (nonatomic, copy) NSString *artworkID;
-@property (nonatomic, copy) NSString *saleID;
+@property (nonatomic, readonly, copy) NSString *artworkID;
+@property (nonatomic, readonly, copy) NSString *saleID;
+@property (nonatomic, readonly, assign) ARBidFlowViewControllerIntent intent;
 
 @end
 

--- a/Pod/Classes/ViewControllers/ARBidFlowViewController.m
+++ b/Pod/Classes/ViewControllers/ARBidFlowViewController.m
@@ -10,7 +10,7 @@
 - (instancetype)initWithArtworkID:(NSString *)artworkID saleID:(NSString *)saleID intent:(ARBidFlowViewControllerIntent)intent
 {
   NSDictionary *props = @{
-                          @"artworkID": artworkID,
+                          @"artworkID": artworkID ?: [NSNull null],
                           @"saleID": saleID,
                           @"intent": (intent == ARBidFlowViewControllerIntentBid ? @"bid" : @"register")
   };

--- a/Pod/Classes/ViewControllers/ARBidFlowViewController.m
+++ b/Pod/Classes/ViewControllers/ARBidFlowViewController.m
@@ -4,11 +4,22 @@
 
 - (instancetype)initWithArtworkID:(NSString *)artworkID saleID:(NSString *)saleID
 {
+    return [self initWithArtworkID:artworkID saleID:saleID intent:ARBidFlowViewControllerIntentBid];
+}
+
+- (instancetype)initWithArtworkID:(NSString *)artworkID saleID:(NSString *)saleID intent:(ARBidFlowViewControllerIntent)intent
+{
+  NSDictionary *props = @{
+                          @"artworkID": artworkID,
+                          @"saleID": saleID,
+                          @"intent": (intent == ARBidFlowViewControllerIntentBid ? @"bid" : @"register")
+  };
   if ((self = [super initWithEmission:nil
                            moduleName:@"BidFlow"
-                    initialProperties:@{ @"artworkID": artworkID, @"saleID": saleID }])) {
+                    initialProperties:props])) {
     _artworkID = artworkID;
     _saleID = saleID;
+    _intent = intent;
   }
   return self;
 }

--- a/src/lib/AppRegistry.tsx
+++ b/src/lib/AppRegistry.tsx
@@ -91,6 +91,7 @@ const MyProfile: React.SFC<{}> = () => <MyProfileRenderer render={renderWithLoad
 interface BidFlowProps {
   artworkID: string
   saleID: string
+  intent: "bid" | "register"
 }
 const BidFlow: React.SFC<BidFlowProps> = props => (
   <BidFlowRenderer {...props} render={renderWithLoadProgress(Containers.BidFlow)} />

--- a/src/lib/AppRegistry.tsx
+++ b/src/lib/AppRegistry.tsx
@@ -89,7 +89,7 @@ const Conversation: React.SFC<ConversationProps> = track<ConversationProps>(prop
 const MyProfile: React.SFC<{}> = () => <MyProfileRenderer render={renderWithLoadProgress(Containers.MyProfile)} />
 
 interface BidFlowProps {
-  artworkID: string
+  artworkID?: string
   saleID: string
   intent: "bid" | "register"
 }

--- a/src/lib/Components/Bidding/__stories__/BidFlow.story.tsx
+++ b/src/lib/Components/Bidding/__stories__/BidFlow.story.tsx
@@ -47,13 +47,21 @@ const BidFlowStoryRenderer: React.SFC<any> = ({ render, query, saleArtworkID }) 
 
 storiesOf("Bidding")
   .add("Show bid flow", () => {
-    return <BidFlowRenderer render={renderWithLoadProgress(BidFlow)} artworkID={testArtworkID} saleID={testSaleID} />
+    return (
+      <BidFlowRenderer
+        render={renderWithLoadProgress(BidFlow)}
+        artworkID={testArtworkID}
+        saleID={testSaleID}
+        intent="bid"
+      />
+    )
   })
   .add("Select Max Bid", () => (
     <BidFlowStoryRenderer
       render={renderWithLoadProgress(MaxBidScreen)}
       query={selectMaxBidQuery}
       saleArtworkID={testSaleArtworkID}
+      intent="bid"
     />
   ))
   .add("Confirm Bid", () => {
@@ -112,6 +120,7 @@ storiesOf("Bidding")
         })}
         query={bidResultQuery}
         saleArtworkID={testSaleArtworkID}
+        intent="bid"
       />
     )
   })
@@ -130,6 +139,7 @@ storiesOf("Bidding")
         })}
         query={bidResultQuery}
         saleArtworkID={testSaleArtworkID}
+        intent="bid"
       />
     )
   })
@@ -151,6 +161,7 @@ storiesOf("Bidding")
         })}
         query={bidResultQuery}
         saleArtworkID={testSaleArtworkID}
+        intent="bid"
       />
     )
   })

--- a/src/lib/Containers/BidFlow.tsx
+++ b/src/lib/Containers/BidFlow.tsx
@@ -10,6 +10,7 @@ import { BidFlow_me } from "../../__generated__/BidFlow_me.graphql"
 interface BidFlowProps extends ViewProperties {
   sale_artwork: BidFlow_sale_artwork
   me: BidFlow_me
+  intent: "bid" | "register"
 }
 
 class BidFlow extends React.Component<BidFlowProps> {

--- a/src/lib/Containers/__tests__/BidFlow-tests.tsx
+++ b/src/lib/Containers/__tests__/BidFlow-tests.tsx
@@ -34,6 +34,6 @@ const SaleArtwork = {
 }
 
 it("renders properly", () => {
-  const bg = renderer.create(<BidFlow me={Me} sale_artwork={SaleArtwork} />).toJSON()
+  const bg = renderer.create(<BidFlow me={Me} sale_artwork={SaleArtwork} intent="bid" />).toJSON()
   expect(bg).toMatchSnapshot()
 })

--- a/src/lib/Containers/__tests__/__snapshots__/BidFlow-tests.tsx.snap
+++ b/src/lib/Containers/__tests__/__snapshots__/BidFlow-tests.tsx.snap
@@ -24,6 +24,7 @@ exports[`renders properly 1`] = `
         Object {
           "component": [Function],
           "passProps": Object {
+            "intent": "bid",
             "me": Object {
               "has_qualified_credit_cards": true,
             },

--- a/src/lib/relay/QueryRenderers.tsx
+++ b/src/lib/relay/QueryRenderers.tsx
@@ -61,9 +61,10 @@ export const ArtistRenderer: React.SFC<ArtistRendererProps> = ({ render, artistI
 interface BidFlowRendererProps extends RendererProps {
   artworkID: string
   saleID: string
+  intent: "bid" | "register"
 }
 
-export const BidFlowRenderer: React.SFC<BidFlowRendererProps> = ({ render, artworkID, saleID }) => {
+export const BidFlowRenderer: React.SFC<BidFlowRendererProps> = ({ render, artworkID, saleID, intent }) => {
   return (
     <QueryRenderer
       environment={environment}
@@ -93,6 +94,7 @@ export const BidFlowRenderer: React.SFC<BidFlowRendererProps> = ({ render, artwo
             props: {
               sale_artwork: props.artwork.sale_artwork,
               me: props.me,
+              intent,
             },
             error,
           })

--- a/src/lib/relay/QueryRenderers.tsx
+++ b/src/lib/relay/QueryRenderers.tsx
@@ -59,12 +59,13 @@ export const ArtistRenderer: React.SFC<ArtistRendererProps> = ({ render, artistI
 }
 
 interface BidFlowRendererProps extends RendererProps {
-  artworkID: string
+  artworkID?: string
   saleID: string
   intent: "bid" | "register"
 }
 
 export const BidFlowRenderer: React.SFC<BidFlowRendererProps> = ({ render, artworkID, saleID, intent }) => {
+  // TODO: artworkID can be nil, so omit that part of the query if it is.
   return (
     <QueryRenderer
       environment={environment}


### PR DESCRIPTION
This work is tracked in [PURCHASE-174](https://artsyproduct.atlassian.net/browse/PURCHASE-174).

This PR was originally going to add a new native view controller, but I decided that reusing the existing Objective-C class was a better choice, but does lead to a little more complexity in the query renderer. Here's the breakdown:

- Expand the existing `<BidFlow>` component to support a registration flow based on a new `intent` prop.
- That makes the `artworkID` a nullable prop, so the query renderer `<BidFlow>` needs to handle missing artwork IDs too. I made a `TODO`.
- There's a possible edge case where the intent is `"bid"` but the `artworkID` is null, which would indicate programmer error, but something I wanted to bring up.

I [verified with Brian](https://artsy.slack.com/archives/C9YNS4X32/p1528309649000818) that both the bidding and registration flows take place in modals. There's a question of what will happen when we move to a partially-visible component (one that doesn't hide the full screen behind it) when over the Auctions view controller, which is still in Swift, but we can deal with that when it gets here.

Marking as #native_no_changes since it's all backwards compatible. 