### PR TITLE
Decreases timer tests duration #trivial

### DIFF
--- a/src/lib/Components/Bidding/Components/__tests__/Timer-tests.tsx
+++ b/src/lib/Components/Bidding/Components/__tests__/Timer-tests.tsx
@@ -59,17 +59,17 @@ it("shows 'Live' when the liveStartsAt prop is given", () => {
 })
 
 it("counts down to zero", () => {
-  const timer = renderer.create(<Timer endsAt="2018-05-14T10:24:31+00:00" />)
+  const timer = renderer.create(<Timer endsAt="2018-05-14T10:23:10+00:00" />)
 
-  expect(getTimerText(timer)).toEqual("03d  14h  01m  59s")
+  expect(getTimerText(timer)).toEqual("03d  14h  00m  38s")
 
   jest.advanceTimersByTime(2 * SECONDS)
 
-  expect(getTimerText(timer)).toEqual("03d  14h  01m  57s")
+  expect(getTimerText(timer)).toEqual("03d  14h  00m  36s")
 
-  jest.advanceTimersByTime(20 * MINUTES)
+  jest.advanceTimersByTime(1 * MINUTES)
 
-  expect(getTimerText(timer)).toEqual("03d  13h  41m  57s")
+  expect(getTimerText(timer)).toEqual("03d  13h  59m  36s")
 })
 
 it("shows month, date, and hour adjusted for the timezone where the user is", () => {


### PR DESCRIPTION
I noticed that the five tests in `Timer-tests.tsx` were consistently taking longer than ten seconds to complete. I took a look and it appears that calls to [`advanceTimersByTime()`](https://github.com/facebook/jest/blob/3ce87434570d23be061648162488ca5599e40651/packages/jest-util/src/fake_timers.js#L260) does an amount of work that scales linearly with the amount of time to advance by (at least in our case, using `setInverval()`). When calling with `20 * MINUTES`, we're really calling `advanceTimersByTime(1200000)` 😅 

This PR reduces the amount of time the test takes to run to about 1s by reducing the number of minutes to advance time by to `1`, along with some adjustments to test data (to make sure time advances still cascade from seconds to minutes to hours). Let me know what I can clarify.