### PR TITLE
Document adding key

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ There is a comprehensive document covering [the various options](docs/debugging.
 
 ### Understanding Relay
 
-We have some debugging tip [when using Relay](docs/relay.md).
+We have some debugging tips [when using Relay](docs/relay.md).
 
 ---
 

--- a/docs/adding_new_keys.md
+++ b/docs/adding_new_keys.md
@@ -2,7 +2,7 @@
 
 Emission uses [`cocoapods-keys`](https://github.com/orta/cocoapods-keys) to store secrets (similar to a `.env` file). In order to expose these keys to our react-native components we must do a fair bit of setup.
 
-Links to examples below come from [this commit](https://github.com/artsy/emission/pull/1086/commits/4a2a3e9260e97d791536cf38376a06b0ad0946a8) adds a key for the Stripe API.
+Links to examples below come from [this commit](https://github.com/artsy/emission/pull/1086/commits/4a2a3e9260e97d791536cf38376a06b0ad0946a8) which adds a key for the Stripe API.
 
 ## Steps
 
@@ -11,13 +11,13 @@ Links to examples below come from [this commit](https://github.com/artsy/emissio
 This is the extent of `cocoapods-keys` official setup, and after this you **could** set the key via `pod keys set <NAME>` or `pod install`... but we have more to do.
 [Example/Podfile](https://github.com/artsy/emission/blob/4a2a3e9260e97d791536cf38376a06b0ad0946a8/Example/Podfile#L63)
 
-```ruby
+```diff
 plugin 'cocoapods-keys', {
   :target => 'Emission',
   :keys => [
     'ArtsyAPIClientSecret',   # Authing to the Artsy API
     'ArtsyAPIClientKey',      #
-    'StripePublishableKey',   # A new key!
++    'StripePublishableKey',
   ]
 }
 ```
@@ -30,16 +30,16 @@ We'll need to update the `initWithUserId...` function, expose the new key as a p
 
 [AREmission.h](https://github.com/artsy/emission/blob/4a2a3e9260e97d791536cf38376a06b0ad0946a8/Pod/Classes/Core/AREmission.h#L17-L34):
 
-```objc
+```diff
 // ENV Variables
-@property (nonatomic, copy, readonly, nullable) NSString *stripePublishableKey; # Add this line
++ @property (nonatomic, copy, readonly, nullable) NSString *stripePublishableKey;
 
 # ...
 
-- (instancetype)initWithUserID:(NSString *)userID
+ - (instancetype)initWithUserID:(NSString *)userID
            authenticationToken:(NSString *)token
                      sentryDSN:(nullable NSString *)sentryDSN
-          stripePublishableKey:(NSString *)stripePublishableKey # Add this line
++         stripePublishableKey:(NSString *)stripePublishableKey
               googleMapsAPIKey:(nullable NSString *)googleAPIKey
                     gravityURL:(NSString *)gravity
                 metaphysicsURL:(NSString *)metaphysics
@@ -48,32 +48,31 @@ We'll need to update the `initWithUserId...` function, expose the new key as a p
 
 [AREmission.m](https://github.com/artsy/emission/blob/4a2a3e9260e97d791536cf38376a06b0ad0946a8/Pod/Classes/Core/AREmission.m#L24-L60):
 
-```objc
-- (NSDictionary *)constantsToExport
-{
-  return @{
-    # Add this line...
-    @"stripePublishableKey": self.stripePublishableKey ?: @"",
-    # ...
-  };
-}
+```diff
+ - (NSDictionary *)constantsToExport
+ {
+   return @{
+     # Add this line...
++    @"stripePublishableKey": self.stripePublishableKey ?: @"",
+     # ...
+   };
+ }
 
-- (instancetype)initWithUserID:(NSString *)userID
-           authenticationToken:(NSString *)token
-                     sentryDSN:(NSString *)sentryDSN
-          stripePublishableKey:(NSString *)stripePublishableKey # Add this line
-              googleMapsAPIKey:(NSString *)googleAPIKey
-                    gravityURL:(NSString *)gravity
-                metaphysicsURL:(NSString *)metaphysics
-                     userAgent:(nonnull NSString *)userAgent
-{
-    self = [super init];
-    _userID = userID.copy;
-    # ... More copies...
-    _stripePublishableKey = stripePublishableKey.copy;   # And this line
-    # ... Even more copies...
-    return self;
-}
+ - (instancetype)initWithUserID:(NSString *)userID
+            authenticationToken:(NSString *)token
+                      sentryDSN:(NSString *)sentryDSN
++          stripePublishableKey:(NSString *)stripePublishableKey
+               googleMapsAPIKey:(NSString *)googleAPIKey
+                     gravityURL:(NSString *)gravity
+                 metaphysicsURL:(NSString *)metaphysics
+                      userAgent:(nonnull NSString *)userAgent
+ {
+     self = [super init];
+     _userID = userID.copy;
+     # ... More copies...
++    _stripePublishableKey = stripePublishableKey.copy;
+     return self;
+ }
 ```
 
 ---

--- a/docs/adding_new_keys.md
+++ b/docs/adding_new_keys.md
@@ -1,0 +1,111 @@
+# Adding a New Key
+
+Emission uses [`cocoapods-keys`](https://github.com/orta/cocoapods-keys) to store secrets (similar to a `.env` file). In order to expose these keys to our react-native components we must do a fair bit of setup.
+
+Links to examples below come from [this commit](https://github.com/artsy/emission/pull/1086/commits/4a2a3e9260e97d791536cf38376a06b0ad0946a8) adds a key for the Stripe API.
+
+## Steps
+
+#### 1. Add the key to the /Example app's Podfile.
+
+This is the extent of `cocoapods-keys` official setup, and after this you **could** set the key via `pod keys set <NAME>` or `pod install`... but we have more to do.
+[Example/Podfile](https://github.com/artsy/emission/blob/4a2a3e9260e97d791536cf38376a06b0ad0946a8/Example/Podfile#L63)
+
+```ruby
+plugin 'cocoapods-keys', {
+  :target => 'Emission',
+  :keys => [
+    'ArtsyAPIClientSecret',   # Authing to the Artsy API
+    'ArtsyAPIClientKey',      #
+    'StripePublishableKey',   # A new key!
+  ]
+}
+```
+
+---
+
+#### 2. Expose the keys in the `AREmission` module
+
+We'll need to update the `initWithUserId...` function, expose the new key as a property and add it to `constantsToExport`.
+
+[AREmission.h](https://github.com/artsy/emission/blob/4a2a3e9260e97d791536cf38376a06b0ad0946a8/Pod/Classes/Core/AREmission.h#L17-L34):
+
+```objc
+// ENV Variables
+@property (nonatomic, copy, readonly, nullable) NSString *stripePublishableKey; # Add this line
+
+# ...
+
+- (instancetype)initWithUserID:(NSString *)userID
+           authenticationToken:(NSString *)token
+                     sentryDSN:(nullable NSString *)sentryDSN
+          stripePublishableKey:(NSString *)stripePublishableKey # Add this line
+              googleMapsAPIKey:(nullable NSString *)googleAPIKey
+                    gravityURL:(NSString *)gravity
+                metaphysicsURL:(NSString *)metaphysics
+                     userAgent:(NSString *)userAgent;
+```
+
+[AREmission.m](https://github.com/artsy/emission/blob/4a2a3e9260e97d791536cf38376a06b0ad0946a8/Pod/Classes/Core/AREmission.m#L24-L60):
+
+```objc
+- (NSDictionary *)constantsToExport
+{
+  return @{
+    # Add this line...
+    @"stripePublishableKey": self.stripePublishableKey ?: @"",
+    # ...
+  };
+}
+
+- (instancetype)initWithUserID:(NSString *)userID
+           authenticationToken:(NSString *)token
+                     sentryDSN:(NSString *)sentryDSN
+          stripePublishableKey:(NSString *)stripePublishableKey # Add this line
+              googleMapsAPIKey:(NSString *)googleAPIKey
+                    gravityURL:(NSString *)gravity
+                metaphysicsURL:(NSString *)metaphysics
+                     userAgent:(nonnull NSString *)userAgent
+{
+    self = [super init];
+    _userID = userID.copy;
+    # ... More copies...
+    _stripePublishableKey = stripePublishableKey.copy;
+    # ... Even more copies...
+    return self;
+}
+```
+
+---
+
+#### 3. Consume that key in the /Example app.
+
+[Example/Emission/AppDelegate.m](https://github.com/artsy/emission/blob/4a2a3e9260e97d791536cf38376a06b0ad0946a8/Example/Emission/AppDelegate.m#L109)
+
+```objc
+# Make sure we have imported they keys (this should already be done)
+#import <Keys/EmissionKeys.h>
+
+# Add the key to our initWith...  call, following the signature we defined in the previous step
+- (void)setupEmissionWithUserID:(NSString *)userID accessToken:(NSString *)accessToken keychainService:(NSString *)service;
+{
+  # ...
+  # stripePublishableKey is somewhere down there...
+  AREmissionConfiguration *config = [[AREmissionConfiguration alloc] initWithUserID:userID authenticationToken:accessToken sentryDSN:nil stripePublishableKey:[keys stripePublishableKey] googleMapsAPIKey:nil gravityURL:setup.gravityURL metaphysicsURL:setup.metaphysicsURL userAgent:@"Emission Example"];
+  # ...
+```
+
+---
+
+#### 4. Add any default setup to the Makefile
+
+[Makefile](https://github.com/artsy/emission/blob/4a2a3e9260e97d791536cf38376a06b0ad0946a8/Makefile#L56)
+
+```sh
+oss:
+  @echo "Installing Cocoa Dependencies"
+  cd Example && bundle exec pod keys set ArtsyAPIClientKey "e750db60ac506978fc70"
+  # Hidden keys by convention are set to a single dash
+  cd Example && bundle exec pod keys set StripePublishableKey "-"
+  # ...And so on
+```

--- a/docs/adding_new_keys.md
+++ b/docs/adding_new_keys.md
@@ -70,7 +70,7 @@ We'll need to update the `initWithUserId...` function, expose the new key as a p
     self = [super init];
     _userID = userID.copy;
     # ... More copies...
-    _stripePublishableKey = stripePublishableKey.copy;
+    _stripePublishableKey = stripePublishableKey.copy;   # And this line
     # ... Even more copies...
     return self;
 }
@@ -78,26 +78,46 @@ We'll need to update the `initWithUserId...` function, expose the new key as a p
 
 ---
 
-#### 3. Consume that key in the /Example app.
+#### 3. Configure that exposed key in the /Example app.
+
+Make sure we have imported they keys (this should already be done) and initialize the new configuration with the signature we defined above.
 
 [Example/Emission/AppDelegate.m](https://github.com/artsy/emission/blob/4a2a3e9260e97d791536cf38376a06b0ad0946a8/Example/Emission/AppDelegate.m#L109)
 
 ```objc
-# Make sure we have imported they keys (this should already be done)
 #import <Keys/EmissionKeys.h>
 
 # Add the key to our initWith...  call, following the signature we defined in the previous step
 - (void)setupEmissionWithUserID:(NSString *)userID accessToken:(NSString *)accessToken keychainService:(NSString *)service;
 {
   # ...
+
   # stripePublishableKey is somewhere down there...
+
   AREmissionConfiguration *config = [[AREmissionConfiguration alloc] initWithUserID:userID authenticationToken:accessToken sentryDSN:nil stripePublishableKey:[keys stripePublishableKey] googleMapsAPIKey:nil gravityURL:setup.gravityURL metaphysicsURL:setup.metaphysicsURL userAgent:@"Emission Example"];
   # ...
 ```
 
 ---
 
-#### 4. Add any default setup to the Makefile
+#### 4. Use that configured key in a `react-native` component.
+
+`Emission` is now exposed along with its configured keys via `react-native`'s `NativeModules`.
+
+```tsx
+import { NativeModules } from "react-native"
+const Emission = NativeModules.Emission || {}
+
+// ... other setup ...
+
+stripe.setOptions({
+  publishableKey: Emission.stripePublishableKey,
+})
+```
+
+---
+
+#### 5. Add any default setup to the Makefile
 
 [Makefile](https://github.com/artsy/emission/blob/4a2a3e9260e97d791536cf38376a06b0ad0946a8/Makefile#L56)
 


### PR DESCRIPTION
This PR adds an explanation of the steps to add and expose a key via `cocoapods-keys`.