### PR TITLE
@yuki24 => Update unica font

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -5,7 +5,7 @@ PODS:
     - NSURL+QueryDictionary
   - Artsy+UIColors (3.1.0)
   - Artsy+UIFonts (3.2.0)
-  - Artsy-UIButtons (2.2.1):
+  - Artsy-UIButtons (2.2.2):
     - Artsy+UIColors (~> 3.0)
     - Artsy+UIFonts
     - UIView+BooleanAnimations
@@ -190,7 +190,7 @@ SPEC CHECKSUMS:
   Artsy+Authentication: 3bf11ceca61c52e9e31490535bf5798f625406fa
   Artsy+UIColors: 31c03c4146f5e6618a9b950f37dfe02dd9ac09a6
   Artsy+UIFonts: d29579aa105e3709032651fb3145d24f8339e905
-  Artsy-UIButtons: a945b08aef7589e2ec2068d2d3e90d30b5ed140e
+  Artsy-UIButtons: 42261a51f0437d2fbb8cf5b9da937ac493d38d54
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: ebb6747c5b66026ad4f97b789c3ceac6f18e57a6
   Emission: f76136f6eaab1ba0f7c692b17727dbcceebfa856
@@ -213,6 +213,6 @@ SPEC CHECKSUMS:
   UIView+BooleanAnimations: a760be9a066036e55f298b7b7350a6cb14cfcd97
   yoga: 55da126afc384965b96bff46652464373b330add
 
-PODFILE CHECKSUM: f04b62d4f9308b0734e1da3c5b453122eac5c131
+PODFILE CHECKSUM: 2f34094d440552e47625024325a9da6b92f96b43
 
 COCOAPODS: 1.4.0

--- a/src/lib/Components/Bidding/Components/Timer.tsx
+++ b/src/lib/Components/Bidding/Components/Timer.tsx
@@ -1,7 +1,7 @@
 import moment from "moment-timezone"
 import React from "react"
 import { Flex } from "../Elements/Flex"
-import { Sans12, Sans14 } from "../Elements/Typography"
+import { SansMedium12, SansMedium14 } from "../Elements/Typography"
 
 interface TimerProps {
   liveStartsAt?: string
@@ -44,18 +44,18 @@ export class Timer extends React.Component<TimerProps, TimerState> {
 
     return (
       <Flex alignItems="center">
-        <Sans12>
+        <SansMedium12>
           {liveStartsAt ? "Live " : "Ends "}
           {moment(liveStartsAt || endsAt, moment.ISO_8601)
             .tz(moment.tz.guess(true))
             .format("MMM D, ha")}
-        </Sans12>
-        <Sans14>
+        </SansMedium12>
+        <SansMedium14>
           {this.padWithZero(duration.days())}d{"  "}
           {this.padWithZero(duration.hours())}h{"  "}
           {this.padWithZero(duration.minutes())}m{"  "}
           {this.padWithZero(duration.seconds())}s
-        </Sans14>
+        </SansMedium14>
       </Flex>
     )
   }

--- a/src/lib/Components/Bidding/Components/__tests__/Timer-tests.tsx
+++ b/src/lib/Components/Bidding/Components/__tests__/Timer-tests.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import "react-native"
 import * as renderer from "react-test-renderer"
 
-import { Sans12, Sans14 } from "../../Elements/Typography"
+import { SansMedium12, SansMedium14 } from "../../Elements/Typography"
 import { Timer } from "../Timer"
 
 const SECONDS = 1000
@@ -10,9 +10,9 @@ const MINUTES = 60 * SECONDS
 
 const dateNow = 1525983752000 // Thursday, May 10, 2018 8:22:32.000 PM UTC in milliseconds
 
-const getTimerLabel = timerComponent => timerComponent.root.findByType(Sans12).props.children.join("")
+const getTimerLabel = timerComponent => timerComponent.root.findByType(SansMedium12).props.children.join("")
 
-const getTimerText = timerComponent => timerComponent.root.findByType(Sans14).props.children.join("")
+const getTimerText = timerComponent => timerComponent.root.findByType(SansMedium14).props.children.join("")
 
 beforeEach(() => {
   jest.useFakeTimers()

--- a/src/lib/Components/Bidding/Elements/Typography.tsx
+++ b/src/lib/Components/Bidding/Elements/Typography.tsx
@@ -5,7 +5,7 @@ import { color, fontSize, lineHeight, maxWidth, space, textAlign } from "styled-
 import { Fonts } from "../../../data/fonts"
 
 const Sans = styled.Text`
-  font-family: "${Fonts.Unica77LLMedium}";
+  font-family: "${Fonts.Unica77LLRegular}";
   ${color}
   ${fontSize}
   ${lineHeight}

--- a/src/lib/Components/Bidding/Elements/Typography.tsx
+++ b/src/lib/Components/Bidding/Elements/Typography.tsx
@@ -14,6 +14,16 @@ const Sans = styled.Text`
   ${maxWidth}
 `
 
+const SansMedium = styled.Text`
+  font-family: "${Fonts.Unica77LLMedium}";
+  ${color}
+  ${fontSize}
+  ${lineHeight}
+  ${space}
+  ${textAlign}
+  ${maxWidth}
+`
+
 const Serif = styled.Text`
   font-family: "${Fonts.GaramondRegular}";
   ${color}
@@ -48,6 +58,11 @@ export const Sans12 = props => <Sans fontSize={1} lineHeight={1} {...props} />
 export const Sans14 = props => <Sans fontSize={2} lineHeight={5} {...props} />
 export const Sans16 = props => <Sans fontSize={3} lineHeight={6} {...props} />
 export const Sans18 = props => <Sans fontSize={4} lineHeight={8} {...props} />
+
+export const SansMedium12 = props => <SansMedium fontSize={1} lineHeight={1} {...props} />
+export const SansMedium14 = props => <SansMedium fontSize={2} lineHeight={5} {...props} />
+export const SansMedium16 = props => <SansMedium fontSize={3} lineHeight={6} {...props} />
+export const SansMedium18 = props => <SansMedium fontSize={4} lineHeight={8} {...props} />
 
 export const Serif12 = props => <Serif fontSize={1} lineHeight={1} {...props} />
 export const Serif14 = props => <Serif fontSize={2} lineHeight={2} {...props} />

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmBid-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmBid-tests.tsx.snap
@@ -360,7 +360,7 @@ exports[`renders properly 1`] = `
             Array [
               Object {
                 "color": "#6E1EFF",
-                "fontFamily": "Unica77LL-Medium",
+                "fontFamily": "Unica77LL-Regular",
                 "fontSize": 12,
                 "lineHeight": 16,
                 "marginBottom": 5,


### PR DESCRIPTION
Turns out we do need to have the Unica Medium font as well as the Regular weight one. 

This PR adds `SansMedium` as a new font which uses Unica medium, and updates the existing `Sans` font to point to the regular-weight Unica font. It looks like the only place we need the medium-weight Unica font right now is on the auction timer, so I updated that accordingly.

Addresses: https://artsyproduct.atlassian.net/browse/PURCHASE-184

This screen shows both:
![image](https://user-images.githubusercontent.com/2081340/41444164-436e9d38-700f-11e8-828e-5a5e5273e7f6.png)
