### PR TITLE
Reduces the default TTL for GraphQL queries in Emission

### DIFF
--- a/Pod/Classes/GraphQL/ARGraphQLQueryCache.m
+++ b/Pod/Classes/GraphQL/ARGraphQLQueryCache.m
@@ -8,7 +8,7 @@
 #define DLog(...) /* */
 #endif
 
-const NSTimeInterval ARGraphQLQueryCacheDefaultTTL = 86400;
+const NSTimeInterval ARGraphQLQueryCacheDefaultTTL = 3600;
 
 typedef NSMutableArray<NSDictionary *> PromiseQueue;
 


### PR DESCRIPTION
Down from a day to an hour.

#native_no_changes