### PR TITLE
Remove "Understanding Relay" Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,6 @@ There is a comprehensive document covering [the various options](docs/debugging.
    * The GraphQL schema of metaphysics that Relay uses to generate queries from: `$ yarn run sync-schema`
    * The colors defined in Artsy’s style-guide: `$ yarn run sync-colors`
 
-### Understanding Relay
-
-We have some debugging tips [when using Relay](docs/relay.md).
-
 ---
 
 Try quitting and restarting your node instance if you change something Relay-related and you run into this error:


### PR DESCRIPTION
The Relay.MD file was removed by @orta here : https://github.com/artsy/emission/commit/6f0be7b23b88353893638c5236aad1829c78269c#diff-e3e2a9bfd88566b05001b02a3f51d286