### PR TITLE
Fresh install feedback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,23 @@
 BREW := $(shell command -v brew 2> /dev/null)
+NVM := $(shell command -v nvm 2> /dev/null)
 YARN := $(shell command -v yarn 2> /dev/null)
 WATCHMAN := $(shell command -v watchman 2> /dev/null)
 CODE := $(shell command -v code 2> /dev/null)
 
 setup:
 ifndef BREW
-    $(error "Please install homebrew before running `make oss`: https://brew.sh")
+	$(error "Please install homebrew before running `make oss`: https://brew.sh")
+endif
+
+ifndef NVM
+	@echo "Installing NVM"
+	curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
+	nvm install 8.4
 endif
 
 ifndef YARN
 	@echo "Installing Yarn"
-	brew install yarn
+	npm install -g yarn
 endif
 
 ifndef WATCHMAN
@@ -28,10 +35,6 @@ endif
 	@echo "Installing Node Dependencies"
 	yarn install
 
-	@echo "Installing Hooks for Styling and Compile-checks"
-	echo "#!/bin/sh\nexport PATH=\$$PATH:/usr/local/bin\nyarn run lint-staged\n" > .git/hooks/pre-commit; chmod +x .git/hooks/pre-commit
-	echo "#!/bin/sh\nexport PATH=\$$PATH:/usr/local/bin\nyarn run type-check\n" > .git/hooks/pre-push; chmod +x .git/hooks/pre-push
-
 	@echo "";
 	@echo "";
 	@echo "That is all of the dependencies for Emission set up, to run the app:";
@@ -44,7 +47,6 @@ endif
 	@echo "Any other details can be found in the README."
 	@echo "Enjoy!"
 	@echo ""
-
 
 artsy:
 	cd Example && bundle && bundle exec pod install

--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,8 @@ endif
 	yarn install
 
 	@echo "Installing Hooks for Styling and Compile-checks"
-	echo "#!/bin/sh\nyarn run lint-staged\n" > .git/hooks/pre-commit; chmod +x .git/hooks/pre-commit
-	echo "#!/bin/sh\nyarn run type-check\n" > .git/hooks/pre-push; chmod +x .git/hooks/pre-push
+	echo "#!/bin/sh\nexport PATH=\$$PATH:/usr/local/bin\nyarn run lint-staged\n" > .git/hooks/pre-commit; chmod +x .git/hooks/pre-commit
+	echo "#!/bin/sh\nexport PATH=\$$PATH:/usr/local/bin\nyarn run type-check\n" > .git/hooks/pre-push; chmod +x .git/hooks/pre-push
 
 	@echo "";
 	@echo "";

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Inside Emission you will find:
 ### Meta
 
 * **State:** production
-* **Point People:** [@sarahscott](https://github.com/sarahscott), [@alloy](https://github.com/alloy)
+* **Point People:** [@alloy](https://github.com/alloy)
 * **CI:** [![Build Status](https://travis-ci.org/artsy/emission.svg?branch=master)](https://travis-ci.org/artsy/emission)
 
 This is a core [Artsy Mobile](https://github.com/artsy/mobile) OSS project, along with [Energy](https://github.com/artsy/energy), [Eidolon](https://github.com/artsy/eidolon), [Eigen](https://github.com/artsy/eigen) and [Emergence](https://github.com/artsy/emergence).
@@ -38,7 +38,7 @@ _Manual install_
 1. Install NPM modules: `$ yarn install`
 1. Install Pods: `$ cd Example && bundle && bundle exec pod install`
 
-### Running the project:
+   ### Running the project:
 
 1. Run `$ yarn start` from the top directory, which will:
 
@@ -46,7 +46,7 @@ _Manual install_
    * Start the example app’s React Native packager.
    * Start the React Storybooks environment.
 
-2. Now from Xcode you can run the app in `Example/Emission.xcworkspace`.
+1. Now from Xcode you can run the app in `Example/Emission.xcworkspace`.
 
 * If you already have the app installed, you can run `open -a Simulator` to open the last sim, and then `xcrun simctl launch booted net.artsy.Emission` to open the app.
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "native-code-version": 3,
   "description": "Artsy React(Native) components.",
   "engines": {
-    "node": "10.4.x",
+    "node": "8.4.x",
     "npm": "6.1.x",
     "yarn": "1.x"
   },
@@ -115,6 +115,7 @@
     "danger-plugin-jest": "^1.1.0",
     "enzyme": "^3.1.0",
     "enzyme-adapter-react-16": "^1.0.2",
+    "husky": "^0.14.3",
     "jest": "^22.4.2",
     "jest-styled-components": "^4.10.0",
     "lint-staged": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "native-code-version": 3,
   "description": "Artsy React(Native) components.",
   "engines": {
-    "node": "8.4.x",
-    "npm": "5.4.x",
+    "node": "10.4.x",
+    "npm": "6.1.x",
     "yarn": "1.x"
   },
   "main": "index.ios.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5144,6 +5144,14 @@ https-proxy-agent@^2.2.0:
     agent-base "^4.1.0"
     debug "^3.1.0"
 
+husky@^0.14.3:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-0.14.3.tgz#c69ed74e2d2779769a17ba8399b54ce0b63c12c3"
+  dependencies:
+    is-ci "^1.0.10"
+    normalize-path "^1.0.0"
+    strip-indent "^2.0.0"
+
 hyperlinker@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/hyperlinker/-/hyperlinker-1.0.0.tgz#23dc9e38a206b208ee49bc2d6c8ef47027df0c0e"
@@ -7441,6 +7449,10 @@ normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
     is-builtin-module "^1.0.0"
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
+
+normalize-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-1.0.0.tgz#32d0e472f91ff345701c15a8311018d3b0a90379"
 
 normalize-path@^2.0.0, normalize-path@^2.0.1:
   version "2.1.1"


### PR DESCRIPTION
Hi,
when running "make setup && make oss" it installs node 10.4.1 and npm 6.1.0, but package.json specifies 8.4.x and 5.4.x, and thus the install breaks.

I updated package.json to point to 10.4.x and 6.1.x, and that seems fine. Added to PR.

Yarn is installed in /usr/local/bin, the pre-commit and pre-push hooks assumes this is in path. When using Tower it was not. Adding "export PATH=$PATH:/usr/local/bin" into the hooks remedied this. Added to PR.

Another thing, compared to the manual install, these automatic steps didn't build Cocoapods. Not sure they should, but thought I'd mention it.

Not sure as to why I had to enter my GitHub credentials during the "bundle exec pod install" step, was that intended?

Cheers

   Niklas