### PR TITLE
Consoldiate types #trivial

### DIFF
--- a/src/lib/Components/Bidding/Components/MaxBidPicker.tsx
+++ b/src/lib/Components/Bidding/Components/MaxBidPicker.tsx
@@ -2,20 +2,17 @@ import React from "react"
 import { Picker, PickerProperties } from "react-native"
 import styled from "styled-components/native"
 
-interface Bid {
-  label: string
-  value: number
-}
+import { Bid } from "../types"
 
 export interface MaxBidPickerProps extends PickerProperties {
-  bids: Bid[]
+  bids: ReadonlyArray<Bid>
 }
 
 export class MaxBidPicker extends React.Component<MaxBidPickerProps> {
   render() {
     return (
       <StyledPicker {...this.props} onValueChange={this.props.onValueChange} selectedValue={this.props.selectedValue}>
-        {this.props.bids.map((bid, index) => <Picker.Item key={index} value={index} label={bid.label} />)}
+        {this.props.bids.map((bid, index) => <Picker.Item key={index} value={index} label={bid.display} />)}
       </StyledPicker>
     )
   }

--- a/src/lib/Components/Bidding/Components/__tests__/MaxBidPicker-tests.tsx
+++ b/src/lib/Components/Bidding/Components/__tests__/MaxBidPicker-tests.tsx
@@ -6,12 +6,12 @@ import { MaxBidPicker } from "../MaxBidPicker"
 
 const Bids = [
   {
-    label: "$35,000 USD",
-    value: 3500000,
+    display: "$35,000 USD",
+    cents: 3500000,
   },
   {
-    label: "$40,000 USD",
-    value: 4000000,
+    display: "$40,000 USD",
+    cents: 4000000,
   },
 ]
 

--- a/src/lib/Components/Bidding/Screens/BidResult.tsx
+++ b/src/lib/Components/Bidding/Screens/BidResult.tsx
@@ -13,34 +13,11 @@ import { Container } from "../Components/Containers"
 import { Markdown } from "../Components/Markdown"
 import { Timer } from "../Components/Timer"
 import { Title } from "../Components/Title"
+import { BidderPositionResult } from "../types"
 
 import { BidResult_sale_artwork } from "__generated__/BidResult_sale_artwork.graphql"
 
 const SHOW_TIMER_STATUSES = ["WINNING", "OUTBID", "RESERVE_NOT_MET"]
-
-export interface BidderPositionResult {
-  status:  // bidder position status
-    | "OUTBID"
-    | "PENDING"
-    | "RESERVE_NOT_MET"
-    | "WINNING"
-    // mutation status
-    | "SALE_CLOSED"
-    | "LIVE_BIDDING_STARTED"
-    | "BIDDER_NOT_QUALIFIED"
-    // general error status for e.g. Gravity not available, no internet in the device
-    | "ERROR"
-
-  message_header: string
-  message_description_md: string
-  position: {
-    id: string
-    suggested_next_bid: {
-      cents: string
-      display: string
-    }
-  }
-}
 
 interface BidResultProps {
   sale_artwork: BidResult_sale_artwork

--- a/src/lib/Components/Bidding/Screens/BillingAddress.tsx
+++ b/src/lib/Components/Bidding/Screens/BillingAddress.tsx
@@ -14,8 +14,7 @@ import { Button } from "../Components/Button"
 import { Container } from "../Components/Containers"
 import { Input } from "../Components/Input"
 import { Title } from "../Components/Title"
-
-import { Address } from "./ConfirmFirstTimeBid"
+import { Address } from "../types"
 
 interface BillingAddressProps {
   onSubmit?: (values: Address) => void

--- a/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
@@ -16,18 +16,14 @@ import { Container } from "../Components/Containers"
 import { Divider } from "../Components/Divider"
 import { Timer } from "../Components/Timer"
 import { Title } from "../Components/Title"
+import { Bid, BidderPositionResult } from "../types"
 
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { metaphysics } from "../../../metaphysics"
 
-import { BidderPositionResult, BidResultScreen } from "./BidResult"
+import { BidResultScreen } from "./BidResult"
 
 import { ConfirmBid_sale_artwork } from "__generated__/ConfirmBid_sale_artwork.graphql"
-
-export interface Bid {
-  display: string
-  cents: number
-}
 
 export interface ConfirmBidProps extends ViewProperties {
   sale_artwork: ConfirmBid_sale_artwork

--- a/src/lib/Components/Bidding/Screens/ConfirmFirstTimeBid.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmFirstTimeBid.tsx
@@ -18,8 +18,9 @@ import { Container } from "../Components/Containers"
 import { Divider } from "../Components/Divider"
 import { Timer } from "../Components/Timer"
 import { Title } from "../Components/Title"
+import { Address, BidderPositionResult, PaymentCardTextFieldParams, StripeToken } from "../types"
 
-import { BidderPositionResult, BidResultScreen } from "./BidResult"
+import { BidResultScreen } from "./BidResult"
 import { BillingAddress } from "./BillingAddress"
 import { bidderPositionMutation, ConfirmBidProps, queryForBidPosition } from "./ConfirmBid"
 import { CreditCardForm } from "./CreditCardForm"
@@ -27,38 +28,6 @@ import { CreditCardForm } from "./CreditCardForm"
 const Emission = NativeModules.Emission || {}
 
 stripe.setOptions({ publishableKey: Emission.stripePublishableKey })
-
-// values from the Tipsi PaymentCardTextField component
-export interface PaymentCardTextFieldParams {
-  number: string
-  expMonth: string
-  expYear: string
-  cvc: string
-  name?: string
-  addressLine1?: string
-  addressLine2?: string
-  addressCity?: string
-  addressState?: string
-  addressZip?: string
-}
-
-export interface Address {
-  fullName: string
-  addressLine1: string
-  addressLine2?: string
-  city: string
-  state: string
-  postalCode: string
-}
-
-interface StripeToken {
-  tokenId: string
-  created: number
-  livemode: 1 | 0
-  card: any
-  bankAccount: any
-  extra: any
-}
 
 interface ConfirmBidState {
   billingAddress?: Address

--- a/src/lib/Components/Bidding/Screens/CreditCardForm.tsx
+++ b/src/lib/Components/Bidding/Screens/CreditCardForm.tsx
@@ -8,7 +8,7 @@ import { Button } from "../Components/Button"
 import { Title } from "../Components/Title"
 import { Flex } from "../Elements/Flex"
 import { theme } from "../Elements/Theme"
-import { PaymentCardTextFieldParams } from "./ConfirmFirstTimeBid"
+import { PaymentCardTextFieldParams } from "../types"
 
 interface CreditCardFormProps {
   navigator?: NavigatorIOS

--- a/src/lib/Components/Bidding/Screens/Registration.tsx
+++ b/src/lib/Components/Bidding/Screens/Registration.tsx
@@ -17,6 +17,7 @@ import { Container } from "../Components/Containers"
 import { Divider } from "../Components/Divider"
 import { Timer } from "../Components/Timer"
 import { Title } from "../Components/Title"
+import { Address, PaymentCardTextFieldParams, StripeToken } from "../types"
 
 import { BillingAddress } from "./BillingAddress"
 import { CreditCardForm } from "./CreditCardForm"
@@ -26,38 +27,6 @@ import { Registration_sale } from "__generated__/Registration_sale.graphql"
 const Emission = NativeModules.Emission || {}
 
 stripe.setOptions({ publishableKey: Emission.stripePublishableKey })
-
-// values from the Tipsi PaymentCardTextField component
-export interface PaymentCardTextFieldParams {
-  number: string
-  expMonth: string
-  expYear: string
-  cvc: string
-  name?: string
-  addressLine1?: string
-  addressLine2?: string
-  addressCity?: string
-  addressState?: string
-  addressZip?: string
-}
-
-export interface Address {
-  fullName: string
-  addressLine1: string
-  addressLine2?: string
-  city: string
-  state: string
-  postalCode: string
-}
-
-interface StripeToken {
-  tokenId: string
-  created: number
-  livemode: 1 | 0
-  card: any
-  bankAccount: any
-  extra: any
-}
 
 export interface RegistrationProps extends ViewProperties {
   sale: Registration_sale

--- a/src/lib/Components/Bidding/Screens/SelectMaxBid.tsx
+++ b/src/lib/Components/Bidding/Screens/SelectMaxBid.tsx
@@ -65,11 +65,7 @@ export class SelectMaxBid extends React.Component<SelectMaxBidProps, SelectMaxBi
   }
 
   render() {
-    const bids =
-      (this.props.sale_artwork &&
-        this.props.sale_artwork.increments &&
-        this.props.sale_artwork.increments.map(i => ({ label: i.display, value: i.cents }))) ||
-      []
+    const bids = (this.props.sale_artwork && this.props.sale_artwork.increments) || []
 
     return (
       <BiddingThemeProvider>

--- a/src/lib/Components/Bidding/Screens/__stories__/BidResult.story.tsx
+++ b/src/lib/Components/Bidding/Screens/__stories__/BidResult.story.tsx
@@ -1,7 +1,8 @@
 import { storiesOf } from "@storybook/react-native"
 import React from "react"
 
-import { BidderPositionResult, BidResult } from "../BidResult"
+import { BidderPositionResult } from "../../types"
+import { BidResult } from "../BidResult"
 
 storiesOf("Bidding")
   .add("Bid Result (winning)", () => {

--- a/src/lib/Components/Bidding/Screens/__tests__/BidResult-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/BidResult-tests.tsx
@@ -10,7 +10,8 @@ import SwitchBoard from "lib/NativeModules/SwitchBoard"
 
 import * as renderer from "react-test-renderer"
 import { BidGhostButton, Button } from "../../Components/Button"
-import { BidderPositionResult, BidResult } from "../BidResult"
+import { BidderPositionResult } from "../../types"
+import { BidResult } from "../BidResult"
 
 const popToTop = jest.fn()
 const mockNavigator = { popToTop }

--- a/src/lib/Components/Bidding/types.d.ts
+++ b/src/lib/Components/Bidding/types.d.ts
@@ -1,0 +1,77 @@
+export interface Address {
+  fullName: string
+  addressLine1: string
+  addressLine2?: string
+  city: string
+  state: string
+  postalCode: string
+}
+
+export interface Bid {
+  display: string
+  cents: number
+}
+
+export interface BidderPositionResult {
+  /*
+   * Represents the status of a bidder position. The logic that determines the status is as follows:
+   *
+   *   bidder position created?
+   *     - yes
+   *       - bidder position processed?
+   *         - yes
+   *           --> OUTBID | RESERVE_NOT_MET | WINNING
+   *         - no
+   *           --> PENDING
+   *     - no
+   *       - do we know why?
+   *         - yes
+   *           --> SALE_CLOSED | LIVE_BIDDING_STARTED | BIDDER_NOT_QUALIFIED
+   *         - no
+   *           --> ERROR
+   **/
+  status:  // bidder position status
+    | "OUTBID"
+    | "PENDING"
+    | "RESERVE_NOT_MET"
+    | "WINNING"
+    // mutation status
+    | "SALE_CLOSED"
+    | "LIVE_BIDDING_STARTED"
+    | "BIDDER_NOT_QUALIFIED"
+    // general error status for e.g. Gravity not available, no internet in the device
+    | "ERROR"
+
+  message_header: string
+  message_description_md: string
+  position: {
+    id: string
+    suggested_next_bid: {
+      cents: string
+      display: string
+    }
+  }
+}
+
+// values from the Tipsi PaymentCardTextField component
+export interface PaymentCardTextFieldParams {
+  number: string
+  expMonth: string
+  expYear: string
+  cvc: string
+  name?: string
+  addressLine1?: string
+  addressLine2?: string
+  addressCity?: string
+  addressState?: string
+  addressZip?: string
+}
+
+interface StripeToken {
+  tokenId: string
+  created: number
+  livemode: 1 | 0
+  card: any
+  bankAccount: any
+  extra: any
+}


### PR DESCRIPTION
We've been adding many many types since we started working on the bidding flow. Now it's time to consolidate and organize types all in `src/lib/Components/Bidding/types.d.ts`.

Let me know if there's any feedback!

#skip_new_tests 