### PR TITLE
Adds support for preview sales to the auction timer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Adds the ability for first-time users to register and place bid simultaneously - yuki24
 * Updates definition of Unica font default weight - sweir27
 * Adds registration screen - sweir27
+* Adds support for startAt in the auction timer - sweir27
 
 ### 1.5.3
 

--- a/src/__generated__/Registration_sale.graphql.ts
+++ b/src/__generated__/Registration_sale.graphql.ts
@@ -4,6 +4,7 @@ import { ConcreteFragment } from "relay-runtime";
 export type Registration_sale = {
     readonly id: string;
     readonly end_at: string | null;
+    readonly is_preview: boolean | null;
     readonly live_start_at: string | null;
     readonly name: string | null;
     readonly start_at: string | null;
@@ -29,6 +30,13 @@ const node: ConcreteFragment = {
       "kind": "ScalarField",
       "alias": null,
       "name": "end_at",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "is_preview",
       "args": null,
       "storageKey": null
     },
@@ -62,5 +70,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = 'db1333661a54cbda65e02632bb203c84';
+(node as any).hash = '18cecaddf8fc0acc4e528ede1b2c5c69';
 export default node;

--- a/src/lib/Components/Bidding/Components/Timer.tsx
+++ b/src/lib/Components/Bidding/Components/Timer.tsx
@@ -27,14 +27,20 @@ export class Timer extends React.Component<TimerProps, TimerState> {
     let upcomingLabel
 
     if (isPreview) {
+      if (!startsAt) {
+        console.error("startsAt is required when isPreview is true")
+      }
+
       relevantDate = startsAt
       upcomingLabel = `Starts ${this.formatDate(startsAt)}`
     } else if (liveStartsAt) {
       relevantDate = liveStartsAt
       upcomingLabel = `Live ${this.formatDate(liveStartsAt)}`
-    } else {
+    } else if (endsAt) {
       relevantDate = endsAt
       upcomingLabel = `Ends ${this.formatDate(endsAt)}`
+    } else {
+      console.error("liveStartsAt or endsAt is required when isPreview is false")
     }
 
     this.state = { timeLeftInMilliseconds: Date.parse(relevantDate) - Date.now(), upcomingLabel }

--- a/src/lib/Components/Bidding/Components/Timer.tsx
+++ b/src/lib/Components/Bidding/Components/Timer.tsx
@@ -6,10 +6,13 @@ import { SansMedium12, SansMedium14 } from "../Elements/Typography"
 interface TimerProps {
   liveStartsAt?: string
   endsAt?: string
+  isPreview?: boolean
+  startsAt?: string
 }
 
 interface TimerState {
   timeLeftInMilliseconds: number
+  upcomingLabel: string
 }
 
 export class Timer extends React.Component<TimerProps, TimerState> {
@@ -18,10 +21,23 @@ export class Timer extends React.Component<TimerProps, TimerState> {
   constructor(props) {
     super(props)
 
-    const { liveStartsAt, endsAt } = props
-    const timeLeftInMilliseconds = Date.parse(liveStartsAt || endsAt) - Date.now()
+    const { liveStartsAt, endsAt, isPreview, startsAt } = props
 
-    this.state = { timeLeftInMilliseconds }
+    let relevantDate
+    let upcomingLabel
+
+    if (isPreview) {
+      relevantDate = startsAt
+      upcomingLabel = `Starts ${this.formatDate(startsAt)}`
+    } else if (liveStartsAt) {
+      relevantDate = liveStartsAt
+      upcomingLabel = `Live ${this.formatDate(liveStartsAt)}`
+    } else {
+      relevantDate = endsAt
+      upcomingLabel = `Ends ${this.formatDate(endsAt)}`
+    }
+
+    this.state = { timeLeftInMilliseconds: Date.parse(relevantDate) - Date.now(), upcomingLabel }
   }
 
   componentDidMount() {
@@ -33,23 +49,21 @@ export class Timer extends React.Component<TimerProps, TimerState> {
   }
 
   timer = () => {
-    this.setState({
-      timeLeftInMilliseconds: this.state.timeLeftInMilliseconds - 1000,
-    })
+    this.setState({ timeLeftInMilliseconds: this.state.timeLeftInMilliseconds - 1000 })
+  }
+
+  formatDate(date: string) {
+    return moment(date, moment.ISO_8601)
+      .tz(moment.tz.guess(true))
+      .format("MMM D, ha")
   }
 
   render() {
-    const { liveStartsAt, endsAt } = this.props
     const duration = moment.duration(this.state.timeLeftInMilliseconds)
 
     return (
       <Flex alignItems="center">
-        <SansMedium12>
-          {liveStartsAt ? "Live " : "Ends "}
-          {moment(liveStartsAt || endsAt, moment.ISO_8601)
-            .tz(moment.tz.guess(true))
-            .format("MMM D, ha")}
-        </SansMedium12>
+        <SansMedium12>{this.state.upcomingLabel}</SansMedium12>
         <SansMedium14>
           {this.padWithZero(duration.days())}d{"  "}
           {this.padWithZero(duration.hours())}h{"  "}

--- a/src/lib/Components/Bidding/Components/__stories__/Timer.story.tsx
+++ b/src/lib/Components/Bidding/Components/__stories__/Timer.story.tsx
@@ -1,0 +1,19 @@
+import { storiesOf } from "@storybook/react-native"
+import React from "react"
+
+import { Flex } from "../../Elements/Flex"
+import { BiddingThemeProvider } from "../BiddingThemeProvider"
+import { Divider } from "../Divider"
+import { Timer } from "../Timer"
+
+storiesOf("Bidding").add("Auction Timer", () => (
+  <BiddingThemeProvider>
+    <Flex mt={7} ml={4} mr={4}>
+      <Timer endsAt="2018-05-10T20:22:42+00:00" />
+      <Divider mt={5} mb={5} />
+      <Timer liveStartsAt="2018-05-10T20:22:42+00:00" />
+      <Divider mt={5} mb={5} />
+      <Timer isPreview={true} startsAt="2018-05-10T20:22:42+00:00" />
+    </Flex>
+  </BiddingThemeProvider>
+))

--- a/src/lib/Components/Bidding/Components/__tests__/Timer-tests.tsx
+++ b/src/lib/Components/Bidding/Components/__tests__/Timer-tests.tsx
@@ -10,7 +10,7 @@ const MINUTES = 60 * SECONDS
 
 const dateNow = 1525983752000 // Thursday, May 10, 2018 8:22:32.000 PM UTC in milliseconds
 
-const getTimerLabel = timerComponent => timerComponent.root.findByType(SansMedium12).props.children.join("")
+const getTimerLabel = timerComponent => timerComponent.root.findByType(SansMedium12).props.children
 
 const getTimerText = timerComponent => timerComponent.root.findByType(SansMedium14).props.children.join("")
 
@@ -56,6 +56,14 @@ it("shows 'Live' when the liveStartsAt prop is given", () => {
   const timer = renderer.create(<Timer liveStartsAt="2018-05-14T20:00:00+00:00" />)
 
   expect(getTimerLabel(timer)).toContain("Live")
+})
+
+it("shows 'Starts' when the startsAt and isPreview props are given", () => {
+  const timer = renderer.create(
+    <Timer startsAt="2018-04-14T20:00:00+00:00" isPreview={true} liveStartsAt="2018-05-14T20:00:00+00:00" />
+  )
+
+  expect(getTimerLabel(timer)).toContain("Starts")
 })
 
 it("counts down to zero", () => {

--- a/src/lib/Components/Bidding/Screens/Registration.tsx
+++ b/src/lib/Components/Bidding/Screens/Registration.tsx
@@ -123,7 +123,7 @@ export class Registration extends React.Component<RegistrationProps, Registratio
   }
 
   render() {
-    const { live_start_at, end_at } = this.props.sale
+    const { live_start_at, end_at, is_preview, start_at } = this.props.sale
     const { billingAddress, creditCardToken: token } = this.state
 
     return (
@@ -131,7 +131,7 @@ export class Registration extends React.Component<RegistrationProps, Registratio
         <Container m={0}>
           <Flex alignItems="center">
             <Title mb={3}>Register to bid</Title>
-            <Timer liveStartsAt={live_start_at} endsAt={end_at} />
+            <Timer liveStartsAt={live_start_at} endsAt={end_at} isPreview={is_preview} startsAt={start_at} />
             <SerifSemibold18 mt={5} mb={5}>
               {this.props.sale.name}
             </SerifSemibold18>
@@ -195,6 +195,7 @@ export const RegistrationScreen = createFragmentContainer(
     fragment Registration_sale on Sale {
       id
       end_at
+      is_preview
       live_start_at
       name
       start_at

--- a/src/lib/Components/Bidding/Screens/__tests__/ConfirmBid-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/ConfirmBid-tests.tsx
@@ -238,6 +238,7 @@ const saleArtwork = {
   },
   sale: {
     id: "best-art-sale-in-town",
+    endsAt: "2018-05-10T20:22:42+00:00",
   },
   lot_label: "538",
 }

--- a/src/lib/Components/Bidding/Screens/__tests__/Registration-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/Registration-tests.tsx
@@ -49,6 +49,7 @@ const sale = {
     end_at: null,
     name: "Phillips New Now",
     start_at: "2018-06-11T01:00:00+00:00",
+    is_preview: true,
   },
 }
 

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmBid-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmBid-tests.tsx.snap
@@ -82,9 +82,7 @@ exports[`renders properly 1`] = `
             undefined,
           ]
         }
-      >
-        Ends Invalid date
-      </Text>
+      />
       <Text
         accessible={true}
         allowFontScaling={true}

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmBid-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmBid-tests.tsx.snap
@@ -83,8 +83,7 @@ exports[`renders properly 1`] = `
           ]
         }
       >
-        Ends 
-        Invalid date
+        Ends Invalid date
       </Text>
       <Text
         accessible={true}

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/Registration-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/Registration-tests.tsx.snap
@@ -82,9 +82,7 @@ exports[`renders properly 1`] = `
             undefined,
           ]
         }
-      >
-        Ends Invalid date
-      </Text>
+      />
       <Text
         accessible={true}
         allowFontScaling={true}

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/Registration-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/Registration-tests.tsx.snap
@@ -83,8 +83,7 @@ exports[`renders properly 1`] = `
           ]
         }
       >
-        Ends 
-        Invalid date
+        Ends Invalid date
       </Text>
       <Text
         accessible={true}

--- a/storybook/storyLoader.js
+++ b/storybook/storyLoader.js
@@ -10,6 +10,7 @@ function loadStories() {
   require('../src/lib/Components/Bidding/Components/__stories__/Checkbox.story.tsx');
   require('../src/lib/Components/Bidding/Components/__stories__/Input.story.tsx');
   require('../src/lib/Components/Bidding/Components/__stories__/Markdown.story.tsx');
+  require('../src/lib/Components/Bidding/Components/__stories__/Timer.story.tsx');
   require('../src/lib/Components/Bidding/Screens/__stories__/BidResult.story.tsx');
   require('../src/lib/Components/Bidding/__stories__/BidFlow.story.tsx');
   require('../src/lib/Components/Buttons/__stories__/Buttons.story.tsx');
@@ -48,6 +49,7 @@ const stories = [
   '../src/lib/Components/Bidding/Components/__stories__/Checkbox.story.tsx',
   '../src/lib/Components/Bidding/Components/__stories__/Input.story.tsx',
   '../src/lib/Components/Bidding/Components/__stories__/Markdown.story.tsx',
+  '../src/lib/Components/Bidding/Components/__stories__/Timer.story.tsx',
   '../src/lib/Components/Bidding/Screens/__stories__/BidResult.story.tsx',
   '../src/lib/Components/Bidding/__stories__/BidFlow.story.tsx',
   '../src/lib/Components/Buttons/__stories__/Buttons.story.tsx',


### PR DESCRIPTION
This PR updates the auction timer component to respect a `start_at` and an `is_preview` flag to be passed in order to show the time until an auction starts (only exercised during the registration flow).

For context, I adapted the logic here: https://github.com/artsy/force/blob/master/src/desktop/components/react/auction_block/utils/upcoming_label.js

Using the `is_preview` flag means we can avoid using system or device time for comparison. But! Brings up the (I think still unanswered?) question of what we should do when the timer _ends_ in any of our cases. On the web right now, we refresh the page to show you the new state. I'm not sure what we want to do here but we can follow up outside of this PR.

![image](https://user-images.githubusercontent.com/2081340/41597661-15e2eba4-739c-11e8-8e03-40c27f7576f6.png)
