### PR TITLE
#trivial Updates to bid flow: require billing address/cc to be present before placing bid; move tokenization to cc form

### DIFF
--- a/src/lib/Components/Bidding/Screens/ConfirmFirstTimeBid.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmFirstTimeBid.tsx
@@ -96,8 +96,12 @@ export class ConfirmFirstTimeBid extends React.Component<ConfirmBidProps, Confir
     })
   }
 
-  onCreditCardAdded = async (params: PaymentCardTextFieldParams) => {
-    const token = await stripe.createTokenWithCard(params)
+  canPlaceBid() {
+    const { billingAddress, creditCardToken, conditionsOfSaleChecked } = this.state
+    return billingAddress && creditCardToken && conditionsOfSaleChecked
+  }
+
+  onCreditCardAdded = async (token: StripeToken, params: PaymentCardTextFieldParams) => {
     this.setState({ creditCardToken: token, creditCardFormParams: params })
   }
 
@@ -264,7 +268,7 @@ export class ConfirmFirstTimeBid extends React.Component<ConfirmBidProps, Confir
                 text="Place Bid"
                 inProgress={this.state.isLoading}
                 selected={this.state.isLoading}
-                onPress={this.state.conditionsOfSaleChecked ? () => this.registerAndPlaceBid() : null}
+                onPress={this.canPlaceBid() ? () => this.registerAndPlaceBid() : null}
               />
             </Flex>
           </View>

--- a/src/lib/Components/Bidding/Screens/CreditCardForm.tsx
+++ b/src/lib/Components/Bidding/Screens/CreditCardForm.tsx
@@ -1,7 +1,7 @@
 import { Fonts } from "lib/data/fonts"
 import React, { Component } from "react"
 import { NavigatorIOS, StyleSheet, View } from "react-native"
-import { PaymentCardTextField } from "tipsi-stripe"
+import stripe, { PaymentCardTextField, StripeToken } from "tipsi-stripe"
 
 import { BiddingThemeProvider } from "../Components/BiddingThemeProvider"
 import { Button } from "../Components/Button"
@@ -12,12 +12,13 @@ import { PaymentCardTextFieldParams } from "../types"
 
 interface CreditCardFormProps {
   navigator?: NavigatorIOS
-  onSubmit: (p: PaymentCardTextFieldParams) => void
+  onSubmit: (t: StripeToken, p: PaymentCardTextFieldParams) => void
 }
 
 interface CreditCardFormState {
   valid: boolean
   params: PaymentCardTextFieldParams
+  isLoading: boolean
 }
 
 const styles = StyleSheet.create({
@@ -41,14 +42,23 @@ export class CreditCardForm extends Component<CreditCardFormProps, CreditCardFor
       expYear: null,
       cvc: null,
     },
+    isLoading: false,
   }
 
   handleFieldParamsChange = (valid, params: PaymentCardTextFieldParams) => {
     this.setState({ valid, params })
   }
 
-  onSubmit() {
-    this.props.onSubmit(this.state.params)
+  tokenizeCardAndSubmit = async () => {
+    this.setState({ isLoading: true })
+
+    const { params } = this.state
+
+    const token = await stripe.createTokenWithCard({
+      ...params,
+    })
+
+    this.props.onSubmit(token, this.state.params)
     this.props.navigator.pop()
   }
 
@@ -62,7 +72,11 @@ export class CreditCardForm extends Component<CreditCardFormProps, CreditCardFor
             <PaymentCardTextField style={styles.field} onParamsChange={this.handleFieldParamsChange} />
           </Flex>
 
-          <Button text="Add credit card" onPress={this.state.valid ? () => this.onSubmit() : null} />
+          <Button
+            text="Add credit card"
+            inProgress={this.state.isLoading}
+            onPress={this.state.valid ? () => this.tokenizeCardAndSubmit() : null}
+          />
         </View>
       </BiddingThemeProvider>
     )

--- a/src/lib/Components/Bidding/Screens/__tests__/ConfirmFirstTimeBid-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/ConfirmFirstTimeBid-tests.tsx
@@ -58,7 +58,7 @@ describe("successful bid", () => {
 
     const component = renderer.create(<ConfirmFirstTimeBid {...initialProps} />)
 
-    // manually setting state to avoid dplicating tests for skipping UI interation, but practically better not to do this.
+    // manually setting state to avoid duplicating tests for skipping UI interation, but practically better not to do this.
     component.root.instance.setState({ billingAddress })
     component.root.instance.setState({ creditCardToken: stripeToken })
     component.root.findByType(Checkbox).instance.props.onPress()

--- a/src/lib/Components/Bidding/Screens/__tests__/CreditCardForm-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/CreditCardForm-tests.tsx
@@ -4,7 +4,12 @@ import * as renderer from "react-test-renderer"
 import { Button } from "../../Components/Button"
 import { CreditCardForm } from "../CreditCardForm"
 
-jest.mock("tipsi-stripe", () => ({ PaymentCardTextField: () => "PaymentCardTextField" }))
+jest.mock("tipsi-stripe", () => ({
+  setOptions: jest.fn(),
+  PaymentCardTextField: () => "PaymentCardTextField",
+  createTokenWithCard: jest.fn(),
+}))
+import stripe from "tipsi-stripe"
 
 const onSubmitMock = jest.fn()
 
@@ -14,12 +19,16 @@ it("renders properly", () => {
 })
 
 it("calls the onSubmit() callback with valid credit card when ADD CREDIT CARD is tapped", () => {
+  stripe.createTokenWithCard.mockReturnValueOnce(stripeToken)
+  jest.useFakeTimers()
   const component = renderer.create(<CreditCardForm onSubmit={onSubmitMock} navigator={{ pop: () => null } as any} />)
 
   component.root.instance.setState({ valid: true, params: creditCard })
   component.root.findByType(Button).instance.props.onPress()
 
-  expect(onSubmitMock).toHaveBeenCalledWith(creditCard)
+  jest.runAllTicks()
+
+  expect(onSubmitMock).toHaveBeenCalledWith(stripeToken, creditCard)
 })
 
 const creditCard = {
@@ -27,4 +36,16 @@ const creditCard = {
   expMonth: "04",
   expYear: "20",
   cvc: "314",
+}
+
+const stripeToken = {
+  tokenId: "fake-token",
+  created: "1528229731",
+  livemode: 0,
+  card: {
+    brand: "VISA",
+    last4: "4242",
+  },
+  bankAccount: null,
+  extra: null,
 }


### PR DESCRIPTION
This PR makes a few small changes (and was born out of my initial exploration into getting us fancy errors after stripe tokenization). I'll document my findings here:

- It _seems_ like most of the errors that would cause tokenization to fail are captured in the built-in form validations on the credit card form (things like an invalid cc number, cvc, or expiration date are already handled for us). 
- I moved the credit card tokenization on the `CreditCardForm` to that component so we get feedback on that screen if something goes wrong, but a follow-up will be to make sure we're catching networking errors and showing something generic on that screen. I'll update the story to be more explicit about this.
- I updated the `ConfirmFirstTimeBid` screen to require `billingAddress`, `creditCardToken`, and `conditionsOfSaleChecked` to be present before allowing one to place a bid.
  - Note that the **button** display isn't yet updated to look "disabled". I know @mennenia is working on consolidating our button usage, so before adding custom states I figured I'd wait for that. I'll make sure to add a follow-up story to capture this requirement.