### PR TITLE
Update auction registration status on bid

### DIFF
--- a/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
@@ -164,6 +164,9 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
       ARAuctionID: this.props.sale_artwork.sale.id,
       ARAuctionArtworkID: this.props.sale_artwork.artwork.id,
     })
+    NativeModules.ARNotificationsManager.postNotificationName("ARAuctionArtworkRegistrationUpdatedNotification", {
+      ARAuctionID: this.props.sale_artwork.sale.id,
+    })
     this.props.navigator.push({
       component: BidResultScreen,
       title: "",

--- a/src/lib/Components/Bidding/Screens/ConfirmFirstTimeBid.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmFirstTimeBid.tsx
@@ -191,6 +191,13 @@ export class ConfirmFirstTimeBid extends React.Component<ConfirmBidProps, Confir
     if (this.props.refreshSaleArtwork) {
       this.props.refreshSaleArtwork()
     }
+    NativeModules.ARNotificationsManager.postNotificationName("ARAuctionArtworkBidUpdated", {
+      ARAuctionID: this.props.sale_artwork.sale.id,
+      ARAuctionArtworkID: this.props.sale_artwork.artwork.id,
+    })
+    NativeModules.ARNotificationsManager.postNotificationName("ARAuctionArtworkRegistrationUpdatedNotification", {
+      ARAuctionID: this.props.sale_artwork.sale.id,
+    })
     this.props.navigator.push({
       component: BidResultScreen,
       title: "",

--- a/src/lib/Components/Bidding/Screens/__tests__/ConfirmBid-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/ConfirmBid-tests.tsx
@@ -19,9 +19,9 @@ import Spinner from "../../../Spinner"
 import objectContaining = jasmine.objectContaining
 
 let nextStep
-const mockPostNotificationName = jest.fn()
 const mockNavigator = { push: route => (nextStep = route) }
 jest.useFakeTimers()
+const mockPostNotificationName = jest.fn()
 
 beforeEach(() => {
   // Because of how we mock metaphysics, the mocked value from one test can bleed into another.
@@ -219,7 +219,13 @@ describe("polling to verify bid position", () => {
       component.root.findByType(Button).instance.props.onPress()
       jest.runAllTicks()
 
-      expect(mockPostNotificationName).toHaveBeenCalledTimes(2)
+      expect(mockPostNotificationName).toHaveBeenCalledWith("ARAuctionArtworkRegistrationUpdatedNotification", {
+        ARAuctionID: "best-art-sale-in-town",
+      })
+      expect(mockPostNotificationName).toHaveBeenCalledWith("ARAuctionArtworkBidUpdated", {
+        ARAuctionID: "best-art-sale-in-town",
+        ARAuctionArtworkID: "meteor shower",
+      })
     })
   })
 


### PR DESCRIPTION
#trivial
This is a very blunt tool right now and might be missing some edge cases. It updates the auction screen's registration status (via NSNotificationCenter) upon receiving any bid result in the ConfirmBid screen.

I'm not sure if i'm missing anything & would like to add more tests- Also considered exporting constants for these Eigen notification names since we'll likely use them in another place on the registration flow, (and LAI bids in the future?) but holding back on that for now.