### PR TITLE
Autocapitalizes words on billing address inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### 1.5.6
 
 * Updates bid status when returning to the [sale] artwork screen- erik
+* Autocapitalizes words on billing address inputs - ash
 
 ### 1.5.5
 

--- a/src/lib/Components/Bidding/Screens/BillingAddress.tsx
+++ b/src/lib/Components/Bidding/Screens/BillingAddress.tsx
@@ -94,17 +94,24 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
               Your billing address
             </Title>
 
-            <StyledInput label="Full name" placeholder="Enter your full name" {...this.propsForInput("fullName")} />
+            <StyledInput
+              label="Full name"
+              placeholder="Enter your full name"
+              autoCapitalize="words"
+              {...this.propsForInput("fullName")}
+            />
 
             <StyledInput
               label="Address line 1"
               placeholder="Enter your street address"
+              autoCapitalize="words"
               {...this.propsForInput("addressLine1")}
             />
 
             <StyledInput
               label="Address line 2 (optional)"
               placeholder="Enter your apt, floor, suite, etc."
+              autoCapitalize="words"
               {...this.propsForInput("addressLine2")}
             />
 
@@ -113,12 +120,14 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
             <StyledInput
               label="State, Province, or Region"
               placeholder="Enter state, province, or region"
+              autoCapitalize="words"
               {...this.propsForInput("state")}
             />
 
             <StyledInput
               label="Postal code"
               placeholder="Enter your postal code"
+              autoCapitalize="words"
               {...this.propsForInput("postalCode")}
             />
 

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/BillingAddress-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/BillingAddress-tests.tsx.snap
@@ -85,6 +85,7 @@ exports[`renders properly 1`] = `
         </Text>
         <TextInput
           allowFontScaling={true}
+          autoCapitalize="words"
           border={1}
           borderColor="black10"
           error={false}
@@ -151,6 +152,7 @@ exports[`renders properly 1`] = `
         </Text>
         <TextInput
           allowFontScaling={true}
+          autoCapitalize="words"
           border={1}
           borderColor="black10"
           error={false}
@@ -217,6 +219,7 @@ exports[`renders properly 1`] = `
         </Text>
         <TextInput
           allowFontScaling={true}
+          autoCapitalize="words"
           border={1}
           borderColor="black10"
           error={false}
@@ -349,6 +352,7 @@ exports[`renders properly 1`] = `
         </Text>
         <TextInput
           allowFontScaling={true}
+          autoCapitalize="words"
           border={1}
           borderColor="black10"
           error={false}
@@ -415,6 +419,7 @@ exports[`renders properly 1`] = `
         </Text>
         <TextInput
           allowFontScaling={true}
+          autoCapitalize="words"
           border={1}
           borderColor="black10"
           error={false}


### PR DESCRIPTION
After pressing spacebar, users will have their shift keys enabled already for them to enter in their info. 

![screen shot 2018-06-21 at 3 24 31 pm](https://user-images.githubusercontent.com/498212/41740831-46630616-7567-11e8-85c8-16a0b8873fc2.png)

Work tracked here: https://artsyproduct.atlassian.net/browse/PURCHASE-223