### PR TITLE
Refactors timer to update on state change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * Updates definition of Unica font default weight - sweir27
 * Adds registration screen - sweir27
 * Adds support for startAt in the auction timer - sweir27
+* Refactors auction timer to support state changes - sweir27
 
 ### 1.5.3
 

--- a/src/lib/Components/Bidding/Components/Timer.tsx
+++ b/src/lib/Components/Bidding/Components/Timer.tsx
@@ -7,12 +7,22 @@ interface TimerProps {
   liveStartsAt?: string
   endsAt?: string
   isPreview?: boolean
+  isClosed?: boolean
   startsAt?: string
 }
 
 interface TimerState {
   timeLeftInMilliseconds: number
-  upcomingLabel: string
+  label: string
+  timerState: AuctionTimerState
+}
+
+export enum AuctionTimerState {
+  PREVIEW = "PREVIEW",
+  LIVE_INTEGRATION_UPCOMING = "LIVE_INTEGRATION_UPCOMING",
+  LIVE_INTEGRATION_ONGOING = "LIVE_INTEGRATION_ONGOING",
+  CLOSING = "CLOSING",
+  CLOSED = "CLOSED",
 }
 
 export class Timer extends React.Component<TimerProps, TimerState> {
@@ -21,29 +31,11 @@ export class Timer extends React.Component<TimerProps, TimerState> {
   constructor(props) {
     super(props)
 
-    const { liveStartsAt, endsAt, isPreview, startsAt } = props
+    const { liveStartsAt, endsAt, isClosed, isPreview, startsAt } = props
+    const timerState = this.currentState(isPreview, isClosed, liveStartsAt)
+    const { relevantDate, label } = this.upcomingLabel(timerState, liveStartsAt, startsAt, endsAt)
 
-    let relevantDate
-    let upcomingLabel
-
-    if (isPreview) {
-      if (!startsAt) {
-        console.error("startsAt is required when isPreview is true")
-      }
-
-      relevantDate = startsAt
-      upcomingLabel = `Starts ${this.formatDate(startsAt)}`
-    } else if (liveStartsAt) {
-      relevantDate = liveStartsAt
-      upcomingLabel = `Live ${this.formatDate(liveStartsAt)}`
-    } else if (endsAt) {
-      relevantDate = endsAt
-      upcomingLabel = `Ends ${this.formatDate(endsAt)}`
-    } else {
-      console.error("liveStartsAt or endsAt is required when isPreview is false")
-    }
-
-    this.state = { timeLeftInMilliseconds: Date.parse(relevantDate) - Date.now(), upcomingLabel }
+    this.state = { timeLeftInMilliseconds: Date.parse(relevantDate) - Date.now(), label, timerState }
   }
 
   componentDidMount() {
@@ -55,7 +47,22 @@ export class Timer extends React.Component<TimerProps, TimerState> {
   }
 
   timer = () => {
-    this.setState({ timeLeftInMilliseconds: this.state.timeLeftInMilliseconds - 1000 })
+    if (this.state.timeLeftInMilliseconds - 1000 > 0) {
+      this.setState({ timeLeftInMilliseconds: this.state.timeLeftInMilliseconds - 1000 })
+    } else {
+      const { liveStartsAt, endsAt, startsAt } = this.props
+      const nextState = this.nextState(this.state.timerState, liveStartsAt)
+      const { relevantDate, label } = this.upcomingLabel(nextState, liveStartsAt, startsAt, endsAt)
+
+      this.setState({ label, timerState: nextState })
+      if (relevantDate) {
+        this.setState({
+          timeLeftInMilliseconds: Date.parse(relevantDate) - Date.now(),
+        })
+      } else {
+        clearInterval(this.intervalId)
+      }
+    }
   }
 
   formatDate(date: string) {
@@ -64,12 +71,79 @@ export class Timer extends React.Component<TimerProps, TimerState> {
       .format("MMM D, ha")
   }
 
+  upcomingLabel(currentState: AuctionTimerState, liveStartsAt: string, startsAt: string, endsAt: string) {
+    switch (currentState) {
+      case AuctionTimerState.PREVIEW: {
+        if (!startsAt) {
+          console.error("startsAt is required when isPreview is true")
+        }
+        return { relevantDate: startsAt, label: `Starts ${this.formatDate(startsAt)}` }
+      }
+      case AuctionTimerState.LIVE_INTEGRATION_UPCOMING: {
+        return { relevantDate: liveStartsAt, label: `Live ${this.formatDate(liveStartsAt)}` }
+      }
+      case AuctionTimerState.LIVE_INTEGRATION_ONGOING: {
+        return { relevantDate: null, label: "In progress" }
+      }
+      case AuctionTimerState.CLOSING: {
+        return { relevantDate: endsAt, label: `Ends ${this.formatDate(endsAt)}` }
+      }
+      default: {
+        return { relevantDate: null, label: "Bidding closed" }
+      }
+    }
+  }
+
+  nextState(currentState: AuctionTimerState, liveStartsAt: string) {
+    switch (currentState) {
+      case AuctionTimerState.PREVIEW: {
+        if (liveStartsAt) {
+          return AuctionTimerState.LIVE_INTEGRATION_UPCOMING
+        } else {
+          return AuctionTimerState.CLOSING
+        }
+      }
+      case AuctionTimerState.CLOSED: {
+        return AuctionTimerState.CLOSED
+      }
+      case AuctionTimerState.LIVE_INTEGRATION_UPCOMING: {
+        return AuctionTimerState.LIVE_INTEGRATION_ONGOING
+      }
+      case AuctionTimerState.LIVE_INTEGRATION_ONGOING: {
+        return AuctionTimerState.LIVE_INTEGRATION_ONGOING
+      }
+      case AuctionTimerState.CLOSING: {
+        return AuctionTimerState.CLOSED
+      }
+      default: {
+        return AuctionTimerState.CLOSED
+      }
+    }
+  }
+
+  currentState(isPreview: boolean, isClosed: boolean, liveStartsAt: string) {
+    if (isPreview) {
+      return AuctionTimerState.PREVIEW
+    } else if (isClosed) {
+      return AuctionTimerState.CLOSED
+    } else if (liveStartsAt) {
+      const isLiveOpen = moment().isAfter(liveStartsAt)
+      if (isLiveOpen) {
+        return AuctionTimerState.LIVE_INTEGRATION_ONGOING
+      } else {
+        return AuctionTimerState.LIVE_INTEGRATION_UPCOMING
+      }
+    } else {
+      return AuctionTimerState.CLOSING
+    }
+  }
+
   render() {
     const duration = moment.duration(this.state.timeLeftInMilliseconds)
 
     return (
       <Flex alignItems="center">
-        <SansMedium12>{this.state.upcomingLabel}</SansMedium12>
+        <SansMedium12>{this.state.label}</SansMedium12>
         <SansMedium14>
           {this.padWithZero(duration.days())}d{"  "}
           {this.padWithZero(duration.hours())}h{"  "}

--- a/src/lib/Components/Bidding/Components/__stories__/Timer.story.tsx
+++ b/src/lib/Components/Bidding/Components/__stories__/Timer.story.tsx
@@ -6,14 +6,26 @@ import { BiddingThemeProvider } from "../BiddingThemeProvider"
 import { Divider } from "../Divider"
 import { Timer } from "../Timer"
 
+import moment from "moment"
+
+const fewSecondsFromNow = moment()
+  .add(3, "seconds")
+  .toISOString()
+
+const fewMoreSecondsFromNow = moment()
+  .add(8, "seconds")
+  .toISOString()
+
 storiesOf("Bidding").add("Auction Timer", () => (
   <BiddingThemeProvider>
     <Flex mt={7} ml={4} mr={4}>
-      <Timer endsAt="2018-05-10T20:22:42+00:00" />
+      <Timer endsAt={fewSecondsFromNow} />
       <Divider mt={5} mb={5} />
-      <Timer liveStartsAt="2018-05-10T20:22:42+00:00" />
+      <Timer isPreview={false} isClosed={false} liveStartsAt={fewSecondsFromNow} />
       <Divider mt={5} mb={5} />
-      <Timer isPreview={true} startsAt="2018-05-10T20:22:42+00:00" />
+      <Timer isPreview={true} startsAt={fewSecondsFromNow} endsAt={fewMoreSecondsFromNow} />
+      <Divider mt={5} mb={5} />
+      <Timer isPreview={true} startsAt={fewSecondsFromNow} liveStartsAt={fewMoreSecondsFromNow} />
     </Flex>
   </BiddingThemeProvider>
 ))

--- a/src/lib/Components/Bidding/Components/__tests__/Timer-tests.tsx
+++ b/src/lib/Components/Bidding/Components/__tests__/Timer-tests.tsx
@@ -24,11 +24,11 @@ beforeEach(() => {
   // Thursday, May 10, 2018 8:22:32.000 PM UTC
   Date.now = () => dateNow
   futureTime = moment(dateNow)
-    .add(1, "hour")
+    .add(1, "second")
     .toISOString()
 
   pastTime = moment(dateNow)
-    .subtract(1, "hour")
+    .subtract(1, "second")
     .toISOString()
 })
 
@@ -132,33 +132,33 @@ describe("timer transitions", () => {
     const timer = renderer.create(<Timer isPreview={true} startsAt={futureTime} endsAt={futureTime} />)
 
     expect(getTimerLabel(timer)).toContain("Starts")
-    expect(getTimerText(timer)).toEqual("00d  01h  00m  00s")
+    expect(getTimerText(timer)).toEqual("00d  00h  00m  01s")
 
-    jest.advanceTimersByTime(60 * MINUTES)
+    jest.advanceTimersByTime(1 * SECONDS)
 
     expect(getTimerLabel(timer)).toContain("Ends")
-    expect(getTimerText(timer)).toEqual("00d  01h  00m  00s")
+    expect(getTimerText(timer)).toEqual("00d  00h  00m  01s")
   })
 
   it("transitions state from preview --> live upcoming when the timer ends", () => {
     const timer = renderer.create(<Timer isPreview={true} startsAt={futureTime} liveStartsAt={futureTime} />)
 
     expect(getTimerLabel(timer)).toContain("Starts")
-    expect(getTimerText(timer)).toEqual("00d  01h  00m  00s")
+    expect(getTimerText(timer)).toEqual("00d  00h  00m  01s")
 
-    jest.advanceTimersByTime(60 * MINUTES)
+    jest.advanceTimersByTime(1 * SECONDS)
 
     expect(getTimerLabel(timer)).toContain("Live")
-    expect(getTimerText(timer)).toEqual("00d  01h  00m  00s")
+    expect(getTimerText(timer)).toEqual("00d  00h  00m  01s")
   })
 
   it("transitions state from live upcoming --> live ongoing when the timer ends", () => {
     const timer = renderer.create(<Timer isPreview={false} startsAt={pastTime} liveStartsAt={futureTime} />)
 
     expect(getTimerLabel(timer)).toContain("Live")
-    expect(getTimerText(timer)).toEqual("00d  01h  00m  00s")
+    expect(getTimerText(timer)).toEqual("00d  00h  00m  01s")
 
-    jest.advanceTimersByTime(60 * MINUTES)
+    jest.advanceTimersByTime(1 * SECONDS)
 
     expect(getTimerLabel(timer)).toContain("In progress")
     expect(getTimerText(timer)).toContain("00d  00h  00m")
@@ -168,9 +168,9 @@ describe("timer transitions", () => {
     const timer = renderer.create(<Timer isPreview={false} startsAt={pastTime} endsAt={futureTime} />)
 
     expect(getTimerLabel(timer)).toContain("Ends")
-    expect(getTimerText(timer)).toEqual("00d  01h  00m  00s")
+    expect(getTimerText(timer)).toEqual("00d  00h  00m  01s")
 
-    jest.advanceTimersByTime(60 * MINUTES)
+    jest.advanceTimersByTime(1 * SECONDS)
 
     expect(getTimerLabel(timer)).toContain("Bidding closed")
     expect(getTimerText(timer)).toContain("00d  00h  00m")

--- a/src/lib/Components/Bidding/Components/__tests__/Timer-tests.tsx
+++ b/src/lib/Components/Bidding/Components/__tests__/Timer-tests.tsx
@@ -103,11 +103,11 @@ describe("timer methods", () => {
   let timer
 
   beforeEach(() => {
-    futureTime = moment()
+    futureTime = moment(dateNow)
       .add(1, "hour")
       .toISOString()
 
-    pastTime = moment()
+    pastTime = moment(dateNow)
       .subtract(1, "hour")
       .toISOString()
 

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmBid-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmBid-tests.tsx.snap
@@ -82,7 +82,9 @@ exports[`renders properly 1`] = `
             undefined,
           ]
         }
-      />
+      >
+        Ends Invalid date
+      </Text>
       <Text
         accessible={true}
         allowFontScaling={true}

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/Registration-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/Registration-tests.tsx.snap
@@ -83,7 +83,9 @@ exports[`renders properly 1`] = `
               undefined,
             ]
           }
-        />
+        >
+          Ends Invalid date
+        </Text>
         <Text
           accessible={true}
           allowFontScaling={true}
@@ -103,13 +105,13 @@ exports[`renders properly 1`] = `
         >
           NaN
           d
-            
+
           NaN
           h
-            
+
           NaN
           m
-            
+
           NaN
           s
         </Text>
@@ -511,7 +513,7 @@ exports[`renders properly 1`] = `
             ]
           }
         >
-          Agree to 
+          Agree to
           <Text
             accessible={true}
             allowFontScaling={true}
@@ -615,4 +617,4 @@ exports[`renders properly 1`] = `
     </View>
   </View>
 </View>
-`;
+`

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/Registration-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/Registration-tests.tsx.snap
@@ -105,13 +105,13 @@ exports[`renders properly 1`] = `
         >
           NaN
           d
-
+            
           NaN
           h
-
+            
           NaN
           m
-
+            
           NaN
           s
         </Text>
@@ -513,7 +513,7 @@ exports[`renders properly 1`] = `
             ]
           }
         >
-          Agree to
+          Agree to 
           <Text
             accessible={true}
             allowFontScaling={true}
@@ -617,4 +617,4 @@ exports[`renders properly 1`] = `
     </View>
   </View>
 </View>
-`
+`;


### PR DESCRIPTION
This PR addresses: https://artsyproduct.atlassian.net/browse/PURCHASE-210

Basically, when the state of an auction changes (or in our case, when the timer runs out), we want to update the label on the timer to reflect the new state.

In order to make this clearer, I extracted `AuctionTimerState` as its own enum and used that to define the `nextState` and `currentState`. The logic looks similar between these two methods but is slightly different so it made sense to keep them separate. But happy for ideas on how to make this make more sense!

![timer](https://user-images.githubusercontent.com/2081340/41790077-65e7c7ca-761f-11e8-8171-a2d2e8812ee3.gif)
