### PR TITLE
Extract payment info into a separate component #trivial

### DIFF
--- a/src/lib/Components/Bidding/Components/PaymentInfo.tsx
+++ b/src/lib/Components/Bidding/Components/PaymentInfo.tsx
@@ -12,19 +12,16 @@ import { Address, PaymentCardTextFieldParams, StripeToken } from "../types"
 
 interface PaymentInfoProps extends FlexProps {
   navigator?: NavigatorIOS
-}
-
-interface PaymentInfoState {
+  onCreditCardAdded: (t: StripeToken, p: PaymentCardTextFieldParams) => void
+  onBillingAddressAdded: (values: Address) => void
   billingAddress?: Address
   creditCardFormParams?: PaymentCardTextFieldParams
   creditCardToken?: StripeToken
 }
 
-export class PaymentInfo extends React.Component<PaymentInfoProps, PaymentInfoState> {
+export class PaymentInfo extends React.Component<PaymentInfoProps> {
   constructor(props) {
     super(props)
-
-    this.state = { billingAddress: null, creditCardFormParams: null, creditCardToken: null }
   }
 
   presentCreditCardForm() {
@@ -33,7 +30,7 @@ export class PaymentInfo extends React.Component<PaymentInfoProps, PaymentInfoSt
       title: "",
       passProps: {
         onSubmit: (token, params) => this.onCreditCardAdded(token, params),
-        params: this.state.creditCardFormParams,
+        params: this.props.creditCardFormParams,
         navigator: this.props.navigator,
       },
     })
@@ -45,22 +42,22 @@ export class PaymentInfo extends React.Component<PaymentInfoProps, PaymentInfoSt
       title: "",
       passProps: {
         onSubmit: address => this.onBillingAddressAdded(address),
-        billingAddress: this.state.billingAddress,
+        billingAddress: this.props.billingAddress,
         navigator: this.props.navigator,
       },
     })
   }
 
   onCreditCardAdded(token: StripeToken, params: PaymentCardTextFieldParams) {
-    this.setState({ creditCardToken: token, creditCardFormParams: params })
+    this.props.onCreditCardAdded(token, params)
   }
 
   onBillingAddressAdded(values: Address) {
-    this.setState({ billingAddress: values })
+    this.props.onBillingAddressAdded(values)
   }
 
   render() {
-    const { billingAddress, creditCardToken: token } = this.state
+    const { billingAddress, creditCardToken: token } = this.props
 
     return (
       <View>

--- a/src/lib/Components/Bidding/Components/PaymentInfo.tsx
+++ b/src/lib/Components/Bidding/Components/PaymentInfo.tsx
@@ -7,6 +7,7 @@ import { CreditCardForm } from "../Screens/CreditCardForm"
 import { BidInfoRow } from "./BidInfoRow"
 import { Divider } from "./Divider"
 
+import { BiddingThemeProvider } from "../Components/BiddingThemeProvider"
 import { FlexProps } from "../Elements/Flex"
 import { Address, PaymentCardTextFieldParams, StripeToken } from "../types"
 
@@ -60,21 +61,23 @@ export class PaymentInfo extends React.Component<PaymentInfoProps> {
     const { billingAddress, creditCardToken: token } = this.props
 
     return (
-      <View>
-        <Divider mb={2} />
-        <BidInfoRow
-          label="Credit Card"
-          value={token && this.formatCard(token)}
-          onPress={() => this.presentCreditCardForm()}
-        />
-        <Divider mb={2} />
-        <BidInfoRow
-          label="Billing address"
-          value={billingAddress && this.formatAddress(billingAddress)}
-          onPress={() => this.presentBillingAddressForm()}
-        />
-        <Divider mb={2} />
-      </View>
+      <BiddingThemeProvider>
+        <View>
+          <Divider mb={2} />
+          <BidInfoRow
+            label="Credit Card"
+            value={token && this.formatCard(token)}
+            onPress={() => this.presentCreditCardForm()}
+          />
+          <Divider mb={2} />
+          <BidInfoRow
+            label="Billing address"
+            value={billingAddress && this.formatAddress(billingAddress)}
+            onPress={() => this.presentBillingAddressForm()}
+          />
+          <Divider mb={2} />
+        </View>
+      </BiddingThemeProvider>
     )
   }
 

--- a/src/lib/Components/Bidding/Components/PaymentInfo.tsx
+++ b/src/lib/Components/Bidding/Components/PaymentInfo.tsx
@@ -1,0 +1,91 @@
+import React from "react"
+import { NavigatorIOS, View } from "react-native"
+
+import { BillingAddress } from "../Screens/BillingAddress"
+import { CreditCardForm } from "../Screens/CreditCardForm"
+
+import { BidInfoRow } from "./BidInfoRow"
+import { Divider } from "./Divider"
+
+import { FlexProps } from "../Elements/Flex"
+import { Address, PaymentCardTextFieldParams, StripeToken } from "../types"
+
+interface PaymentInfoProps extends FlexProps {
+  navigator?: NavigatorIOS
+}
+
+interface PaymentInfoState {
+  billingAddress?: Address
+  creditCardFormParams?: PaymentCardTextFieldParams
+  creditCardToken?: StripeToken
+}
+
+export class PaymentInfo extends React.Component<PaymentInfoProps, PaymentInfoState> {
+  constructor(props) {
+    super(props)
+
+    this.state = { billingAddress: null, creditCardFormParams: null, creditCardToken: null }
+  }
+
+  presentCreditCardForm() {
+    this.props.navigator.push({
+      component: CreditCardForm,
+      title: "",
+      passProps: {
+        onSubmit: (token, params) => this.onCreditCardAdded(token, params),
+        params: this.state.creditCardFormParams,
+        navigator: this.props.navigator,
+      },
+    })
+  }
+
+  presentBillingAddressForm() {
+    this.props.navigator.push({
+      component: BillingAddress,
+      title: "",
+      passProps: {
+        onSubmit: address => this.onBillingAddressAdded(address),
+        billingAddress: this.state.billingAddress,
+        navigator: this.props.navigator,
+      },
+    })
+  }
+
+  onCreditCardAdded(token: StripeToken, params: PaymentCardTextFieldParams) {
+    this.setState({ creditCardToken: token, creditCardFormParams: params })
+  }
+
+  onBillingAddressAdded(values: Address) {
+    this.setState({ billingAddress: values })
+  }
+
+  render() {
+    const { billingAddress, creditCardToken: token } = this.state
+
+    return (
+      <View>
+        <Divider mb={2} />
+        <BidInfoRow
+          label="Credit Card"
+          value={token && this.formatCard(token)}
+          onPress={() => this.presentCreditCardForm()}
+        />
+        <Divider mb={2} />
+        <BidInfoRow
+          label="Billing address"
+          value={billingAddress && this.formatAddress(billingAddress)}
+          onPress={() => this.presentBillingAddressForm()}
+        />
+        <Divider mb={2} />
+      </View>
+    )
+  }
+
+  private formatCard(token: StripeToken) {
+    return `${token.card.brand} •••• ${token.card.last4}`
+  }
+
+  private formatAddress(address: Address) {
+    return [address.addressLine1, address.addressLine2, address.city, address.state].filter(el => el).join(" ")
+  }
+}

--- a/src/lib/Components/Bidding/Components/__tests__/PaymentInfo-tests.tsx
+++ b/src/lib/Components/Bidding/Components/__tests__/PaymentInfo-tests.tsx
@@ -1,0 +1,69 @@
+import React from "react"
+import * as renderer from "react-test-renderer"
+
+import { Serif16 } from "../../Elements/Typography"
+import { BillingAddress } from "../../Screens/BillingAddress"
+import { CreditCardForm } from "../../Screens/CreditCardForm"
+import { PaymentInfo } from "../PaymentInfo"
+
+import { BidInfoRow } from "../../Components/BidInfoRow"
+
+jest.mock("tipsi-stripe", () => ({
+  setOptions: jest.fn(),
+  paymentRequestWithCardForm: jest.fn(),
+  createTokenWithCard: jest.fn(),
+}))
+
+let nextStep
+const mockNavigator = { push: route => (nextStep = route), pop: () => null }
+jest.useFakeTimers()
+
+it("renders properly", () => {
+  const component = renderer.create(<PaymentInfo {...initialProps} />).toJSON()
+  expect(component).toMatchSnapshot()
+})
+
+it("shows the billing address that the user typed in the billing address form", () => {
+  const billingAddressRow = renderer.create(<PaymentInfo {...initialProps} />).root.findAllByType(BidInfoRow)[1]
+  billingAddressRow.instance.props.onPress()
+  expect(nextStep.component).toEqual(BillingAddress)
+
+  expect(billingAddressRow.findByType(Serif16).props.children).toEqual("401 Broadway 25th floor New York NY")
+})
+
+it("shows the cc info that the user had typed into the form", () => {
+  const creditCardRow = renderer.create(<PaymentInfo {...initialProps} />).root.findAllByType(BidInfoRow)[0]
+  creditCardRow.instance.props.onPress()
+  expect(nextStep.component).toEqual(CreditCardForm)
+
+  expect(creditCardRow.findByType(Serif16).props.children).toEqual("VISA •••• 4242")
+})
+
+const billingAddress = {
+  fullName: "Yuki Stockmeier",
+  addressLine1: "401 Broadway",
+  addressLine2: "25th floor",
+  city: "New York",
+  state: "NY",
+  postalCode: "10013",
+}
+
+const creditCardToken = {
+  tokenId: "fake-token",
+  created: "1528229731",
+  livemode: 0,
+  card: {
+    brand: "VISA",
+    last4: "4242",
+  },
+  bankAccount: null,
+  extra: null,
+}
+
+const initialProps = {
+  navigator: mockNavigator,
+  onCreditCardAdded: jest.fn(),
+  onBillingAddressAdded: jest.fn(),
+  billingAddress,
+  creditCardToken,
+} as any

--- a/src/lib/Components/Bidding/Components/__tests__/__snapshots__/PaymentInfo-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Components/__tests__/__snapshots__/PaymentInfo-tests.tsx.snap
@@ -1,0 +1,341 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders properly 1`] = `
+<View>
+  <View
+    border={1}
+    borderBottomWidth={0}
+    borderColor="black10"
+    mb={2}
+    style={
+      Array [
+        Object {
+          "borderColor": "#E5E5E5",
+          "borderStyle": "solid",
+          "borderWidth": 1,
+          "marginBottom": 5,
+          "width": "100%",
+        },
+        undefined,
+      ]
+    }
+    width="100%"
+  />
+  <View
+    accessibilityComponentType={undefined}
+    accessibilityLabel={undefined}
+    accessibilityTraits={undefined}
+    accessible={true}
+    alignItems="center"
+    flexDirection="row"
+    hitSlop={undefined}
+    justifyContent="space-between"
+    nativeID={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    p={4}
+    style={
+      Array [
+        Object {
+          "paddingBottom": 20,
+          "paddingLeft": 20,
+          "paddingRight": 20,
+          "paddingTop": 20,
+        },
+        undefined,
+      ]
+    }
+    testID={undefined}
+  >
+    <View
+      flex={1}
+      style={
+        Array [
+          Object {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
+          },
+          undefined,
+        ]
+      }
+    >
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        fontSize={3}
+        lineHeight={5}
+        style={
+          Array [
+            Object {
+              "fontFamily": "AGaramondPro-Semibold",
+              "fontSize": 16,
+              "lineHeight": 24,
+            },
+            undefined,
+          ]
+        }
+      >
+        Credit Card
+      </Text>
+    </View>
+    <View
+      alignItems="flex-end"
+      flex={1}
+      style={
+        Array [
+          Object {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
+          },
+          undefined,
+        ]
+      }
+    >
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        fontSize={3}
+        lineHeight={5}
+        numberOfLines={1}
+        style={
+          Array [
+            Object {
+              "fontFamily": "AGaramondPro-Regular",
+              "fontSize": 16,
+              "lineHeight": 24,
+            },
+            undefined,
+          ]
+        }
+      >
+        VISA •••• 4242
+      </Text>
+    </View>
+    <View
+      alignItems="flex-end"
+      flex={null}
+      flexBasis="auto"
+      flexGrow={0}
+      flexShrink={0}
+      style={
+        Array [
+          Object {},
+          undefined,
+        ]
+      }
+    >
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        color="purple100"
+        ellipsizeMode="tail"
+        fontSize={1}
+        lineHeight={1}
+        mb={2}
+        ml={3}
+        style={
+          Array [
+            Object {
+              "color": "#6E1EFF",
+              "fontFamily": "Unica77LL-Regular",
+              "fontSize": 12,
+              "lineHeight": 16,
+              "marginBottom": 5,
+              "marginLeft": 10,
+            },
+            undefined,
+          ]
+        }
+      >
+        Edit
+      </Text>
+    </View>
+  </View>
+  <View
+    border={1}
+    borderBottomWidth={0}
+    borderColor="black10"
+    mb={2}
+    style={
+      Array [
+        Object {
+          "borderColor": "#E5E5E5",
+          "borderStyle": "solid",
+          "borderWidth": 1,
+          "marginBottom": 5,
+          "width": "100%",
+        },
+        undefined,
+      ]
+    }
+    width="100%"
+  />
+  <View
+    accessibilityComponentType={undefined}
+    accessibilityLabel={undefined}
+    accessibilityTraits={undefined}
+    accessible={true}
+    alignItems="center"
+    flexDirection="row"
+    hitSlop={undefined}
+    justifyContent="space-between"
+    nativeID={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    p={4}
+    style={
+      Array [
+        Object {
+          "paddingBottom": 20,
+          "paddingLeft": 20,
+          "paddingRight": 20,
+          "paddingTop": 20,
+        },
+        undefined,
+      ]
+    }
+    testID={undefined}
+  >
+    <View
+      flex={1}
+      style={
+        Array [
+          Object {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
+          },
+          undefined,
+        ]
+      }
+    >
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        fontSize={3}
+        lineHeight={5}
+        style={
+          Array [
+            Object {
+              "fontFamily": "AGaramondPro-Semibold",
+              "fontSize": 16,
+              "lineHeight": 24,
+            },
+            undefined,
+          ]
+        }
+      >
+        Billing address
+      </Text>
+    </View>
+    <View
+      alignItems="flex-end"
+      flex={1}
+      style={
+        Array [
+          Object {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
+          },
+          undefined,
+        ]
+      }
+    >
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        fontSize={3}
+        lineHeight={5}
+        numberOfLines={1}
+        style={
+          Array [
+            Object {
+              "fontFamily": "AGaramondPro-Regular",
+              "fontSize": 16,
+              "lineHeight": 24,
+            },
+            undefined,
+          ]
+        }
+      >
+        401 Broadway 25th floor New York NY
+      </Text>
+    </View>
+    <View
+      alignItems="flex-end"
+      flex={null}
+      flexBasis="auto"
+      flexGrow={0}
+      flexShrink={0}
+      style={
+        Array [
+          Object {},
+          undefined,
+        ]
+      }
+    >
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        color="purple100"
+        ellipsizeMode="tail"
+        fontSize={1}
+        lineHeight={1}
+        mb={2}
+        ml={3}
+        style={
+          Array [
+            Object {
+              "color": "#6E1EFF",
+              "fontFamily": "Unica77LL-Regular",
+              "fontSize": 12,
+              "lineHeight": 16,
+              "marginBottom": 5,
+              "marginLeft": 10,
+            },
+            undefined,
+          ]
+        }
+      >
+        Edit
+      </Text>
+    </View>
+  </View>
+  <View
+    border={1}
+    borderBottomWidth={0}
+    borderColor="black10"
+    mb={2}
+    style={
+      Array [
+        Object {
+          "borderColor": "#E5E5E5",
+          "borderStyle": "solid",
+          "borderWidth": 1,
+          "marginBottom": 5,
+          "width": "100%",
+        },
+        undefined,
+      ]
+    }
+    width="100%"
+  />
+</View>
+`;

--- a/src/lib/Components/Bidding/Elements/Grid.tsx
+++ b/src/lib/Components/Bidding/Elements/Grid.tsx
@@ -1,5 +1,5 @@
 import React from "react"
 import { Flex } from "../Elements/Flex"
 
-export const Row = props => <Flex flexDirection="row" justifyContent="space-between" {...props} />
+export const Row = props => <Flex flexDirection="row" justifyContent="space-between" alignItems="center" {...props} />
 export const Col = props => <Flex flex={1} {...props} />

--- a/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
@@ -235,6 +235,14 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
     SwitchBoard.presentModalViewController(this, "/conditions-of-sale?present_modally=true")
   }
 
+  onCreditCardAdded(token: StripeToken, params: PaymentCardTextFieldParams) {
+    this.setState({ creditCardToken: token, creditCardFormParams: params })
+  }
+
+  onBillingAddressAdded(values: Address) {
+    this.setState({ billingAddress: values })
+  }
+
   goBackToSelectMaxBid() {
     this.props.navigator.pop()
   }
@@ -265,7 +273,7 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
 
   render() {
     const { artwork, lot_label, sale } = this.props.sale_artwork
-    const { billingAddress, creditCardToken: token, requiresPaymentInformation, requiresCheckbox } = this.state
+    const { requiresPaymentInformation, requiresCheckbox } = this.state
 
     return (
       <BiddingThemeProvider>
@@ -289,7 +297,18 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
 
             <BidInfoRow label="Max bid" value={this.props.bid.display} onPress={() => this.goBackToSelectMaxBid()} />
 
-            {requiresPaymentInformation ? <PaymentInfo navigator={this.props.navigator} /> : <Divider mb={9} />}
+            {requiresPaymentInformation ? (
+              <PaymentInfo
+                navigator={this.props.navigator}
+                onCreditCardAdded={this.onCreditCardAdded.bind(this)}
+                onBillingAddressAdded={this.onBillingAddressAdded.bind(this)}
+                billingAddress={this.state.billingAddress}
+                creditCardFormParams={this.state.creditCardFormParams}
+                creditCardToken={this.state.creditCardToken}
+              />
+            ) : (
+              <Divider mb={9} />
+            )}
           </View>
 
           <View>

--- a/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
@@ -17,13 +17,12 @@ import { Button } from "../Components/Button"
 import { Checkbox } from "../Components/Checkbox"
 import { Container } from "../Components/Containers"
 import { Divider } from "../Components/Divider"
+import { PaymentInfo } from "../Components/PaymentInfo"
 import { Timer } from "../Components/Timer"
 import { Title } from "../Components/Title"
 import { Address, Bid, BidderPositionResult, PaymentCardTextFieldParams, StripeToken } from "../types"
 
 import { BidResultScreen } from "./BidResult"
-import { BillingAddress } from "./BillingAddress"
-import { CreditCardForm } from "./CreditCardForm"
 
 import { ConfirmBid_me } from "__generated__/ConfirmBid_me.graphql"
 import { ConfirmBid_sale_artwork } from "__generated__/ConfirmBid_sale_artwork.graphql"
@@ -236,14 +235,6 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
     SwitchBoard.presentModalViewController(this, "/conditions-of-sale?present_modally=true")
   }
 
-  onCreditCardAdded(token: StripeToken, params: PaymentCardTextFieldParams) {
-    this.setState({ creditCardToken: token, creditCardFormParams: params })
-  }
-
-  onBillingAddressAdded(values: Address) {
-    this.setState({ billingAddress: values })
-  }
-
   goBackToSelectMaxBid() {
     this.props.navigator.pop()
   }
@@ -272,29 +263,6 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
     this.setState({ isLoading: false })
   }
 
-  presentCreditCardForm() {
-    this.props.navigator.push({
-      component: CreditCardForm,
-      title: "",
-      passProps: {
-        onSubmit: (token, params) => this.onCreditCardAdded(token, params),
-        navigator: this.props.navigator,
-      },
-    })
-  }
-
-  presentBillingAddressForm() {
-    this.props.navigator.push({
-      component: BillingAddress,
-      title: "",
-      passProps: {
-        onSubmit: address => this.onBillingAddressAdded(address),
-        billingAddress: this.state.billingAddress,
-        navigator: this.props.navigator,
-      },
-    })
-  }
-
   render() {
     const { artwork, lot_label, sale } = this.props.sale_artwork
     const { billingAddress, creditCardToken: token, requiresPaymentInformation, requiresCheckbox } = this.state
@@ -321,25 +289,7 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
 
             <BidInfoRow label="Max bid" value={this.props.bid.display} onPress={() => this.goBackToSelectMaxBid()} />
 
-            {requiresPaymentInformation ? (
-              <View>
-                <Divider mb={2} />
-                <BidInfoRow
-                  label="Credit Card"
-                  value={token && this.formatCard(token)}
-                  onPress={() => this.presentCreditCardForm()}
-                />
-                <Divider mb={2} />
-                <BidInfoRow
-                  label="Billing address"
-                  value={billingAddress && this.formatAddress(billingAddress)}
-                  onPress={() => this.presentBillingAddressForm()}
-                />
-                <Divider mb={2} />
-              </View>
-            ) : (
-              <Divider mb={9} />
-            )}
+            {requiresPaymentInformation ? <PaymentInfo navigator={this.props.navigator} /> : <Divider mb={9} />}
           </View>
 
           <View>
@@ -365,14 +315,6 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
         </Container>
       </BiddingThemeProvider>
     )
-  }
-
-  private formatCard(token: StripeToken) {
-    return `${token.card.brand} •••• ${token.card.last4}`
-  }
-
-  private formatAddress(address: Address) {
-    return [address.addressLine1, address.addressLine2, address.city, address.state].filter(el => el).join(" ")
   }
 }
 

--- a/src/lib/Components/Bidding/Screens/CreditCardForm.tsx
+++ b/src/lib/Components/Bidding/Screens/CreditCardForm.tsx
@@ -13,6 +13,7 @@ import { PaymentCardTextFieldParams } from "../types"
 
 interface CreditCardFormProps {
   navigator?: NavigatorIOS
+  params: PaymentCardTextFieldParams
   onSubmit: (t: StripeToken, p: PaymentCardTextFieldParams) => void
 }
 
@@ -35,15 +36,10 @@ const styles = StyleSheet.create({
 })
 
 export class CreditCardForm extends Component<CreditCardFormProps, CreditCardFormState> {
-  state = {
-    valid: false,
-    params: {
-      number: null,
-      expMonth: null,
-      expYear: null,
-      cvc: null,
-    },
-    isLoading: false,
+  constructor(props) {
+    super(props)
+
+    this.state = { valid: null, params: this.props.params, isLoading: false }
   }
 
   handleFieldParamsChange = (valid, params: PaymentCardTextFieldParams) => {
@@ -55,9 +51,7 @@ export class CreditCardForm extends Component<CreditCardFormProps, CreditCardFor
 
     const { params } = this.state
 
-    const token = await stripe.createTokenWithCard({
-      ...params,
-    })
+    const token = await stripe.createTokenWithCard({ ...params })
 
     this.props.onSubmit(token, this.state.params)
     this.props.navigator.pop()

--- a/src/lib/Components/Bidding/Screens/CreditCardForm.tsx
+++ b/src/lib/Components/Bidding/Screens/CreditCardForm.tsx
@@ -13,7 +13,7 @@ import { PaymentCardTextFieldParams } from "../types"
 
 interface CreditCardFormProps {
   navigator?: NavigatorIOS
-  params: PaymentCardTextFieldParams
+  params?: PaymentCardTextFieldParams
   onSubmit: (t: StripeToken, p: PaymentCardTextFieldParams) => void
 }
 
@@ -36,10 +36,19 @@ const styles = StyleSheet.create({
 })
 
 export class CreditCardForm extends Component<CreditCardFormProps, CreditCardFormState> {
+  private paymentInfo: PaymentCardTextField
+
   constructor(props) {
     super(props)
 
-    this.state = { valid: null, params: this.props.params, isLoading: false }
+    this.paymentInfo = (React as any).createRef()
+    this.state = { valid: null, params: { ...this.props.params }, isLoading: false }
+  }
+
+  componentDidMount() {
+    if (this.paymentInfo.value) {
+      this.paymentInfo.value.setParams(this.state.params)
+    }
   }
 
   handleFieldParamsChange = (valid, params: PaymentCardTextFieldParams) => {
@@ -65,7 +74,11 @@ export class CreditCardForm extends Component<CreditCardFormProps, CreditCardFor
             <Title>Your credit card</Title>
 
             <Flex m={4}>
-              <PaymentCardTextField style={styles.field} onParamsChange={this.handleFieldParamsChange} />
+              <PaymentCardTextField
+                ref={this.paymentInfo}
+                style={styles.field}
+                onParamsChange={this.handleFieldParamsChange}
+              />
             </Flex>
           </View>
 

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmBid-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmBid-tests.tsx.snap
@@ -238,6 +238,7 @@ exports[`renders properly 1`] = `
       accessibilityLabel={undefined}
       accessibilityTraits={undefined}
       accessible={true}
+      alignItems="center"
       flexDirection="row"
       hitSlop={undefined}
       justifyContent="space-between"

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/Registration-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/Registration-tests.tsx.snap
@@ -21,42 +21,7 @@ exports[`renders properly 1`] = `
     ]
   }
 >
-  <View
-    alignItems="center"
-    style={
-      Array [
-        Object {},
-        undefined,
-      ]
-    }
-  >
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
-      fontSize={5}
-      lineHeight={9}
-      m={4}
-      mb={3}
-      style={
-        Array [
-          Object {
-            "fontFamily": "AGaramondPro-Semibold",
-            "fontSize": 22,
-            "lineHeight": 32,
-            "marginBottom": 10,
-            "marginLeft": 20,
-            "marginRight": 20,
-            "marginTop": 20,
-            "textAlign": "center",
-          },
-          undefined,
-        ]
-      }
-      textAlign="center"
-    >
-      Register to bid
-    </Text>
+  <View>
     <View
       alignItems="center"
       style={
@@ -70,359 +35,402 @@ exports[`renders properly 1`] = `
         accessible={true}
         allowFontScaling={true}
         ellipsizeMode="tail"
-        fontSize={1}
-        lineHeight={1}
+        fontSize={5}
+        lineHeight={9}
+        m={4}
+        mb={3}
         style={
           Array [
             Object {
-              "fontFamily": "Unica77LL-Medium",
-              "fontSize": 12,
-              "lineHeight": 16,
+              "fontFamily": "AGaramondPro-Semibold",
+              "fontSize": 22,
+              "lineHeight": 32,
+              "marginBottom": 10,
+              "marginLeft": 20,
+              "marginRight": 20,
+              "marginTop": 20,
+              "textAlign": "center",
             },
             undefined,
           ]
         }
-      />
+        textAlign="center"
+      >
+        Register to bid
+      </Text>
+      <View
+        alignItems="center"
+        style={
+          Array [
+            Object {},
+            undefined,
+          ]
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          fontSize={1}
+          lineHeight={1}
+          style={
+            Array [
+              Object {
+                "fontFamily": "Unica77LL-Medium",
+                "fontSize": 12,
+                "lineHeight": 16,
+              },
+              undefined,
+            ]
+          }
+        />
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          fontSize={2}
+          lineHeight={5}
+          style={
+            Array [
+              Object {
+                "fontFamily": "Unica77LL-Medium",
+                "fontSize": 14,
+                "lineHeight": 24,
+              },
+              undefined,
+            ]
+          }
+        >
+          NaN
+          d
+            
+          NaN
+          h
+            
+          NaN
+          m
+            
+          NaN
+          s
+        </Text>
+      </View>
       <Text
         accessible={true}
         allowFontScaling={true}
         ellipsizeMode="tail"
-        fontSize={2}
-        lineHeight={5}
+        fontSize={4}
+        lineHeight={6}
+        mb={5}
+        mt={5}
         style={
           Array [
             Object {
-              "fontFamily": "Unica77LL-Medium",
-              "fontSize": 14,
-              "lineHeight": 24,
-            },
-            undefined,
-          ]
-        }
-      >
-        NaN
-        d
-          
-        NaN
-        h
-          
-        NaN
-        m
-          
-        NaN
-        s
-      </Text>
-    </View>
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
-      fontSize={4}
-      lineHeight={6}
-      mb={5}
-      mt={5}
-      style={
-        Array [
-          Object {
-            "fontFamily": "AGaramondPro-Semibold",
-            "fontSize": 18,
-            "lineHeight": 26,
-            "marginBottom": 30,
-            "marginTop": 30,
-          },
-          undefined,
-        ]
-      }
-    />
-    <View
-      border={1}
-      borderBottomWidth={0}
-      borderColor="black10"
-      mb={2}
-      style={
-        Array [
-          Object {
-            "borderColor": "#E5E5E5",
-            "borderStyle": "solid",
-            "borderWidth": 1,
-            "marginBottom": 5,
-            "width": "100%",
-          },
-          undefined,
-        ]
-      }
-      width="100%"
-    />
-    <View
-      accessibilityComponentType={undefined}
-      accessibilityLabel={undefined}
-      accessibilityTraits={undefined}
-      accessible={true}
-      flexDirection="row"
-      hitSlop={undefined}
-      justifyContent="space-between"
-      nativeID={undefined}
-      onLayout={undefined}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      p={4}
-      style={
-        Array [
-          Object {
-            "paddingBottom": 20,
-            "paddingLeft": 20,
-            "paddingRight": 20,
-            "paddingTop": 20,
-          },
-          undefined,
-        ]
-      }
-      testID={undefined}
-    >
-      <View
-        flex={1}
-        style={
-          Array [
-            Object {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
-            },
-            undefined,
-          ]
-        }
-      >
-        <Text
-          accessible={true}
-          allowFontScaling={true}
-          ellipsizeMode="tail"
-          fontSize={3}
-          lineHeight={5}
-          style={
-            Array [
-              Object {
-                "fontFamily": "AGaramondPro-Semibold",
-                "fontSize": 16,
-                "lineHeight": 24,
-              },
-              undefined,
-            ]
-          }
-        >
-          Credit Card
-        </Text>
-      </View>
-      <View
-        alignItems="flex-end"
-        flex={1}
-        style={
-          Array [
-            Object {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
+              "fontFamily": "AGaramondPro-Semibold",
+              "fontSize": 18,
+              "lineHeight": 26,
+              "marginBottom": 30,
+              "marginTop": 30,
             },
             undefined,
           ]
         }
       />
-      <View
-        alignItems="flex-end"
-        flex={null}
-        flexBasis="auto"
-        flexGrow={0}
-        flexShrink={0}
-        style={
-          Array [
-            Object {},
-            undefined,
-          ]
-        }
-      >
-        <Text
-          accessible={true}
-          allowFontScaling={true}
-          color="purple100"
-          ellipsizeMode="tail"
-          fontSize={1}
-          lineHeight={1}
-          mb={2}
-          ml={3}
-          style={
-            Array [
-              Object {
-                "color": "#6E1EFF",
-                "fontFamily": "Unica77LL-Regular",
-                "fontSize": 12,
-                "lineHeight": 16,
-                "marginBottom": 5,
-                "marginLeft": 10,
-              },
-              undefined,
-            ]
-          }
-        >
-          Add
-        </Text>
-      </View>
     </View>
-    <View
-      border={1}
-      borderBottomWidth={0}
-      borderColor="black10"
-      mb={2}
-      style={
-        Array [
-          Object {
-            "borderColor": "#E5E5E5",
-            "borderStyle": "solid",
-            "borderWidth": 1,
-            "marginBottom": 5,
-            "width": "100%",
-          },
-          undefined,
-        ]
-      }
-      width="100%"
-    />
-    <View
-      accessibilityComponentType={undefined}
-      accessibilityLabel={undefined}
-      accessibilityTraits={undefined}
-      accessible={true}
-      flexDirection="row"
-      hitSlop={undefined}
-      justifyContent="space-between"
-      nativeID={undefined}
-      onLayout={undefined}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      p={4}
-      style={
-        Array [
-          Object {
-            "paddingBottom": 20,
-            "paddingLeft": 20,
-            "paddingRight": 20,
-            "paddingTop": 20,
-          },
-          undefined,
-        ]
-      }
-      testID={undefined}
-    >
+    <View>
       <View
-        flex={1}
+        border={1}
+        borderBottomWidth={0}
+        borderColor="black10"
+        mb={2}
         style={
           Array [
             Object {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
+              "borderColor": "#E5E5E5",
+              "borderStyle": "solid",
+              "borderWidth": 1,
+              "marginBottom": 5,
+              "width": "100%",
             },
             undefined,
           ]
         }
-      >
-        <Text
-          accessible={true}
-          allowFontScaling={true}
-          ellipsizeMode="tail"
-          fontSize={3}
-          lineHeight={5}
-          style={
-            Array [
-              Object {
-                "fontFamily": "AGaramondPro-Semibold",
-                "fontSize": 16,
-                "lineHeight": 24,
-              },
-              undefined,
-            ]
-          }
-        >
-          Billing address
-        </Text>
-      </View>
-      <View
-        alignItems="flex-end"
-        flex={1}
-        style={
-          Array [
-            Object {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
-            },
-            undefined,
-          ]
-        }
+        width="100%"
       />
       <View
-        alignItems="flex-end"
-        flex={null}
-        flexBasis="auto"
-        flexGrow={0}
-        flexShrink={0}
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        alignItems="center"
+        flexDirection="row"
+        hitSlop={undefined}
+        justifyContent="space-between"
+        nativeID={undefined}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        p={4}
         style={
           Array [
-            Object {},
+            Object {
+              "paddingBottom": 20,
+              "paddingLeft": 20,
+              "paddingRight": 20,
+              "paddingTop": 20,
+            },
             undefined,
           ]
         }
+        testID={undefined}
       >
-        <Text
-          accessible={true}
-          allowFontScaling={true}
-          color="purple100"
-          ellipsizeMode="tail"
-          fontSize={1}
-          lineHeight={1}
-          mb={2}
-          ml={3}
+        <View
+          flex={1}
           style={
             Array [
               Object {
-                "color": "#6E1EFF",
-                "fontFamily": "Unica77LL-Regular",
-                "fontSize": 12,
-                "lineHeight": 16,
-                "marginBottom": 5,
-                "marginLeft": 10,
+                "flexBasis": 0,
+                "flexGrow": 1,
+                "flexShrink": 1,
               },
               undefined,
             ]
           }
         >
-          Add
-        </Text>
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            fontSize={3}
+            lineHeight={5}
+            style={
+              Array [
+                Object {
+                  "fontFamily": "AGaramondPro-Semibold",
+                  "fontSize": 16,
+                  "lineHeight": 24,
+                },
+                undefined,
+              ]
+            }
+          >
+            Credit Card
+          </Text>
+        </View>
+        <View
+          alignItems="flex-end"
+          flex={1}
+          style={
+            Array [
+              Object {
+                "flexBasis": 0,
+                "flexGrow": 1,
+                "flexShrink": 1,
+              },
+              undefined,
+            ]
+          }
+        />
+        <View
+          alignItems="flex-end"
+          flex={null}
+          flexBasis="auto"
+          flexGrow={0}
+          flexShrink={0}
+          style={
+            Array [
+              Object {},
+              undefined,
+            ]
+          }
+        >
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            color="purple100"
+            ellipsizeMode="tail"
+            fontSize={1}
+            lineHeight={1}
+            mb={2}
+            ml={3}
+            style={
+              Array [
+                Object {
+                  "color": "#6E1EFF",
+                  "fontFamily": "Unica77LL-Regular",
+                  "fontSize": 12,
+                  "lineHeight": 16,
+                  "marginBottom": 5,
+                  "marginLeft": 10,
+                },
+                undefined,
+              ]
+            }
+          >
+            Add
+          </Text>
+        </View>
       </View>
+      <View
+        border={1}
+        borderBottomWidth={0}
+        borderColor="black10"
+        mb={2}
+        style={
+          Array [
+            Object {
+              "borderColor": "#E5E5E5",
+              "borderStyle": "solid",
+              "borderWidth": 1,
+              "marginBottom": 5,
+              "width": "100%",
+            },
+            undefined,
+          ]
+        }
+        width="100%"
+      />
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        alignItems="center"
+        flexDirection="row"
+        hitSlop={undefined}
+        justifyContent="space-between"
+        nativeID={undefined}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        p={4}
+        style={
+          Array [
+            Object {
+              "paddingBottom": 20,
+              "paddingLeft": 20,
+              "paddingRight": 20,
+              "paddingTop": 20,
+            },
+            undefined,
+          ]
+        }
+        testID={undefined}
+      >
+        <View
+          flex={1}
+          style={
+            Array [
+              Object {
+                "flexBasis": 0,
+                "flexGrow": 1,
+                "flexShrink": 1,
+              },
+              undefined,
+            ]
+          }
+        >
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            fontSize={3}
+            lineHeight={5}
+            style={
+              Array [
+                Object {
+                  "fontFamily": "AGaramondPro-Semibold",
+                  "fontSize": 16,
+                  "lineHeight": 24,
+                },
+                undefined,
+              ]
+            }
+          >
+            Billing address
+          </Text>
+        </View>
+        <View
+          alignItems="flex-end"
+          flex={1}
+          style={
+            Array [
+              Object {
+                "flexBasis": 0,
+                "flexGrow": 1,
+                "flexShrink": 1,
+              },
+              undefined,
+            ]
+          }
+        />
+        <View
+          alignItems="flex-end"
+          flex={null}
+          flexBasis="auto"
+          flexGrow={0}
+          flexShrink={0}
+          style={
+            Array [
+              Object {},
+              undefined,
+            ]
+          }
+        >
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            color="purple100"
+            ellipsizeMode="tail"
+            fontSize={1}
+            lineHeight={1}
+            mb={2}
+            ml={3}
+            style={
+              Array [
+                Object {
+                  "color": "#6E1EFF",
+                  "fontFamily": "Unica77LL-Regular",
+                  "fontSize": 12,
+                  "lineHeight": 16,
+                  "marginBottom": 5,
+                  "marginLeft": 10,
+                },
+                undefined,
+              ]
+            }
+          >
+            Add
+          </Text>
+        </View>
+      </View>
+      <View
+        border={1}
+        borderBottomWidth={0}
+        borderColor="black10"
+        mb={2}
+        style={
+          Array [
+            Object {
+              "borderColor": "#E5E5E5",
+              "borderStyle": "solid",
+              "borderWidth": 1,
+              "marginBottom": 5,
+              "width": "100%",
+            },
+            undefined,
+          ]
+        }
+        width="100%"
+      />
     </View>
-    <View
-      border={1}
-      borderBottomWidth={0}
-      borderColor="black10"
-      style={
-        Array [
-          Object {
-            "borderColor": "#E5E5E5",
-            "borderStyle": "solid",
-            "borderWidth": 1,
-            "width": "100%",
-          },
-          undefined,
-        ]
-      }
-      width="100%"
-    />
   </View>
   <View>
     <View


### PR DESCRIPTION
This PR extracts the payment info (which wraps the `BillingAddress` and `CreditCardForm` components), since it's re-used between the registration flow and the bid flow.

The parent of those components has to hold the truth about the credit card token and billing address, since we create the credit card + (bid or register) in one go on that big button. So there's still a little repeated logic but it's not too bad.

I also updated the credit card form to accept props and pre-fill the card number based on what you'd entered before, if you click the "Edit" button to go back.

Note that we don't handle _anywhere_ the ability to halfway-save your billing address or credit card info. Not sure if that's an issue, but will make sure to follow up in case that becomes a need.

Made this #trivial since it's just a refactor and doesn't add much new functionality.

#skip_new_tests