### PR TITLE
[Bidflow] Disabled Button State

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 * Fixes the `commitMutation` compatibility by not throwing errors - yuki24
 * Update button style in bidflow to latest spec - maxim
+* Add disabled state to new button type, primary black - maxim
 
 ### 1.5.6
 

--- a/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
@@ -328,6 +328,7 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
                 inProgress={this.state.isLoading}
                 selected={this.state.isLoading}
                 onPress={this.canPlaceBid() ? () => this.placeBid() : null}
+                disabled={!this.canPlaceBid()}
               />
             </Flex>
           </View>

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmBid-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmBid-tests.tsx.snap
@@ -537,7 +537,7 @@ exports[`renders properly 1`] = `
           style={
             Object {
               "alignItems": "center",
-              "backgroundColor": "rgba(0, 0, 0, 1)",
+              "backgroundColor": "rgba(229, 229, 229, 1)",
               "borderRadius": 2,
               "flex": 1,
               "justifyContent": "center",

--- a/src/lib/Components/Buttons/PrimaryBlack.tsx
+++ b/src/lib/Components/Buttons/PrimaryBlack.tsx
@@ -13,6 +13,7 @@ export interface PrimaryBlackProps extends React.Props<PrimaryBlack> {
   text: string
   textStyle?: StyleProp<TextStyle>
   selected?: boolean
+  disabled?: boolean
   inProgress?: boolean
   onPress?: React.TouchEventHandler<PrimaryBlack>
   onSelectionAnimationFinished?: Animated.EndCallback
@@ -49,9 +50,10 @@ export default class PrimaryBlack extends React.Component<PrimaryBlackProps, Pri
   }
 
   render() {
+    const disabledBackgroundColor = "#E5E5E5" // 10 percent black, on white bg
     const backgroundColor = this.state.backgroundColor.interpolate({
       inputRange: [0, 1],
-      outputRange: ["black", colors["purple-regular"]],
+      outputRange: [this.props.disabled ? disabledBackgroundColor : "black", colors["purple-regular"]],
     })
     const styling = {
       underlayColor: this.props.selected ? "black" : colors["purple-regular"],
@@ -66,7 +68,12 @@ export default class PrimaryBlack extends React.Component<PrimaryBlackProps, Pri
       content = <AnimatedHeadline style={headlineStyles}>{this.props.text}</AnimatedHeadline>
     }
     return (
-      <AnimatedTouchable onPress={this.props.onPress} activeOpacity={1} disabled={this.props.inProgress} {...styling}>
+      <AnimatedTouchable
+        onPress={this.props.onPress}
+        activeOpacity={1}
+        disabled={this.props.disabled || this.props.inProgress}
+        {...styling}
+      >
         <View>{content}</View>
       </AnimatedTouchable>
     )


### PR DESCRIPTION
Fix [Purchase 211](https://artsyproduct.atlassian.net/browse/PURCHASE-211)

_Note_ this merges into the [primary black button branch/PR](https://github.com/artsy/emission/pull/1120) (as it depends on that work)

#skip_new_tests

Looks like:

![simulator screen shot - iphone 6 - 9 1 - 2018-06-26 at 17 13 27](https://user-images.githubusercontent.com/373860/41925546-cdca658a-7964-11e8-9d6d-3daecd115575.png)