### PR TITLE
Properly format error message for the PENDING state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Update button style in bidflow to latest spec - maxim
 * Add disabled state to new button type, primary black - maxim
 * Registration screen handles when a user already has a credit card on file - sweir27
+* Removes unnecessary white spaces in the bid result screen - yuki24
 
 ### 1.5.6
 

--- a/src/lib/Components/Bidding/Screens/BidResult.tsx
+++ b/src/lib/Components/Bidding/Screens/BidResult.tsx
@@ -29,13 +29,11 @@ interface BidResultProps {
 
 const messageForPollingTimeout = {
   title: "Bid processing",
-  description: `
-    We’re receiving a high volume of traffic
-    and your bid is still processing.
-
-    If you don’t receive an update soon,
-    please contact [support@artsy.net](mailto:support@artsy.net).
-  `,
+  description:
+    "We’re receiving a high volume of traffic\n" +
+    "and your bid is still processing.\n\n" +
+    "If you don’t receive an update soon,\n" +
+    "please contact [support@artsy.net](mailto:support@artsy.net).",
 }
 
 const Icons = {


### PR DESCRIPTION
I noticed that the white spaces in the `messageForPollingTimeout.desription` were interpreted as an actual space in the parsed markdown `Text`s. This PR removes them so the message will show up without a weird offset.