### PR TITLE
Fixes a style issue where the spacing of the messages looks weird on “Outbid” payoff screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Fixes the `commitMutation` compatibility by not throwing errors - yuki24
 * Refetches bidder info when returning to ConfirmBid screen - sweir27
 * Refactors auction timer to support state changes - sweir27
+* Fixes a style issue where the spacing of the messages looks weird on “Outbid” payoff screen - yuki24
 
 ### 1.5.6
 

--- a/src/lib/Components/Bidding/Components/Markdown.tsx
+++ b/src/lib/Components/Bidding/Components/Markdown.tsx
@@ -6,7 +6,7 @@ import styled from "styled-components/native"
 
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { Flex, FlexProps } from "../Elements/Flex"
-import { Serif16 } from "../Elements/Typography"
+import { Serif16t } from "../Elements/Typography"
 
 // Rules for rendering parsed markdown. Currently only handles links and text. Add rules similar to
 // https://github.com/CharlesMangwa/react-native-simple-markdown/blob/next/src/rules.js for new functionalities.
@@ -44,9 +44,9 @@ const rules = {
     match: SimpleMarkdown.blockRegex(/^((?:[^\n]|\n(?! *\n))+)(?:\n *)/),
     react: (node, output, state) => {
       return (
-        <Serif16 color="black60" key={state.key} textAlign="center">
+        <Serif16t color="black60" key={state.key} textAlign="center">
           {output(node.content, state)}
-        </Serif16>
+        </Serif16t>
       )
     },
   },

--- a/src/lib/Components/Bidding/Components/Title.tsx
+++ b/src/lib/Components/Bidding/Components/Title.tsx
@@ -1,5 +1,5 @@
 import React from "react"
 
-import { SerifSemibold22 } from "../Elements/Typography"
+import { SerifSemibold22t } from "../Elements/Typography"
 
-export const Title = props => <SerifSemibold22 m={4} textAlign="center" {...props} />
+export const Title = props => <SerifSemibold22t m={4} textAlign="center" {...props} />

--- a/src/lib/Components/Bidding/Components/__tests__/__snapshots__/Title-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Components/__tests__/__snapshots__/Title-tests.tsx.snap
@@ -6,14 +6,14 @@ exports[`renders properly 1`] = `
   allowFontScaling={true}
   ellipsizeMode="tail"
   fontSize={5}
-  lineHeight={9}
+  lineHeight={7}
   m={4}
   style={
     Array [
       Object {
         "fontFamily": "AGaramondPro-Semibold",
         "fontSize": 32,
-        "lineHeight": 9,
+        "lineHeight": 7,
         "marginBottom": 32,
         "marginLeft": 32,
         "marginRight": 32,

--- a/src/lib/Components/Bidding/Elements/Typography.tsx
+++ b/src/lib/Components/Bidding/Elements/Typography.tsx
@@ -69,11 +69,16 @@ export const Serif14 = props => <Serif fontSize={2} lineHeight={2} {...props} />
 export const Serif16 = props => <Serif fontSize={3} lineHeight={5} {...props} />
 export const Serif18 = props => <Serif fontSize={4} lineHeight={6} {...props} />
 
+export const Serif16t = props => <Serif fontSize={3} lineHeight={3} {...props} />
+export const Serif18t = props => <Serif fontSize={4} lineHeight={4} {...props} />
+
 export const SerifSemibold12 = props => <SerifSemibold fontSize={1} lineHeight={1} {...props} />
 export const SerifSemibold14 = props => <SerifSemibold fontSize={2} lineHeight={2} {...props} />
 export const SerifSemibold16 = props => <SerifSemibold fontSize={3} lineHeight={5} {...props} />
 export const SerifSemibold18 = props => <SerifSemibold fontSize={4} lineHeight={6} {...props} />
 export const SerifSemibold22 = props => <SerifSemibold fontSize={5} lineHeight={9} {...props} />
+
+export const SerifSemibold22t = props => <SerifSemibold fontSize={5} lineHeight={7} {...props} />
 
 export const SerifItalic12 = props => <SerifItalic fontSize={1} lineHeight={1} {...props} />
 export const SerifItalic14 = props => <SerifItalic fontSize={2} lineHeight={2} {...props} />

--- a/src/lib/Components/Bidding/Screens/BidResult.tsx
+++ b/src/lib/Components/Bidding/Screens/BidResult.tsx
@@ -80,13 +80,15 @@ export class BidResult extends React.Component<BidResultProps> {
             <Flex alignItems="center">
               <Icon20 source={Icons[status] || require("../../../../../images/circle-x-red.png")} />
 
-              <Title m={4}>
+              <Title mt={0} mb={5}>
                 {status === "PENDING" ? messageForPollingTimeout.title : message_header || "You’re the highest bidder"}
               </Title>
 
-              <Markdown>
-                {status === "PENDING" ? messageForPollingTimeout.description : message_description_md || ""}
-              </Markdown>
+              {status !== "WINNING" && (
+                <Markdown mb={5}>
+                  {status === "PENDING" ? messageForPollingTimeout.description : message_description_md}
+                </Markdown>
+              )}
 
               {this.shouldDisplayTimer(status) && <Timer liveStartsAt={live_start_at} endsAt={end_at} />}
             </Flex>

--- a/src/lib/Components/Bidding/Screens/__stories__/BidResult.story.tsx
+++ b/src/lib/Components/Bidding/Screens/__stories__/BidResult.story.tsx
@@ -57,7 +57,7 @@ const Statuses = {
   live_bidding_started: {
     status: "LIVE_BIDDING_STARTED",
     message_header: "Live bidding has started",
-    message_description_md: `Sorry, your bid wasn’t received before live bidding started.\nTo continue bidding, please [join the live auction](http://live-staging.artsy.net/).`,
+    message_description_md: `Sorry, your bid wasn’t received before\nlive bidding started. To continue\nbidding, please [join the live auction](http://live-staging.artsy.net/).`,
   } as BidderPositionResult,
   pending: {
     status: "PENDING",

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/BillingAddress-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/BillingAddress-tests.tsx.snap
@@ -28,7 +28,7 @@ exports[`renders properly 1`] = `
         allowFontScaling={true}
         ellipsizeMode="tail"
         fontSize={5}
-        lineHeight={9}
+        lineHeight={7}
         m={4}
         mb={6}
         mt={0}
@@ -37,7 +37,7 @@ exports[`renders properly 1`] = `
             Object {
               "fontFamily": "AGaramondPro-Semibold",
               "fontSize": 22,
-              "lineHeight": 32,
+              "lineHeight": 28,
               "marginBottom": 40,
               "marginLeft": 20,
               "marginRight": 20,

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmBid-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmBid-tests.tsx.snap
@@ -35,7 +35,7 @@ exports[`renders properly 1`] = `
       allowFontScaling={true}
       ellipsizeMode="tail"
       fontSize={5}
-      lineHeight={9}
+      lineHeight={7}
       m={4}
       mb={3}
       style={
@@ -43,7 +43,7 @@ exports[`renders properly 1`] = `
           Object {
             "fontFamily": "AGaramondPro-Semibold",
             "fontSize": 22,
-            "lineHeight": 32,
+            "lineHeight": 28,
             "marginBottom": 10,
             "marginLeft": 20,
             "marginRight": 20,

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/CreditCardForm-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/CreditCardForm-tests.tsx.snap
@@ -27,14 +27,14 @@ exports[`renders properly 1`] = `
       allowFontScaling={true}
       ellipsizeMode="tail"
       fontSize={5}
-      lineHeight={9}
+      lineHeight={7}
       m={4}
       style={
         Array [
           Object {
             "fontFamily": "AGaramondPro-Semibold",
             "fontSize": 22,
-            "lineHeight": 32,
+            "lineHeight": 28,
             "marginBottom": 20,
             "marginLeft": 20,
             "marginRight": 20,

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/Registration-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/Registration-tests.tsx.snap
@@ -36,7 +36,7 @@ exports[`renders properly 1`] = `
         allowFontScaling={true}
         ellipsizeMode="tail"
         fontSize={5}
-        lineHeight={9}
+        lineHeight={7}
         m={4}
         mb={3}
         style={
@@ -44,7 +44,7 @@ exports[`renders properly 1`] = `
             Object {
               "fontFamily": "AGaramondPro-Semibold",
               "fontSize": 22,
-              "lineHeight": 32,
+              "lineHeight": 28,
               "marginBottom": 10,
               "marginLeft": 20,
               "marginRight": 20,

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/SelectMaxBid-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/SelectMaxBid-tests.tsx.snap
@@ -26,14 +26,14 @@ exports[`renders properly 1`] = `
     allowFontScaling={true}
     ellipsizeMode="tail"
     fontSize={5}
-    lineHeight={9}
+    lineHeight={7}
     m={4}
     style={
       Array [
         Object {
           "fontFamily": "AGaramondPro-Semibold",
           "fontSize": 22,
-          "lineHeight": 32,
+          "lineHeight": 28,
           "marginBottom": 20,
           "marginLeft": 20,
           "marginRight": 20,

--- a/src/lib/Containers/__tests__/__snapshots__/BidFlow-tests.tsx.snap
+++ b/src/lib/Containers/__tests__/__snapshots__/BidFlow-tests.tsx.snap
@@ -100,14 +100,14 @@ exports[`renders properly 1`] = `
           allowFontScaling={true}
           ellipsizeMode="tail"
           fontSize={5}
-          lineHeight={9}
+          lineHeight={7}
           m={4}
           style={
             Array [
               Object {
                 "fontFamily": "AGaramondPro-Semibold",
                 "fontSize": 22,
-                "lineHeight": 32,
+                "lineHeight": 28,
                 "marginBottom": 20,
                 "marginLeft": 20,
                 "marginRight": 20,


### PR DESCRIPTION
finishes https://artsyproduct.atlassian.net/browse/PURCHASE-225

This PR removes the spacing between the icon and the message on the bid result screen. Below is a screenshot for a successful bid but this applies to any message pattern.

## Screenshots

<img width="598" alt="screen_shot_2018-06-26_at_3_43_43_pm" src="https://user-images.githubusercontent.com/386234/41936968-ff52de82-795c-11e8-830d-ed0086b8ac1f.png">

![screen shot 2018-06-26 at 5 44 46 pm](https://user-images.githubusercontent.com/386234/41941006-accc0376-7968-11e8-8929-8579784bafba.png)
![screen shot 2018-06-26 at 5 44 54 pm](https://user-images.githubusercontent.com/386234/41941002-aca1bd78-7968-11e8-9aa9-2a3c58512062.png)
![screen shot 2018-06-26 at 5 44 52 pm](https://user-images.githubusercontent.com/386234/41941003-acac5fda-7968-11e8-9231-5028b47bb77b.png)
![screen shot 2018-06-26 at 5 44 49 pm](https://user-images.githubusercontent.com/386234/41941004-acb7cda2-7968-11e8-9c5c-5c3be9b6ac6f.png)

#skip_new_tests