### PR TITLE
There should be more space visually between conditions of sale checkbox and place bid button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Master
 
+* There should be more space visually between conditions of sale checkbox and place bid button - yuki24
+
 ### 1.5.7
 
 * Fixes the `commitMutation` compatibility by not throwing errors - yuki24

--- a/src/lib/Components/Bidding/Components/BidInfoRow.tsx
+++ b/src/lib/Components/Bidding/Components/BidInfoRow.tsx
@@ -17,7 +17,7 @@ export class BidInfoRow extends React.Component<BidInfoRowProps> {
 
     return (
       <TouchableWithoutFeedback onPress={onPress}>
-        <Row p={4} {...props}>
+        <Row p={4} pb={3} mb={1} {...props}>
           <Col>
             <SerifSemibold16>{label}</SerifSemibold16>
           </Col>
@@ -25,7 +25,7 @@ export class BidInfoRow extends React.Component<BidInfoRowProps> {
           <Col alignItems="flex-end">{value && <Serif16 numberOfLines={1}>{value}</Serif16>}</Col>
 
           <Col alignItems="flex-end" flexGrow={0} flexShrink={0} flexBasis="auto" flex={null}>
-            <Sans12 color="purple100" ml={3} mb={2}>
+            <Sans12 color="purple100" ml={3} mb={1}>
               {Boolean(value) ? "Edit" : "Add"}
             </Sans12>
           </Col>

--- a/src/lib/Components/Bidding/Components/PaymentInfo.tsx
+++ b/src/lib/Components/Bidding/Components/PaymentInfo.tsx
@@ -63,19 +63,23 @@ export class PaymentInfo extends React.Component<PaymentInfoProps> {
     return (
       <BiddingThemeProvider>
         <View>
-          <Divider mb={2} />
+          <Divider />
+
           <BidInfoRow
-            label="Credit Card"
+            label="Credit card"
             value={token && this.formatCard(token)}
             onPress={() => this.presentCreditCardForm()}
           />
-          <Divider mb={2} />
+
+          <Divider />
+
           <BidInfoRow
             label="Billing address"
             value={billingAddress && this.formatAddress(billingAddress)}
             onPress={() => this.presentBillingAddressForm()}
           />
-          <Divider mb={2} />
+
+          <Divider />
         </View>
       </BiddingThemeProvider>
     )

--- a/src/lib/Components/Bidding/Components/__tests__/__snapshots__/PaymentInfo-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Components/__tests__/__snapshots__/PaymentInfo-tests.tsx.snap
@@ -6,14 +6,12 @@ exports[`renders properly 1`] = `
     border={1}
     borderBottomWidth={0}
     borderColor="black10"
-    mb={2}
     style={
       Array [
         Object {
           "borderColor": "#E5E5E5",
           "borderStyle": "solid",
           "borderWidth": 1,
-          "marginBottom": 5,
           "width": "100%",
         },
         undefined,
@@ -30,6 +28,7 @@ exports[`renders properly 1`] = `
     flexDirection="row"
     hitSlop={undefined}
     justifyContent="space-between"
+    mb={1}
     nativeID={undefined}
     onLayout={undefined}
     onResponderGrant={[Function]}
@@ -39,10 +38,12 @@ exports[`renders properly 1`] = `
     onResponderTerminationRequest={[Function]}
     onStartShouldSetResponder={[Function]}
     p={4}
+    pb={3}
     style={
       Array [
         Object {
-          "paddingBottom": 20,
+          "marginBottom": 3,
+          "paddingBottom": 10,
           "paddingLeft": 20,
           "paddingRight": 20,
           "paddingTop": 20,
@@ -82,7 +83,7 @@ exports[`renders properly 1`] = `
           ]
         }
       >
-        Credit Card
+        Credit card
       </Text>
     </View>
     <View
@@ -140,7 +141,7 @@ exports[`renders properly 1`] = `
         ellipsizeMode="tail"
         fontSize={1}
         lineHeight={1}
-        mb={2}
+        mb={1}
         ml={3}
         style={
           Array [
@@ -149,7 +150,7 @@ exports[`renders properly 1`] = `
               "fontFamily": "Unica77LL-Regular",
               "fontSize": 12,
               "lineHeight": 16,
-              "marginBottom": 5,
+              "marginBottom": 3,
               "marginLeft": 10,
             },
             undefined,
@@ -164,14 +165,12 @@ exports[`renders properly 1`] = `
     border={1}
     borderBottomWidth={0}
     borderColor="black10"
-    mb={2}
     style={
       Array [
         Object {
           "borderColor": "#E5E5E5",
           "borderStyle": "solid",
           "borderWidth": 1,
-          "marginBottom": 5,
           "width": "100%",
         },
         undefined,
@@ -188,6 +187,7 @@ exports[`renders properly 1`] = `
     flexDirection="row"
     hitSlop={undefined}
     justifyContent="space-between"
+    mb={1}
     nativeID={undefined}
     onLayout={undefined}
     onResponderGrant={[Function]}
@@ -197,10 +197,12 @@ exports[`renders properly 1`] = `
     onResponderTerminationRequest={[Function]}
     onStartShouldSetResponder={[Function]}
     p={4}
+    pb={3}
     style={
       Array [
         Object {
-          "paddingBottom": 20,
+          "marginBottom": 3,
+          "paddingBottom": 10,
           "paddingLeft": 20,
           "paddingRight": 20,
           "paddingTop": 20,
@@ -298,7 +300,7 @@ exports[`renders properly 1`] = `
         ellipsizeMode="tail"
         fontSize={1}
         lineHeight={1}
-        mb={2}
+        mb={1}
         ml={3}
         style={
           Array [
@@ -307,7 +309,7 @@ exports[`renders properly 1`] = `
               "fontFamily": "Unica77LL-Regular",
               "fontSize": 12,
               "lineHeight": 16,
-              "marginBottom": 5,
+              "marginBottom": 3,
               "marginLeft": 10,
             },
             undefined,
@@ -322,14 +324,12 @@ exports[`renders properly 1`] = `
     border={1}
     borderBottomWidth={0}
     borderColor="black10"
-    mb={2}
     style={
       Array [
         Object {
           "borderColor": "#E5E5E5",
           "borderStyle": "solid",
           "borderWidth": 1,
-          "marginBottom": 5,
           "width": "100%",
         },
         undefined,

--- a/src/lib/Components/Bidding/Elements/Typography.tsx
+++ b/src/lib/Components/Bidding/Elements/Typography.tsx
@@ -80,6 +80,7 @@ export const SerifSemibold16 = props => <SerifSemibold fontSize={3} lineHeight={
 export const SerifSemibold18 = props => <SerifSemibold fontSize={4} lineHeight={6} {...props} />
 export const SerifSemibold22 = props => <SerifSemibold fontSize={5} lineHeight={9} {...props} />
 
+export const SerifSemibold18t = props => <SerifSemibold fontSize={4} lineHeight={4} {...props} />
 export const SerifSemibold22t = props => <SerifSemibold fontSize={5} lineHeight={7} {...props} />
 
 export const SerifItalic12 = props => <SerifItalic fontSize={1} lineHeight={1} {...props} />

--- a/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
@@ -9,7 +9,7 @@ import { metaphysics } from "../../../metaphysics"
 import { Schema, screenTrack, track } from "../../../utils/track"
 
 import { Flex } from "../Elements/Flex"
-import { Serif14, SerifItalic14, SerifSemibold14, SerifSemibold18 } from "../Elements/Typography"
+import { Serif14, SerifItalic14, SerifSemibold14, SerifSemibold18t } from "../Elements/Typography"
 
 import { BiddingThemeProvider } from "../Components/BiddingThemeProvider"
 import { BidInfoRow } from "../Components/BidInfoRow"
@@ -327,7 +327,7 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
 
           <View>
             <Flex m={4} mt={0} alignItems="center">
-              <SerifSemibold18>{artwork.artist_names}</SerifSemibold18>
+              <SerifSemibold18t>{artwork.artist_names}</SerifSemibold18t>
               <SerifSemibold14>Lot {lot_label}</SerifSemibold14>
 
               <SerifItalic14 color="black60" textAlign="center">
@@ -335,7 +335,7 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
               </SerifItalic14>
             </Flex>
 
-            <Divider mb={2} />
+            <Divider />
 
             <BidInfoRow label="Max bid" value={this.props.bid.display} onPress={() => this.goBackToSelectMaxBid()} />
 
@@ -355,7 +355,7 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
 
           <View>
             {requiresCheckbox ? (
-              <Checkbox justifyContent="center" onPress={() => this.onConditionsOfSaleCheckboxPressed()}>
+              <Checkbox mb={4} justifyContent="center" onPress={() => this.onConditionsOfSaleCheckboxPressed()}>
                 <Serif14 mt={2} color="black60">
                   You agree to{" "}
                   <LinkText onPress={() => this.onConditionsOfSaleLinkPressed()}>Conditions of Sale</LinkText>

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmBid-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmBid-tests.tsx.snap
@@ -138,13 +138,13 @@ exports[`renders properly 1`] = `
         allowFontScaling={true}
         ellipsizeMode="tail"
         fontSize={4}
-        lineHeight={6}
+        lineHeight={4}
         style={
           Array [
             Object {
               "fontFamily": "AGaramondPro-Semibold",
               "fontSize": 18,
-              "lineHeight": 26,
+              "lineHeight": 22,
             },
             undefined,
           ]
@@ -220,14 +220,12 @@ exports[`renders properly 1`] = `
       border={1}
       borderBottomWidth={0}
       borderColor="black10"
-      mb={2}
       style={
         Array [
           Object {
             "borderColor": "#E5E5E5",
             "borderStyle": "solid",
             "borderWidth": 1,
-            "marginBottom": 5,
             "width": "100%",
           },
           undefined,
@@ -244,6 +242,7 @@ exports[`renders properly 1`] = `
       flexDirection="row"
       hitSlop={undefined}
       justifyContent="space-between"
+      mb={1}
       nativeID={undefined}
       onLayout={undefined}
       onResponderGrant={[Function]}
@@ -253,10 +252,12 @@ exports[`renders properly 1`] = `
       onResponderTerminationRequest={[Function]}
       onStartShouldSetResponder={[Function]}
       p={4}
+      pb={3}
       style={
         Array [
           Object {
-            "paddingBottom": 20,
+            "marginBottom": 3,
+            "paddingBottom": 10,
             "paddingLeft": 20,
             "paddingRight": 20,
             "paddingTop": 20,
@@ -354,7 +355,7 @@ exports[`renders properly 1`] = `
           ellipsizeMode="tail"
           fontSize={1}
           lineHeight={1}
-          mb={2}
+          mb={1}
           ml={3}
           style={
             Array [
@@ -363,7 +364,7 @@ exports[`renders properly 1`] = `
                 "fontFamily": "Unica77LL-Regular",
                 "fontSize": 12,
                 "lineHeight": 16,
-                "marginBottom": 5,
+                "marginBottom": 3,
                 "marginLeft": 10,
               },
               undefined,
@@ -404,6 +405,7 @@ exports[`renders properly 1`] = `
       flexDirection="row"
       hitSlop={undefined}
       justifyContent="center"
+      mb={4}
       nativeID={undefined}
       onLayout={undefined}
       onPress={[Function]}
@@ -415,7 +417,9 @@ exports[`renders properly 1`] = `
       onStartShouldSetResponder={[Function]}
       style={
         Array [
-          Object {},
+          Object {
+            "marginBottom": 20,
+          },
           undefined,
         ]
       }

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/Registration-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/Registration-tests.tsx.snap
@@ -467,14 +467,12 @@ exports[`renders properly for a user without a credit card 1`] = `
         border={1}
         borderBottomWidth={0}
         borderColor="black10"
-        mb={2}
         style={
           Array [
             Object {
               "borderColor": "#E5E5E5",
               "borderStyle": "solid",
               "borderWidth": 1,
-              "marginBottom": 5,
               "width": "100%",
             },
             undefined,
@@ -491,6 +489,7 @@ exports[`renders properly for a user without a credit card 1`] = `
         flexDirection="row"
         hitSlop={undefined}
         justifyContent="space-between"
+        mb={1}
         nativeID={undefined}
         onLayout={undefined}
         onResponderGrant={[Function]}
@@ -500,10 +499,12 @@ exports[`renders properly for a user without a credit card 1`] = `
         onResponderTerminationRequest={[Function]}
         onStartShouldSetResponder={[Function]}
         p={4}
+        pb={3}
         style={
           Array [
             Object {
-              "paddingBottom": 20,
+              "marginBottom": 3,
+              "paddingBottom": 10,
               "paddingLeft": 20,
               "paddingRight": 20,
               "paddingTop": 20,
@@ -543,7 +544,7 @@ exports[`renders properly for a user without a credit card 1`] = `
               ]
             }
           >
-            Credit Card
+            Credit card
           </Text>
         </View>
         <View
@@ -580,7 +581,7 @@ exports[`renders properly for a user without a credit card 1`] = `
             ellipsizeMode="tail"
             fontSize={1}
             lineHeight={1}
-            mb={2}
+            mb={1}
             ml={3}
             style={
               Array [
@@ -589,7 +590,7 @@ exports[`renders properly for a user without a credit card 1`] = `
                   "fontFamily": "Unica77LL-Regular",
                   "fontSize": 12,
                   "lineHeight": 16,
-                  "marginBottom": 5,
+                  "marginBottom": 3,
                   "marginLeft": 10,
                 },
                 undefined,
@@ -604,14 +605,12 @@ exports[`renders properly for a user without a credit card 1`] = `
         border={1}
         borderBottomWidth={0}
         borderColor="black10"
-        mb={2}
         style={
           Array [
             Object {
               "borderColor": "#E5E5E5",
               "borderStyle": "solid",
               "borderWidth": 1,
-              "marginBottom": 5,
               "width": "100%",
             },
             undefined,
@@ -628,6 +627,7 @@ exports[`renders properly for a user without a credit card 1`] = `
         flexDirection="row"
         hitSlop={undefined}
         justifyContent="space-between"
+        mb={1}
         nativeID={undefined}
         onLayout={undefined}
         onResponderGrant={[Function]}
@@ -637,10 +637,12 @@ exports[`renders properly for a user without a credit card 1`] = `
         onResponderTerminationRequest={[Function]}
         onStartShouldSetResponder={[Function]}
         p={4}
+        pb={3}
         style={
           Array [
             Object {
-              "paddingBottom": 20,
+              "marginBottom": 3,
+              "paddingBottom": 10,
               "paddingLeft": 20,
               "paddingRight": 20,
               "paddingTop": 20,
@@ -717,7 +719,7 @@ exports[`renders properly for a user without a credit card 1`] = `
             ellipsizeMode="tail"
             fontSize={1}
             lineHeight={1}
-            mb={2}
+            mb={1}
             ml={3}
             style={
               Array [
@@ -726,7 +728,7 @@ exports[`renders properly for a user without a credit card 1`] = `
                   "fontFamily": "Unica77LL-Regular",
                   "fontSize": 12,
                   "lineHeight": 16,
-                  "marginBottom": 5,
+                  "marginBottom": 3,
                   "marginLeft": 10,
                 },
                 undefined,
@@ -741,14 +743,12 @@ exports[`renders properly for a user without a credit card 1`] = `
         border={1}
         borderBottomWidth={0}
         borderColor="black10"
-        mb={2}
         style={
           Array [
             Object {
               "borderColor": "#E5E5E5",
               "borderStyle": "solid",
               "borderWidth": 1,
-              "marginBottom": 5,
               "width": "100%",
             },
             undefined,


### PR DESCRIPTION
finishes https://artsyproduct.atlassian.net/browse/PURCHASE-181

 * Prefer `Credit card` over `Credit Card`
 * The margin between the checkbox and the Place bid button should be 20px when alreadt agreed and 40px when needs to show a checkbox
 * Changed the margin for each row to be 20px so all the elements will be accommodated well in iPhone SE's smaller screen
# Screenshots:

![screen_shot_2018-06-27_at_2_53_46_pm](https://user-images.githubusercontent.com/386234/41995879-24c04c26-7a21-11e8-98a2-29f564c783c3.png)

![screen_shot_2018-06-27_at_3_43_02_pm](https://user-images.githubusercontent.com/386234/41995781-df6dfa4c-7a20-11e8-8000-40adc159a700.png)

#skip_new_tests