### PR TITLE
Users see updated timer text style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Add disabled state to new button type, primary black - maxim
 * Registration screen handles when a user already has a credit card on file - sweir27
 * Removes unnecessary white spaces in the bid result screen - yuki24
+* Updates the text style and order for the auction timer - yuki24
 
 ### 1.5.6
 

--- a/src/lib/Components/Bidding/Components/Timer.tsx
+++ b/src/lib/Components/Bidding/Components/Timer.tsx
@@ -1,7 +1,7 @@
 import moment from "moment-timezone"
 import React from "react"
 import { Flex } from "../Elements/Flex"
-import { SansMedium12, SansMedium14 } from "../Elements/Typography"
+import { SansMedium12, SansMedium16t } from "../Elements/Typography"
 
 interface TimerProps {
   liveStartsAt?: string
@@ -68,7 +68,7 @@ export class Timer extends React.Component<TimerProps, TimerState> {
   formatDate(date: string) {
     return moment(date, moment.ISO_8601)
       .tz(moment.tz.guess(true))
-      .format("MMM D, ha")
+      .format("MMM D, h A")
   }
 
   upcomingLabel(currentState: AuctionTimerState, liveStartsAt: string, startsAt: string, endsAt: string) {
@@ -143,13 +143,13 @@ export class Timer extends React.Component<TimerProps, TimerState> {
 
     return (
       <Flex alignItems="center">
-        <SansMedium12>{this.state.label}</SansMedium12>
-        <SansMedium14>
+        <SansMedium16t>
           {this.padWithZero(duration.days())}d{"  "}
           {this.padWithZero(duration.hours())}h{"  "}
           {this.padWithZero(duration.minutes())}m{"  "}
           {this.padWithZero(duration.seconds())}s
-        </SansMedium14>
+        </SansMedium16t>
+        <SansMedium12>{this.state.label}</SansMedium12>
       </Flex>
     )
   }

--- a/src/lib/Components/Bidding/Components/__tests__/Timer-tests.tsx
+++ b/src/lib/Components/Bidding/Components/__tests__/Timer-tests.tsx
@@ -3,7 +3,7 @@ import React from "react"
 import "react-native"
 import * as renderer from "react-test-renderer"
 
-import { SansMedium12, SansMedium14 } from "../../Elements/Typography"
+import { SansMedium12, SansMedium16t } from "../../Elements/Typography"
 import { Timer } from "../Timer"
 
 const SECONDS = 1000
@@ -13,7 +13,7 @@ const dateNow = 1525983752000 // Thursday, May 10, 2018 8:22:32.000 PM UTC in mi
 
 const getTimerLabel = timerComponent => timerComponent.root.findByType(SansMedium12).props.children
 
-const getTimerText = timerComponent => timerComponent.root.findByType(SansMedium14).props.children.join("")
+const getTimerText = timerComponent => timerComponent.root.findByType(SansMedium16t).props.children.join("")
 
 let pastTime
 let futureTime
@@ -124,7 +124,7 @@ it("shows month, date, and hour adjusted for the timezone where the user is", ()
   // Thursday, May 14, 2018 1:00:00.000 PM PDT in LA
   const timer = renderer.create(<Timer endsAt="2018-05-14T20:00:00+00:00" />)
 
-  expect(getTimerLabel(timer)).toEqual("Ends May 14, 1pm")
+  expect(getTimerLabel(timer)).toEqual("Ends May 14, 1 PM")
 })
 
 describe("timer transitions", () => {

--- a/src/lib/Components/Bidding/Elements/Typography.tsx
+++ b/src/lib/Components/Bidding/Elements/Typography.tsx
@@ -64,6 +64,8 @@ export const SansMedium14 = props => <SansMedium fontSize={2} lineHeight={5} {..
 export const SansMedium16 = props => <SansMedium fontSize={3} lineHeight={6} {...props} />
 export const SansMedium18 = props => <SansMedium fontSize={4} lineHeight={8} {...props} />
 
+export const SansMedium16t = props => <SansMedium fontSize={3} lineHeight={5} {...props} />
+
 export const Serif12 = props => <Serif fontSize={1} lineHeight={1} {...props} />
 export const Serif14 = props => <Serif fontSize={2} lineHeight={2} {...props} />
 export const Serif16 = props => <Serif fontSize={3} lineHeight={5} {...props} />

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmBid-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmBid-tests.tsx.snap
@@ -70,32 +70,13 @@ exports[`renders properly 1`] = `
         accessible={true}
         allowFontScaling={true}
         ellipsizeMode="tail"
-        fontSize={1}
-        lineHeight={1}
-        style={
-          Array [
-            Object {
-              "fontFamily": "Unica77LL-Medium",
-              "fontSize": 12,
-              "lineHeight": 16,
-            },
-            undefined,
-          ]
-        }
-      >
-        Ends Invalid date
-      </Text>
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-        fontSize={2}
+        fontSize={3}
         lineHeight={5}
         style={
           Array [
             Object {
               "fontFamily": "Unica77LL-Medium",
-              "fontSize": 14,
+              "fontSize": 16,
               "lineHeight": 24,
             },
             undefined,
@@ -113,6 +94,25 @@ exports[`renders properly 1`] = `
           
         NaN
         s
+      </Text>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        fontSize={1}
+        lineHeight={1}
+        style={
+          Array [
+            Object {
+              "fontFamily": "Unica77LL-Medium",
+              "fontSize": 12,
+              "lineHeight": 16,
+            },
+            undefined,
+          ]
+        }
+      >
+        Ends Invalid date
       </Text>
     </View>
   </View>

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/Registration-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/Registration-tests.tsx.snap
@@ -71,32 +71,13 @@ exports[`renders properly for a user with a credit card 1`] = `
           accessible={true}
           allowFontScaling={true}
           ellipsizeMode="tail"
-          fontSize={1}
-          lineHeight={1}
-          style={
-            Array [
-              Object {
-                "fontFamily": "Unica77LL-Medium",
-                "fontSize": 12,
-                "lineHeight": 16,
-              },
-              undefined,
-            ]
-          }
-        >
-          Ends Invalid date
-        </Text>
-        <Text
-          accessible={true}
-          allowFontScaling={true}
-          ellipsizeMode="tail"
-          fontSize={2}
+          fontSize={3}
           lineHeight={5}
           style={
             Array [
               Object {
                 "fontFamily": "Unica77LL-Medium",
-                "fontSize": 14,
+                "fontSize": 16,
                 "lineHeight": 24,
               },
               undefined,
@@ -114,6 +95,25 @@ exports[`renders properly for a user with a credit card 1`] = `
             
           NaN
           s
+        </Text>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          fontSize={1}
+          lineHeight={1}
+          style={
+            Array [
+              Object {
+                "fontFamily": "Unica77LL-Medium",
+                "fontSize": 12,
+                "lineHeight": 16,
+              },
+              undefined,
+            ]
+          }
+        >
+          Ends Invalid date
         </Text>
       </View>
       <Text
@@ -395,32 +395,13 @@ exports[`renders properly for a user without a credit card 1`] = `
           accessible={true}
           allowFontScaling={true}
           ellipsizeMode="tail"
-          fontSize={1}
-          lineHeight={1}
-          style={
-            Array [
-              Object {
-                "fontFamily": "Unica77LL-Medium",
-                "fontSize": 12,
-                "lineHeight": 16,
-              },
-              undefined,
-            ]
-          }
-        >
-          Ends Invalid date
-        </Text>
-        <Text
-          accessible={true}
-          allowFontScaling={true}
-          ellipsizeMode="tail"
-          fontSize={2}
+          fontSize={3}
           lineHeight={5}
           style={
             Array [
               Object {
                 "fontFamily": "Unica77LL-Medium",
-                "fontSize": 14,
+                "fontSize": 16,
                 "lineHeight": 24,
               },
               undefined,
@@ -438,6 +419,25 @@ exports[`renders properly for a user without a credit card 1`] = `
             
           NaN
           s
+        </Text>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          fontSize={1}
+          lineHeight={1}
+          style={
+            Array [
+              Object {
+                "fontFamily": "Unica77LL-Medium",
+                "fontSize": 12,
+                "lineHeight": 16,
+              },
+              undefined,
+            ]
+          }
+        >
+          Ends Invalid date
         </Text>
       </View>
       <Text


### PR DESCRIPTION
finishes https://artsyproduct.atlassian.net/browse/PURCHASE-228

The timer's text style and order were updated about two weeks ago and this PR addresses the change.

## Screenshots

<img width="1062" alt="screen_shot_2018-06-27_at_7_44_21_pm" src="https://user-images.githubusercontent.com/386234/42005742-194ff01c-7a44-11e8-8125-7706321faccf.png">
<img width="1047" alt="screen shot 2018-06-27 at 7 44 47 pm" src="https://user-images.githubusercontent.com/386234/42005914-e08ee7b4-7a44-11e8-894b-322c159e1c38.png">

#skip_new_tests