### PR TITLE
Cc form placeholders #trivial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Master
 
+* Add placeholders to credit card form - erikdstock
+
 ### 1.5.7
 
 * Fixes the `commitMutation` compatibility by not throwing errors - yuki24

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -130,7 +130,7 @@ PODS:
     - Sentry (~> 3.9.0)
     - Sentry/KSCrash (~> 3.9.0)
   - Stripe (11.2.0)
-  - tipsi-stripe (5.2.1):
+  - tipsi-stripe (5.2.4):
     - React
     - Stripe (~> 11.2.0)
   - UIView+BooleanAnimations (1.0.2)
@@ -209,7 +209,7 @@ SPEC CHECKSUMS:
   Sentry: e2707f9a6b498277d9620a48fcb1bd3b655c8473
   SentryReactNative: a292506edfa707119e3aa155892cdb07e453a93a
   Stripe: 898f83a95d72180c6eb4acd65b2ae6158fc6a8bd
-  tipsi-stripe: 7cb9ec05e2b76170f9eec68227fca11aec49863f
+  tipsi-stripe: 25a3f6ba746e9a27f7b21e928c9974d016efcd77
   UIView+BooleanAnimations: a760be9a066036e55f298b7b7350a6cb14cfcd97
   yoga: 55da126afc384965b96bff46652464373b330add
 

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "simple-markdown": "^0.4.0",
     "styled-components": "^3.1.4",
     "styled-system": "^2.2.4",
-    "tipsi-stripe": "erikdstock/tipsi-stripe#fix-podspec-requires-packagejson"
+    "tipsi-stripe": "5.2.4"
   },
   "devDependencies": {
     "@playlyfe/gql": "^2.3.2",

--- a/src/lib/Components/Bidding/Screens/CreditCardForm.tsx
+++ b/src/lib/Components/Bidding/Screens/CreditCardForm.tsx
@@ -78,6 +78,9 @@ export class CreditCardForm extends Component<CreditCardFormProps, CreditCardFor
                 ref={this.paymentInfo}
                 style={styles.field}
                 onParamsChange={this.handleFieldParamsChange}
+                numberPlaceholder="Card number"
+                expirationPlaceholder="MM/YY"
+                cvcPlaceholde="CVC"
               />
             </Flex>
           </View>

--- a/yarn.lock
+++ b/yarn.lock
@@ -10563,9 +10563,9 @@ timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
-tipsi-stripe@erikdstock/tipsi-stripe#fix-podspec-requires-packagejson:
-  version "5.2.1"
-  resolved "https://codeload.github.com/erikdstock/tipsi-stripe/tar.gz/efcbc49dc7cf472099d8aa8c3fb2b64441fc5ea1"
+tipsi-stripe@5.2.4:
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/tipsi-stripe/-/tipsi-stripe-5.2.4.tgz#bb68509359f0efb36434c332df889d867b19047a"
 
 title-case@^2.1.0:
   version "2.1.1"


### PR DESCRIPTION
This PR fixes the default placeholder fields in our credit card form. It relied on a change to tipsi-stripe, which now merged also means we can update our package.json to use the official version rather than my fork.

![image](https://user-images.githubusercontent.com/9088720/42062814-e976c8c0-7afc-11e8-8fb8-828b602d001d.png)
