### PR TITLE
User should see the minutes in the auction timer when the sale does not on the hour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 * There should be more space visually between conditions of sale checkbox and place bid button - yuki24
 * Add placeholders to credit card form - erikdstock
+* Now users see the minutes in the auction timer when the sale does not on the hour - yuki24
 
 ### 1.5.7
 

--- a/src/lib/Components/Bidding/Components/Timer.tsx
+++ b/src/lib/Components/Bidding/Components/Timer.tsx
@@ -66,9 +66,10 @@ export class Timer extends React.Component<TimerProps, TimerState> {
   }
 
   formatDate(date: string) {
-    return moment(date, moment.ISO_8601)
-      .tz(moment.tz.guess(true))
-      .format("MMM D, h A")
+    const dateInMoment = moment(date, moment.ISO_8601).tz(moment.tz.guess(true))
+    const format = dateInMoment.minutes() === 0 ? "MMM D, h A" : "MMM D, h:mm A"
+
+    return dateInMoment.format(format)
   }
 
   upcomingLabel(currentState: AuctionTimerState, liveStartsAt: string, startsAt: string, endsAt: string) {

--- a/src/lib/Components/Bidding/Components/__tests__/Timer-tests.tsx
+++ b/src/lib/Components/Bidding/Components/__tests__/Timer-tests.tsx
@@ -131,6 +131,26 @@ it("shows month, date, and hour adjusted for the timezone where the user is", ()
   expect(getTimerLabel(timer)).toEqual("Ends May 14, 1 PM")
 })
 
+it("displays the minutes when the sale does not end on the hour", () => {
+  mockTimezone("America/New_York")
+
+  let timer = renderer.create(<Timer endsAt="2018-05-14T20:01:00+00:00" />)
+
+  expect(getTimerLabel(timer)).toEqual("Ends May 14, 4:01 PM")
+
+  timer = renderer.create(<Timer endsAt="2018-05-14T20:30:00+00:00" />)
+
+  expect(getTimerLabel(timer)).toEqual("Ends May 14, 4:30 PM")
+})
+
+it("omits the minutes when the sale ends on the hour", () => {
+  mockTimezone("America/New_York")
+
+  const timer = renderer.create(<Timer endsAt="2018-05-14T20:00:00+00:00" />)
+
+  expect(getTimerLabel(timer)).toEqual("Ends May 14, 4 PM")
+})
+
 describe("timer transitions", () => {
   it("transitions state from preview --> closing when the timer ends", () => {
     const timer = renderer.create(<Timer isPreview={true} startsAt={futureTime} endsAt={futureTime} />)

--- a/src/lib/Components/Bidding/Components/__tests__/Timer-tests.tsx
+++ b/src/lib/Components/Bidding/Components/__tests__/Timer-tests.tsx
@@ -15,6 +15,15 @@ const getTimerLabel = timerComponent => timerComponent.root.findByType(SansMediu
 
 const getTimerText = timerComponent => timerComponent.root.findByType(SansMedium16t).props.children.join("")
 
+const mockTimezone = timezone => {
+  const mutatedResolvedOptions: any = Intl.DateTimeFormat().resolvedOptions()
+  const mutatedDateTimeFormat: any = Intl.DateTimeFormat()
+
+  mutatedResolvedOptions.timeZone = timezone
+  mutatedDateTimeFormat.resolvedOptions = () => mutatedResolvedOptions
+  Intl.DateTimeFormat = (() => mutatedDateTimeFormat) as any
+}
+
 let pastTime
 let futureTime
 
@@ -113,12 +122,7 @@ it("counts down to zero", () => {
 })
 
 it("shows month, date, and hour adjusted for the timezone where the user is", () => {
-  const mutatedResolvedOptions: any = Intl.DateTimeFormat().resolvedOptions()
-  const mutatedDateTimeFormat: any = Intl.DateTimeFormat()
-
-  mutatedResolvedOptions.timeZone = "America/Los_Angeles"
-  mutatedDateTimeFormat.resolvedOptions = () => mutatedResolvedOptions
-  Intl.DateTimeFormat = (() => mutatedDateTimeFormat) as any
+  mockTimezone("America/Los_Angeles")
 
   // Thursday, May 14, 2018 8:00:00.000 PM UTC
   // Thursday, May 14, 2018 1:00:00.000 PM PDT in LA


### PR DESCRIPTION
finishes https://artsyproduct.atlassian.net/browse/PURCHASE-149

Here is a screenshot for what it look like in the PR:

![timer](https://user-images.githubusercontent.com/386234/42114129-e5201ece-7bbb-11e8-8cef-e6aa938e6dfc.png)
