### PR TITLE
Fixes to the credit card form keyboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 * There should be more space visually between conditions of sale checkbox and place bid button - yuki24
 * Add placeholders to credit card form - erikdstock
+* Update credit card form to have more sophisticated keyboard behavior - sweir27
 
 ### 1.5.7
 

--- a/src/lib/Components/Bidding/Screens/CreditCardForm.tsx
+++ b/src/lib/Components/Bidding/Screens/CreditCardForm.tsx
@@ -1,6 +1,6 @@
 import { Fonts } from "lib/data/fonts"
 import React, { Component } from "react"
-import { NavigatorIOS, StyleSheet, View } from "react-native"
+import { NavigatorIOS, ScrollView, StyleSheet, View } from "react-native"
 import stripe, { PaymentCardTextField, StripeToken } from "tipsi-stripe"
 
 import { BiddingThemeProvider } from "../Components/BiddingThemeProvider"
@@ -49,6 +49,8 @@ export class CreditCardForm extends Component<CreditCardFormProps, CreditCardFor
     if (this.paymentInfo.value) {
       this.paymentInfo.value.setParams(this.state.params)
     }
+
+    this.paymentInfo.value.focus()
   }
 
   handleFieldParamsChange = (valid, params: PaymentCardTextFieldParams) => {
@@ -69,28 +71,30 @@ export class CreditCardForm extends Component<CreditCardFormProps, CreditCardFor
   render() {
     return (
       <BiddingThemeProvider>
-        <Container m={0}>
-          <View>
-            <Title>Your credit card</Title>
+        <ScrollView scrollEnabled={false}>
+          <Container m={0}>
+            <View>
+              <Title>Your credit card</Title>
 
-            <Flex m={4}>
-              <PaymentCardTextField
-                ref={this.paymentInfo}
-                style={styles.field}
-                onParamsChange={this.handleFieldParamsChange}
-                numberPlaceholder="Card number"
-                expirationPlaceholder="MM/YY"
-                cvcPlaceholde="CVC"
-              />
-            </Flex>
-          </View>
+              <Flex m={4}>
+                <PaymentCardTextField
+                  ref={this.paymentInfo}
+                  style={styles.field}
+                  onParamsChange={this.handleFieldParamsChange}
+                  numberPlaceholder="Card number"
+                  expirationPlaceholder="MM/YY"
+                  cvcPlaceholde="CVC"
+                />
+              </Flex>
+            </View>
 
-          <View>
-            <Flex m={4}>
-              <Button text="Add credit card" onPress={this.state.valid ? () => this.tokenizeCardAndSubmit() : null} />
-            </Flex>
-          </View>
-        </Container>
+            <View>
+              <Flex m={4}>
+                <Button text="Add credit card" onPress={this.state.valid ? () => this.tokenizeCardAndSubmit() : null} />
+              </Flex>
+            </View>
+          </Container>
+        </ScrollView>
       </BiddingThemeProvider>
     )
   }

--- a/src/lib/Components/Bidding/Screens/CreditCardForm.tsx
+++ b/src/lib/Components/Bidding/Screens/CreditCardForm.tsx
@@ -3,6 +3,7 @@ import React, { Component } from "react"
 import { NavigatorIOS, ScrollView, StyleSheet, View } from "react-native"
 import stripe, { PaymentCardTextField, StripeToken } from "tipsi-stripe"
 
+import BottomAlignedButtonWrapper from "lib/Components/Buttons/BottomAlignedButtonWrapper"
 import { BiddingThemeProvider } from "../Components/BiddingThemeProvider"
 import { Button } from "../Components/Button"
 import { Container } from "../Components/Containers"
@@ -48,9 +49,8 @@ export class CreditCardForm extends Component<CreditCardFormProps, CreditCardFor
   componentDidMount() {
     if (this.paymentInfo.value) {
       this.paymentInfo.value.setParams(this.state.params)
+      this.paymentInfo.value.focus()
     }
-
-    this.paymentInfo.value.focus()
   }
 
   handleFieldParamsChange = (valid, params: PaymentCardTextFieldParams) => {
@@ -69,32 +69,40 @@ export class CreditCardForm extends Component<CreditCardFormProps, CreditCardFor
   }
 
   render() {
+    const buttonComponent = (
+      <Flex m={4}>
+        <Button
+          text="Add credit card"
+          disabled={!this.state.valid}
+          onPress={this.state.valid ? () => this.tokenizeCardAndSubmit() : null}
+        />
+      </Flex>
+    )
     return (
       <BiddingThemeProvider>
-        <ScrollView scrollEnabled={false}>
-          <Container m={0}>
-            <View>
-              <Title>Your credit card</Title>
+        <BottomAlignedButtonWrapper
+          onPress={this.state.valid ? () => this.tokenizeCardAndSubmit() : null}
+          buttonComponent={buttonComponent}
+        >
+          <ScrollView scrollEnabled={false}>
+            <Container m={0}>
+              <View>
+                <Title>Your credit card</Title>
 
-              <Flex m={4}>
-                <PaymentCardTextField
-                  ref={this.paymentInfo}
-                  style={styles.field}
-                  onParamsChange={this.handleFieldParamsChange}
-                  numberPlaceholder="Card number"
-                  expirationPlaceholder="MM/YY"
-                  cvcPlaceholde="CVC"
-                />
-              </Flex>
-            </View>
-
-            <View>
-              <Flex m={4}>
-                <Button text="Add credit card" onPress={this.state.valid ? () => this.tokenizeCardAndSubmit() : null} />
-              </Flex>
-            </View>
-          </Container>
-        </ScrollView>
+                <Flex m={4}>
+                  <PaymentCardTextField
+                    ref={this.paymentInfo}
+                    style={styles.field}
+                    onParamsChange={this.handleFieldParamsChange}
+                    numberPlaceholder="Card number"
+                    expirationPlaceholder="MM/YY"
+                    cvcPlaceholde="CVC"
+                  />
+                </Flex>
+              </View>
+            </Container>
+          </ScrollView>
+        </BottomAlignedButtonWrapper>
       </BiddingThemeProvider>
     )
   }

--- a/src/lib/Components/Bidding/Screens/__tests__/CreditCardForm-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/CreditCardForm-tests.tsx
@@ -31,6 +31,24 @@ it("calls the onSubmit() callback with valid credit card when ADD CREDIT CARD is
   expect(onSubmitMock).toHaveBeenCalledWith(stripeToken, creditCard)
 })
 
+it("is disabled while the form is invalid", () => {
+  stripe.createTokenWithCard.mockReturnValueOnce(stripeToken)
+  jest.useFakeTimers()
+  const component = renderer.create(<CreditCardForm onSubmit={onSubmitMock} navigator={{ pop: () => null } as any} />)
+
+  component.root.instance.setState({ valid: false, params: creditCard })
+  expect(component.root.findByType(Button).props.disabled).toEqual(true)
+})
+
+it("is enabled while the form is valid", () => {
+  stripe.createTokenWithCard.mockReturnValueOnce(stripeToken)
+  jest.useFakeTimers()
+  const component = renderer.create(<CreditCardForm onSubmit={onSubmitMock} navigator={{ pop: () => null } as any} />)
+
+  component.root.instance.setState({ valid: true, params: creditCard })
+  expect(component.root.findByType(Button).props.disabled).toEqual(false)
+})
+
 const creditCard = {
   number: "4242424242424242",
   expMonth: "04",

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/CreditCardForm-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/CreditCardForm-tests.tsx.snap
@@ -2,148 +2,176 @@
 
 exports[`renders properly 1`] = `
 <View
-  flex={1}
-  flexDirection="column"
-  justifyContent="space-between"
-  m={0}
+  enabled={true}
+  keyboardVerticalOffset={15}
+  onLayout={[Function]}
   style={
     Array [
       Object {
-        "flexBasis": 0,
-        "flexGrow": 1,
-        "flexShrink": 1,
-        "marginBottom": 0,
-        "marginLeft": 0,
-        "marginRight": 0,
-        "marginTop": 0,
+        "flex": 1,
       },
-      undefined,
+      Object {
+        "paddingBottom": 0,
+      },
     ]
   }
 >
-  <View>
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
-      fontSize={5}
-      lineHeight={7}
-      m={4}
-      style={
-        Array [
-          Object {
-            "fontFamily": "AGaramondPro-Semibold",
-            "fontSize": 22,
-            "lineHeight": 28,
-            "marginBottom": 20,
-            "marginLeft": 20,
-            "marginRight": 20,
-            "marginTop": 20,
-            "textAlign": "center",
-          },
-          undefined,
-        ]
+  <View
+    style={
+      Object {
+        "flexGrow": 1,
       }
-      textAlign="center"
+    }
+  >
+    <RCTScrollView
+      scrollEnabled={false}
     >
-      Your credit card
-    </Text>
-    <View
-      m={4}
-      style={
-        Array [
-          Object {
-            "marginBottom": 20,
-            "marginLeft": 20,
-            "marginRight": 20,
-            "marginTop": 20,
-          },
-          undefined,
-        ]
-      }
-    >
-      PaymentCardTextField
-    </View>
+      <View>
+        <View
+          flex={1}
+          flexDirection="column"
+          justifyContent="space-between"
+          m={0}
+          style={
+            Array [
+              Object {
+                "flexBasis": 0,
+                "flexGrow": 1,
+                "flexShrink": 1,
+                "marginBottom": 0,
+                "marginLeft": 0,
+                "marginRight": 0,
+                "marginTop": 0,
+              },
+              undefined,
+            ]
+          }
+        >
+          <View>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              fontSize={5}
+              lineHeight={7}
+              m={4}
+              style={
+                Array [
+                  Object {
+                    "fontFamily": "AGaramondPro-Semibold",
+                    "fontSize": 22,
+                    "lineHeight": 28,
+                    "marginBottom": 20,
+                    "marginLeft": 20,
+                    "marginRight": 20,
+                    "marginTop": 20,
+                    "textAlign": "center",
+                  },
+                  undefined,
+                ]
+              }
+              textAlign="center"
+            >
+              Your credit card
+            </Text>
+            <View
+              m={4}
+              style={
+                Array [
+                  Object {
+                    "marginBottom": 20,
+                    "marginLeft": 20,
+                    "marginRight": 20,
+                    "marginTop": 20,
+                  },
+                  undefined,
+                ]
+              }
+            >
+              PaymentCardTextField
+            </View>
+          </View>
+        </View>
+      </View>
+    </RCTScrollView>
   </View>
-  <View>
+  <View
+    m={4}
+    style={
+      Array [
+        Object {
+          "marginBottom": 20,
+          "marginLeft": 20,
+          "marginRight": 20,
+          "marginTop": 20,
+        },
+        undefined,
+      ]
+    }
+  >
     <View
-      m={4}
+      height={50}
       style={
         Array [
           Object {
-            "marginBottom": 20,
-            "marginLeft": 20,
-            "marginRight": 20,
-            "marginTop": 20,
+            "height": 50,
           },
           undefined,
         ]
       }
     >
       <View
-        height={50}
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hasTVPreferredFocus={undefined}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        nativeID={undefined}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
-          Array [
-            Object {
-              "height": 50,
-            },
-            undefined,
-          ]
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "rgba(229, 229, 229, 1)",
+            "borderRadius": 2,
+            "flex": 1,
+            "justifyContent": "center",
+          }
         }
+        testID={undefined}
+        tvParallaxProperties={undefined}
       >
         <View
-          accessibilityComponentType={undefined}
-          accessibilityLabel={undefined}
-          accessibilityTraits={undefined}
-          accessible={true}
-          hasTVPreferredFocus={undefined}
-          hitSlop={undefined}
-          isTVSelectable={true}
-          nativeID={undefined}
-          onLayout={undefined}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          style={
-            Object {
-              "alignItems": "center",
-              "backgroundColor": "rgba(0, 0, 0, 1)",
-              "borderRadius": 2,
-              "flex": 1,
-              "justifyContent": "center",
-            }
-          }
-          testID={undefined}
-          tvParallaxProperties={undefined}
+          style={null}
         >
-          <View
-            style={null}
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "fontSize": 14,
+                },
+                Object {
+                  "color": "white",
+                  "opacity": 1,
+                },
+                Object {
+                  "fontFamily": "Unica77LL-Medium",
+                },
+              ]
+            }
           >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "fontSize": 14,
-                  },
-                  Object {
-                    "color": "white",
-                    "opacity": 1,
-                  },
-                  Object {
-                    "fontFamily": "Unica77LL-Medium",
-                  },
-                ]
-              }
-            >
-              Add credit card
-            </Text>
-          </View>
+            Add credit card
+          </Text>
         </View>
       </View>
     </View>

--- a/src/lib/Components/Buttons/BottomAlignedButtonWrapper.tsx
+++ b/src/lib/Components/Buttons/BottomAlignedButtonWrapper.tsx
@@ -1,0 +1,28 @@
+import React from "react"
+import { Dimensions, KeyboardAvoidingView, View } from "react-native"
+
+export interface BottomAlignedProps extends React.Props<JSX.Element> {
+  onPress: () => void
+  verticalOffset?: number
+  buttonComponent: any
+}
+
+// TODO: Remove this once React Native has been updated
+const isPhoneX = Dimensions.get("window").height === 812 && Dimensions.get("window").width === 375
+const defaultVerticalOffset = isPhoneX ? 30 : 15
+
+const BottomAlignedButtonWrapper: React.SFC<BottomAlignedProps> = props => (
+  <KeyboardAvoidingView
+    behavior="padding"
+    keyboardVerticalOffset={props.verticalOffset || defaultVerticalOffset}
+    style={{ flex: 1 }}
+  >
+    <View key="space-eater" style={{ flexGrow: 1 }}>
+      {props.children}
+    </View>
+
+    {props.buttonComponent}
+  </KeyboardAvoidingView>
+)
+
+export default BottomAlignedButtonWrapper

--- a/src/lib/Components/Consignments/Components/DoneButton.tsx
+++ b/src/lib/Components/Consignments/Components/DoneButton.tsx
@@ -15,6 +15,7 @@ const DoneButton: React.SFC<DoneButtonProps> = props => {
     paddingTop: 18,
     height: 56,
   }
+  // This uses an outdated version of the BottomAlignedButton
   return (
     <BottomAlignedButton
       onPress={props.onPress}


### PR DESCRIPTION
This PR updates the credit card form in the bidding flow to:
- Focus on the cc form when the component is rendered
- Have a button that slides up with the keyboard and is disabled when the inputs aren't valid.

Screenshot:
![image](https://user-images.githubusercontent.com/2081340/42184325-2466460e-7e13-11e8-855a-e1b3945a8123.png)

gif:
![cc-button](https://user-images.githubusercontent.com/2081340/42184331-29d3c904-7e13-11e8-86a3-e039997cb47f.gif)

#skip_new_tests