### PR TITLE
Billing address keyboard optimizations #trivial

### DIFF
--- a/src/lib/Components/Bidding/Components/Input.tsx
+++ b/src/lib/Components/Bidding/Components/Input.tsx
@@ -41,6 +41,7 @@ export class Input extends Component<InputProps, InputState> {
   }
 
   onFocus() {
+    // this fails right now
     this.setState({ borderColor: "purple100" })
   }
 

--- a/src/lib/Components/Bidding/Components/Input.tsx
+++ b/src/lib/Components/Bidding/Components/Input.tsx
@@ -4,6 +4,11 @@ import { TextInput, TextInputProps } from "../Elements/TextInput"
 
 interface InputProps extends TextInputProps, TextInputProperties {
   error?: boolean
+  // In order to create a ref to a lower-level input component from a higher-level parent,
+  // we pass in a function defined on the parent and call it with a pointer to the current Input.
+  refName?: any
+  createCustomRef?: any
+  customOnBlur?: any
 }
 
 class InputState {
@@ -19,20 +24,23 @@ export class Input extends Component<InputProps, InputState> {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
-    this.setState({
-      borderColor: nextProps.error ? "red100" : "black10",
-    })
+  componentDidUpdate(prevProps) {
+    if (this.props.error !== prevProps.error) {
+      this.setState({ borderColor: this.props.error ? "red100" : "black10" })
+    }
   }
 
   onBlur() {
+    if (this.props.customOnBlur) {
+      this.props.customOnBlur()
+    }
+
     this.setState({
       borderColor: this.props.error ? "red100" : "black10",
     })
   }
 
   onFocus() {
-    // this fails right now
     this.setState({ borderColor: "purple100" })
   }
 
@@ -44,6 +52,7 @@ export class Input extends Component<InputProps, InputState> {
         fontSize={3}
         onBlur={() => this.onBlur()}
         onFocus={() => this.onFocus()}
+        ref={component => this.props.createCustomRef && this.props.createCustomRef(this.props.refName, component)}
         p={3}
         pb={2}
         {...this.props}

--- a/src/lib/Components/Bidding/Components/Input.tsx
+++ b/src/lib/Components/Bidding/Components/Input.tsx
@@ -32,6 +32,7 @@ export class Input extends Component<InputProps, InputState> {
   }
 
   onFocus() {
+    // this fails right now
     this.setState({ borderColor: "purple100" })
   }
 

--- a/src/lib/Components/Bidding/Screens/BillingAddress.tsx
+++ b/src/lib/Components/Bidding/Screens/BillingAddress.tsx
@@ -2,7 +2,7 @@ import React from "react"
 
 import { Schema, screenTrack, track } from "../../../utils/track"
 
-import { Dimensions, KeyboardAvoidingView, NavigatorIOS, ScrollView, View } from "react-native"
+import { Dimensions, KeyboardAvoidingView, NavigatorIOS, ScrollView, TextInputProperties, View } from "react-native"
 
 import { Flex } from "../Elements/Flex"
 import { Sans12, Serif16 } from "../Elements/Typography"

--- a/src/lib/Components/Bidding/Screens/BillingAddress.tsx
+++ b/src/lib/Components/Bidding/Screens/BillingAddress.tsx
@@ -2,7 +2,7 @@ import React from "react"
 
 import { Schema, screenTrack, track } from "../../../utils/track"
 
-import { Dimensions, KeyboardAvoidingView, NavigatorIOS, ScrollView, TextInputProperties, View } from "react-native"
+import { Dimensions, KeyboardAvoidingView, NavigatorIOS, ScrollView, View } from "react-native"
 
 import { Flex } from "../Elements/Flex"
 import { Sans12, Serif16 } from "../Elements/Typography"
@@ -16,6 +16,22 @@ import { Container } from "../Components/Containers"
 import { Input } from "../Components/Input"
 import { Title } from "../Components/Title"
 import { Address } from "../types"
+
+interface StyledInputInterface {
+  /** The object which styled components wraps */
+  root?: {
+    focus?: () => void
+    blur?: () => void
+  }
+}
+
+const StyledInput = ({ label, error, refName, createCustomRef, ...props }) => (
+  <Flex mb={4}>
+    <Serif16 mb={2}>{label}</Serif16>
+    <Input mb={3} error={Boolean(error)} refName={refName} createCustomRef={createCustomRef} {...props} />
+    {error && <Sans12 color="red100">{error}</Sans12>}
+  </Flex>
+)
 
 interface BillingAddressProps {
   onSubmit?: (values: Address) => void
@@ -40,8 +56,17 @@ interface BillingAddressState {
   context_screen_owner_type: null,
 })
 export class BillingAddress extends React.Component<BillingAddressProps, BillingAddressState> {
+  private fullName: StyledInputInterface
+  private addressLine1: StyledInputInterface
+  private addressLine2: StyledInputInterface
+  private city: StyledInputInterface
+  private stateProvinceRegion: StyledInputInterface
+  private postalCode: StyledInputInterface
+
   constructor(props) {
     super(props)
+
+    this.selectNextInput = this.selectNextInput.bind(this)
 
     this.state = {
       values: { ...this.props.billingAddress },
@@ -86,6 +111,31 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
     this.props.navigator.pop()
   }
 
+  selectNextInput = nextComponent => {
+    const inputs = [
+      this.fullName,
+      this.addressLine1,
+      this.addressLine2,
+      this.city,
+      this.stateProvinceRegion,
+      this.postalCode,
+    ]
+
+    for (const input of inputs) {
+      if (input === nextComponent) {
+        input.root.focus()
+      } else {
+        input.root.blur()
+      }
+    }
+  }
+
+  createCustomRef(refName: string, component: any) {
+    if (component) {
+      return (this[refName] = component)
+    }
+  }
+
   render() {
     // TODO: Remove this once React Native has been updated
     const isPhoneX = Dimensions.get("window").height === 812 && Dimensions.get("window").width === 375
@@ -109,6 +159,9 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
                   autoCapitalize="words"
                   autoFocus={true}
                   returnKeyType="next"
+                  refName="fullName"
+                  createCustomRef={this.createCustomRef.bind(this)}
+                  onSubmitEditing={() => this.selectNextInput(this.addressLine1)}
                   {...this.propsForInput("fullName")}
                 />
 
@@ -117,6 +170,9 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
                   placeholder="Enter your street address"
                   autoCapitalize="words"
                   returnKeyType="next"
+                  refName="addressLine1"
+                  createCustomRef={this.createCustomRef.bind(this)}
+                  onSubmitEditing={() => this.selectNextInput(this.addressLine2)}
                   {...this.propsForInput("addressLine1")}
                 />
 
@@ -125,16 +181,30 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
                   placeholder="Enter your apt, floor, suite, etc."
                   autoCapitalize="words"
                   returnKeyType="next"
+                  refName="addressLine2"
+                  createCustomRef={this.createCustomRef.bind(this)}
+                  onSubmitEditing={() => this.selectNextInput(this.city)}
                   {...this.propsForInput("addressLine2")}
                 />
 
-                <StyledInput label="City" placeholder="Enter city" {...this.propsForInput("city")} />
+                <StyledInput
+                  label="City"
+                  placeholder="Enter city"
+                  returnKeyType="next"
+                  refName="city"
+                  createCustomRef={this.createCustomRef.bind(this)}
+                  onSubmitEditing={() => this.selectNextInput(this.stateProvinceRegion)}
+                  {...this.propsForInput("city")}
+                />
 
                 <StyledInput
                   label="State, Province, or Region"
                   placeholder="Enter state, province, or region"
                   autoCapitalize="words"
                   returnKeyType="next"
+                  refName="stateProvinceRegion"
+                  createCustomRef={this.createCustomRef.bind(this)}
+                  onSubmitEditing={() => this.selectNextInput(this.postalCode)}
                   {...this.propsForInput("state")}
                 />
 
@@ -142,6 +212,8 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
                   label="Postal code"
                   placeholder="Enter your postal code"
                   autoCapitalize="words"
+                  refName="postalCode"
+                  createCustomRef={this.createCustomRef.bind(this)}
                   {...this.propsForInput("postalCode")}
                 />
 
@@ -158,16 +230,8 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
     return {
       error: this.state.errors[field],
       onChangeText: value => this.setState({ values: { ...this.state.values, [field]: value } }),
-      onBlur: () => this.validateField(field),
+      customOnBlur: () => this.validateField(field),
       value: this.state.values[field],
     }
   }
 }
-type StyledInputProps = { label: string; error: string } & TextInputProperties
-const StyledInput: (input: StyledInputProps) => JSX.Element = ({ label, error, ...props }) => (
-  <Flex mb={4}>
-    <Serif16 mb={2}>{label}</Serif16>
-    <Input mb={3} error={Boolean(error)} {...props} />
-    {error && <Sans12 color="red100">{error}</Sans12>}
-  </Flex>
-)

--- a/src/lib/Components/Bidding/Screens/BillingAddress.tsx
+++ b/src/lib/Components/Bidding/Screens/BillingAddress.tsx
@@ -2,7 +2,7 @@ import React from "react"
 
 import { Schema, screenTrack, track } from "../../../utils/track"
 
-import { NavigatorIOS, ScrollView, View } from "react-native"
+import { Dimensions, KeyboardAvoidingView, NavigatorIOS, ScrollView, TextInputProperties, View } from "react-native"
 
 import { Flex } from "../Elements/Flex"
 import { Sans12, Serif16 } from "../Elements/Typography"
@@ -87,11 +87,16 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
   }
 
   render() {
+    // TODO: Remove this once React Native has been updated
+    const isPhoneX = Dimensions.get("window").height === 812 && Dimensions.get("window").width === 375
+    const defaultVerticalOffset = isPhoneX ? 30 : 15
+
     return (
       <BiddingThemeProvider>
         <View>
           <BackButton navigator={this.props.navigator} />
 
+<<<<<<< HEAD
           <ScrollView>
             <Container>
               <Title mt={0} mb={6}>
@@ -138,6 +143,61 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
               <Button text="Add billing address" onPress={() => this.onSubmit()} />
             </Container>
           </ScrollView>
+=======
+          <KeyboardAvoidingView behavior="padding" keyboardVerticalOffset={defaultVerticalOffset} style={{ flex: 1 }}>
+            <ScrollView>
+              <Container>
+                <Title mt={0} mb={6}>
+                  Your billing address
+                </Title>
+
+                <StyledInput
+                  label="Full name"
+                  placeholder="Enter your full name"
+                  autoCapitalize="words"
+                  autoFocus={true}
+                  returnKeyType="next"
+                  {...this.propsForInput("fullName")}
+                />
+
+                <StyledInput
+                  label="Address line 1"
+                  placeholder="Enter your street address"
+                  autoCapitalize="words"
+                  returnKeyType="next"
+                  {...this.propsForInput("addressLine1")}
+                />
+
+                <StyledInput
+                  label="Address line 2 (optional)"
+                  placeholder="Enter your apt, floor, suite, etc."
+                  autoCapitalize="words"
+                  returnKeyType="next"
+                  {...this.propsForInput("addressLine2")}
+                />
+
+                <StyledInput label="City" placeholder="Enter city" {...this.propsForInput("city")} />
+
+                <StyledInput
+                  label="State, Province, or Region"
+                  placeholder="Enter state, province, or region"
+                  autoCapitalize="words"
+                  returnKeyType="next"
+                  {...this.propsForInput("state")}
+                />
+
+                <StyledInput
+                  label="Postal code"
+                  placeholder="Enter your postal code"
+                  autoCapitalize="words"
+                  {...this.propsForInput("postalCode")}
+                />
+
+                <Button text="Add billing address" onPress={() => this.onSubmit()} />
+              </Container>
+            </ScrollView>
+          </KeyboardAvoidingView>
+>>>>>>> adds scroll view to billing address and moves button above keyboard
         </View>
       </BiddingThemeProvider>
     )
@@ -152,8 +212,8 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
     }
   }
 }
-
-const StyledInput = ({ label, error, ...props }) => (
+type StyledInputProps = { label: string; error: string } & TextInputProperties
+const StyledInput: (input: StyledInputProps) => JSX.Element = ({ label, error, ...props }) => (
   <Flex mb={4}>
     <Serif16 mb={2}>{label}</Serif16>
     <Input mb={3} error={Boolean(error)} {...props} />

--- a/src/lib/Components/Bidding/Screens/BillingAddress.tsx
+++ b/src/lib/Components/Bidding/Screens/BillingAddress.tsx
@@ -96,54 +96,6 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
         <View>
           <BackButton navigator={this.props.navigator} />
 
-<<<<<<< HEAD
-          <ScrollView>
-            <Container>
-              <Title mt={0} mb={6}>
-                Your billing address
-              </Title>
-
-              <StyledInput
-                label="Full name"
-                placeholder="Add your full name"
-                autoCapitalize="words"
-                {...this.propsForInput("fullName")}
-              />
-
-              <StyledInput
-                label="Address line 1"
-                placeholder="Add your street address"
-                autoCapitalize="words"
-                {...this.propsForInput("addressLine1")}
-              />
-
-              <StyledInput
-                label="Address line 2 (optional)"
-                placeholder="Add your apt, floor, suite, etc."
-                autoCapitalize="words"
-                {...this.propsForInput("addressLine2")}
-              />
-
-              <StyledInput label="City" placeholder="Add your city" {...this.propsForInput("city")} />
-
-              <StyledInput
-                label="State, Province, or Region"
-                placeholder="Add your state, province, or region"
-                autoCapitalize="words"
-                {...this.propsForInput("state")}
-              />
-
-              <StyledInput
-                label="Postal code"
-                placeholder="Add your postal code"
-                autoCapitalize="words"
-                {...this.propsForInput("postalCode")}
-              />
-
-              <Button text="Add billing address" onPress={() => this.onSubmit()} />
-            </Container>
-          </ScrollView>
-=======
           <KeyboardAvoidingView behavior="padding" keyboardVerticalOffset={defaultVerticalOffset} style={{ flex: 1 }}>
             <ScrollView>
               <Container>
@@ -197,7 +149,6 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
               </Container>
             </ScrollView>
           </KeyboardAvoidingView>
->>>>>>> adds scroll view to billing address and moves button above keyboard
         </View>
       </BiddingThemeProvider>
     )

--- a/src/lib/Components/Bidding/Screens/BillingAddress.tsx
+++ b/src/lib/Components/Bidding/Screens/BillingAddress.tsx
@@ -2,7 +2,7 @@ import React from "react"
 
 import { Schema, screenTrack, track } from "../../../utils/track"
 
-import { Dimensions, KeyboardAvoidingView, NavigatorIOS, ScrollView, TextInputProperties, View } from "react-native"
+import { Dimensions, KeyboardAvoidingView, NavigatorIOS, ScrollView, View } from "react-native"
 
 import { Flex } from "../Elements/Flex"
 import { Sans12, Serif16 } from "../Elements/Typography"
@@ -143,10 +143,10 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
 
     return (
       <BiddingThemeProvider>
-        <View>
-          <BackButton navigator={this.props.navigator} />
+        <KeyboardAvoidingView behavior="padding" keyboardVerticalOffset={defaultVerticalOffset} style={{ flex: 1 }}>
+          <View>
+            <BackButton navigator={this.props.navigator} />
 
-          <KeyboardAvoidingView behavior="padding" keyboardVerticalOffset={defaultVerticalOffset} style={{ flex: 1 }}>
             <ScrollView>
               <Container>
                 <Title mt={0} mb={6}>
@@ -155,7 +155,7 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
 
                 <StyledInput
                   label="Full name"
-                  placeholder="Enter your full name"
+                  placeholder="Add your full name"
                   autoCapitalize="words"
                   autoFocus={true}
                   returnKeyType="next"
@@ -167,7 +167,7 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
 
                 <StyledInput
                   label="Address line 1"
-                  placeholder="Enter your street address"
+                  placeholder="Add your street address"
                   autoCapitalize="words"
                   returnKeyType="next"
                   refName="addressLine1"
@@ -178,7 +178,7 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
 
                 <StyledInput
                   label="Address line 2 (optional)"
-                  placeholder="Enter your apt, floor, suite, etc."
+                  placeholder="Add your apt, floor, suite, etc."
                   autoCapitalize="words"
                   returnKeyType="next"
                   refName="addressLine2"
@@ -189,7 +189,7 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
 
                 <StyledInput
                   label="City"
-                  placeholder="Enter city"
+                  placeholder="Add your city"
                   returnKeyType="next"
                   refName="city"
                   createCustomRef={this.createCustomRef.bind(this)}
@@ -199,7 +199,7 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
 
                 <StyledInput
                   label="State, Province, or Region"
-                  placeholder="Enter state, province, or region"
+                  placeholder="Add your state, province, or region"
                   autoCapitalize="words"
                   returnKeyType="next"
                   refName="stateProvinceRegion"
@@ -210,7 +210,7 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
 
                 <StyledInput
                   label="Postal code"
-                  placeholder="Enter your postal code"
+                  placeholder="Add your postal code"
                   autoCapitalize="words"
                   refName="postalCode"
                   createCustomRef={this.createCustomRef.bind(this)}
@@ -220,8 +220,8 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
                 <Button text="Add billing address" onPress={() => this.onSubmit()} />
               </Container>
             </ScrollView>
-          </KeyboardAvoidingView>
-        </View>
+          </View>
+        </KeyboardAvoidingView>
       </BiddingThemeProvider>
     )
   }

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/BillingAddress-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/BillingAddress-tests.tsx.snap
@@ -1,41 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders properly 1`] = `
-<View>
-  <Image
-    accessibilityComponentType={undefined}
-    accessibilityLabel={undefined}
-    accessibilityTraits={undefined}
-    accessible={true}
-    hitSlop={undefined}
-    left={10}
-    nativeID={undefined}
-    onLayout={undefined}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
-    position="absolute"
-    source={
+<View
+  enabled={true}
+  keyboardVerticalOffset={15}
+  onLayout={[Function]}
+  style={
+    Array [
       Object {
-        "testUri": "../../../images/angle-left.png",
-      }
-    }
-    style={
-      Array [
-        Object {
-          "position": "absolute",
-        },
-        Object {
-          "zIndex": 10,
-        },
-      ]
-    }
-    testID={undefined}
-    top={10}
-  />
+        "flex": 1,
+      },
+      Object {
+        "paddingBottom": 0,
+      },
+    ]
+  }
+>
   <RCTScrollView>
     <View>
       <View
@@ -121,6 +101,7 @@ exports[`renders properly 1`] = `
           <TextInput
             allowFontScaling={true}
             autoCapitalize="words"
+            autoFocus={true}
             border={1}
             borderColor="black10"
             error={false}
@@ -131,7 +112,12 @@ exports[`renders properly 1`] = `
             onFocus={[Function]}
             p={3}
             pb={2}
+<<<<<<< HEAD
             placeholder="Add your full name"
+=======
+            placeholder="Enter your full name"
+            returnKeyType="next"
+>>>>>>> adds scroll view to billing address and moves button above keyboard
             style={
               Array [
                 Object {
@@ -198,7 +184,12 @@ exports[`renders properly 1`] = `
             onFocus={[Function]}
             p={3}
             pb={2}
+<<<<<<< HEAD
             placeholder="Add your street address"
+=======
+            placeholder="Enter your street address"
+            returnKeyType="next"
+>>>>>>> adds scroll view to billing address and moves button above keyboard
             style={
               Array [
                 Object {
@@ -265,7 +256,12 @@ exports[`renders properly 1`] = `
             onFocus={[Function]}
             p={3}
             pb={2}
+<<<<<<< HEAD
             placeholder="Add your apt, floor, suite, etc."
+=======
+            placeholder="Enter your apt, floor, suite, etc."
+            returnKeyType="next"
+>>>>>>> adds scroll view to billing address and moves button above keyboard
             style={
               Array [
                 Object {
@@ -398,7 +394,12 @@ exports[`renders properly 1`] = `
             onFocus={[Function]}
             p={3}
             pb={2}
+<<<<<<< HEAD
             placeholder="Add your state, province, or region"
+=======
+            placeholder="Enter state, province, or region"
+            returnKeyType="next"
+>>>>>>> adds scroll view to billing address and moves button above keyboard
             style={
               Array [
                 Object {
@@ -557,4 +558,4 @@ exports[`renders properly 1`] = `
     </View>
   </RCTScrollView>
 </View>
-`;
+`

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/BillingAddress-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/BillingAddress-tests.tsx.snap
@@ -104,18 +104,22 @@ exports[`renders properly 1`] = `
             autoFocus={true}
             border={1}
             borderColor="black10"
+            createCustomRef={[Function]}
+            customOnBlur={[Function]}
             error={false}
             fontSize={3}
             mb={3}
             onBlur={[Function]}
             onChangeText={[Function]}
             onFocus={[Function]}
+            onSubmitEditing={[Function]}
             p={3}
             pb={2}
 <<<<<<< HEAD
             placeholder="Add your full name"
 =======
             placeholder="Enter your full name"
+            refName="fullName"
             returnKeyType="next"
 >>>>>>> adds scroll view to billing address and moves button above keyboard
             style={
@@ -176,18 +180,22 @@ exports[`renders properly 1`] = `
             autoCapitalize="words"
             border={1}
             borderColor="black10"
+            createCustomRef={[Function]}
+            customOnBlur={[Function]}
             error={false}
             fontSize={3}
             mb={3}
             onBlur={[Function]}
             onChangeText={[Function]}
             onFocus={[Function]}
+            onSubmitEditing={[Function]}
             p={3}
             pb={2}
 <<<<<<< HEAD
             placeholder="Add your street address"
 =======
             placeholder="Enter your street address"
+            refName="addressLine1"
             returnKeyType="next"
 >>>>>>> adds scroll view to billing address and moves button above keyboard
             style={
@@ -248,18 +256,22 @@ exports[`renders properly 1`] = `
             autoCapitalize="words"
             border={1}
             borderColor="black10"
+            createCustomRef={[Function]}
+            customOnBlur={[Function]}
             error={false}
             fontSize={3}
             mb={3}
             onBlur={[Function]}
             onChangeText={[Function]}
             onFocus={[Function]}
+            onSubmitEditing={[Function]}
             p={3}
             pb={2}
 <<<<<<< HEAD
             placeholder="Add your apt, floor, suite, etc."
 =======
             placeholder="Enter your apt, floor, suite, etc."
+            refName="addressLine2"
             returnKeyType="next"
 >>>>>>> adds scroll view to billing address and moves button above keyboard
             style={
@@ -319,15 +331,24 @@ exports[`renders properly 1`] = `
             allowFontScaling={true}
             border={1}
             borderColor="black10"
+            createCustomRef={[Function]}
+            customOnBlur={[Function]}
             error={false}
             fontSize={3}
             mb={3}
             onBlur={[Function]}
             onChangeText={[Function]}
             onFocus={[Function]}
+            onSubmitEditing={[Function]}
             p={3}
             pb={2}
+<<<<<<< HEAD
             placeholder="Add your city"
+=======
+            placeholder="Enter city"
+            refName="city"
+            returnKeyType="next"
+>>>>>>> fixes scroll behavior
             style={
               Array [
                 Object {
@@ -386,18 +407,22 @@ exports[`renders properly 1`] = `
             autoCapitalize="words"
             border={1}
             borderColor="black10"
+            createCustomRef={[Function]}
+            customOnBlur={[Function]}
             error={false}
             fontSize={3}
             mb={3}
             onBlur={[Function]}
             onChangeText={[Function]}
             onFocus={[Function]}
+            onSubmitEditing={[Function]}
             p={3}
             pb={2}
 <<<<<<< HEAD
             placeholder="Add your state, province, or region"
 =======
             placeholder="Enter state, province, or region"
+            refName="stateProvinceRegion"
             returnKeyType="next"
 >>>>>>> adds scroll view to billing address and moves button above keyboard
             style={
@@ -458,6 +483,8 @@ exports[`renders properly 1`] = `
             autoCapitalize="words"
             border={1}
             borderColor="black10"
+            createCustomRef={[Function]}
+            customOnBlur={[Function]}
             error={false}
             fontSize={3}
             mb={3}
@@ -466,7 +493,12 @@ exports[`renders properly 1`] = `
             onFocus={[Function]}
             p={3}
             pb={2}
+<<<<<<< HEAD
             placeholder="Add your postal code"
+=======
+            placeholder="Enter your postal code"
+            refName="postalCode"
+>>>>>>> fixes scroll behavior
             style={
               Array [
                 Object {

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/BillingAddress-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/BillingAddress-tests.tsx.snap
@@ -16,62 +16,58 @@ exports[`renders properly 1`] = `
     ]
   }
 >
-  <RCTScrollView>
-    <View>
-      <View
-        flex={1}
-        flexDirection="column"
-        justifyContent="space-between"
-        m={4}
-        style={
-          Array [
-            Object {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
-              "marginBottom": 20,
-              "marginLeft": 20,
-              "marginRight": 20,
-              "marginTop": 20,
-            },
-            undefined,
-          ]
+  <View>
+    <Image
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      left={10}
+      nativeID={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      position="absolute"
+      source={
+        Object {
+          "testUri": "../../../images/angle-left.png",
         }
-      >
-        <Text
-          accessible={true}
-          allowFontScaling={true}
-          ellipsizeMode="tail"
-          fontSize={5}
-          lineHeight={7}
+      }
+      style={
+        Array [
+          Object {
+            "position": "absolute",
+          },
+          Object {
+            "zIndex": 10,
+          },
+        ]
+      }
+      testID={undefined}
+      top={10}
+    />
+    <RCTScrollView>
+      <View>
+        <View
+          flex={1}
+          flexDirection="column"
+          justifyContent="space-between"
           m={4}
-          mb={6}
-          mt={0}
           style={
             Array [
               Object {
-                "fontFamily": "AGaramondPro-Semibold",
-                "fontSize": 22,
-                "lineHeight": 28,
-                "marginBottom": 40,
+                "flexBasis": 0,
+                "flexGrow": 1,
+                "flexShrink": 1,
+                "marginBottom": 20,
                 "marginLeft": 20,
                 "marginRight": 20,
-                "marginTop": 0,
-                "textAlign": "center",
-              },
-              undefined,
-            ]
-          }
-          textAlign="center"
-        >
-          Your billing address
-        </Text>
-        <View
-          mb={4}
-          style={
-            Array [
-              Object {
-                "marginBottom": 20,
+                "marginTop": 20,
               },
               undefined,
             ]
@@ -81,513 +77,529 @@ exports[`renders properly 1`] = `
             accessible={true}
             allowFontScaling={true}
             ellipsizeMode="tail"
-            fontSize={3}
-            lineHeight={5}
-            mb={2}
+            fontSize={5}
+            lineHeight={7}
+            m={4}
+            mb={6}
+            mt={0}
             style={
               Array [
                 Object {
-                  "fontFamily": "AGaramondPro-Regular",
-                  "fontSize": 16,
-                  "lineHeight": 24,
-                  "marginBottom": 5,
+                  "fontFamily": "AGaramondPro-Semibold",
+                  "fontSize": 22,
+                  "lineHeight": 28,
+                  "marginBottom": 40,
+                  "marginLeft": 20,
+                  "marginRight": 20,
+                  "marginTop": 0,
+                  "textAlign": "center",
                 },
                 undefined,
               ]
             }
+            textAlign="center"
           >
-            Full name
+            Your billing address
           </Text>
-          <TextInput
-            allowFontScaling={true}
-            autoCapitalize="words"
-            autoFocus={true}
-            border={1}
-            borderColor="black10"
-            createCustomRef={[Function]}
-            customOnBlur={[Function]}
-            error={false}
-            fontSize={3}
-            mb={3}
-            onBlur={[Function]}
-            onChangeText={[Function]}
-            onFocus={[Function]}
-            onSubmitEditing={[Function]}
-            p={3}
-            pb={2}
-<<<<<<< HEAD
-            placeholder="Add your full name"
-=======
-            placeholder="Enter your full name"
-            refName="fullName"
-            returnKeyType="next"
->>>>>>> adds scroll view to billing address and moves button above keyboard
-            style={
-              Array [
-                Object {
-                  "borderColor": "#E5E5E5",
-                  "borderStyle": "solid",
-                  "borderWidth": 1,
-                  "fontFamily": "AGaramondPro-Regular",
-                  "fontSize": 16,
-                  "height": 40,
-                  "marginBottom": 10,
-                  "paddingBottom": 5,
-                  "paddingLeft": 10,
-                  "paddingRight": 10,
-                  "paddingTop": 10,
-                },
-                undefined,
-              ]
-            }
-            value={undefined}
-          />
-        </View>
-        <View
-          mb={4}
-          style={
-            Array [
-              Object {
-                "marginBottom": 20,
-              },
-              undefined,
-            ]
-          }
-        >
-          <Text
-            accessible={true}
-            allowFontScaling={true}
-            ellipsizeMode="tail"
-            fontSize={3}
-            lineHeight={5}
-            mb={2}
-            style={
-              Array [
-                Object {
-                  "fontFamily": "AGaramondPro-Regular",
-                  "fontSize": 16,
-                  "lineHeight": 24,
-                  "marginBottom": 5,
-                },
-                undefined,
-              ]
-            }
-          >
-            Address line 1
-          </Text>
-          <TextInput
-            allowFontScaling={true}
-            autoCapitalize="words"
-            border={1}
-            borderColor="black10"
-            createCustomRef={[Function]}
-            customOnBlur={[Function]}
-            error={false}
-            fontSize={3}
-            mb={3}
-            onBlur={[Function]}
-            onChangeText={[Function]}
-            onFocus={[Function]}
-            onSubmitEditing={[Function]}
-            p={3}
-            pb={2}
-<<<<<<< HEAD
-            placeholder="Add your street address"
-=======
-            placeholder="Enter your street address"
-            refName="addressLine1"
-            returnKeyType="next"
->>>>>>> adds scroll view to billing address and moves button above keyboard
-            style={
-              Array [
-                Object {
-                  "borderColor": "#E5E5E5",
-                  "borderStyle": "solid",
-                  "borderWidth": 1,
-                  "fontFamily": "AGaramondPro-Regular",
-                  "fontSize": 16,
-                  "height": 40,
-                  "marginBottom": 10,
-                  "paddingBottom": 5,
-                  "paddingLeft": 10,
-                  "paddingRight": 10,
-                  "paddingTop": 10,
-                },
-                undefined,
-              ]
-            }
-            value={undefined}
-          />
-        </View>
-        <View
-          mb={4}
-          style={
-            Array [
-              Object {
-                "marginBottom": 20,
-              },
-              undefined,
-            ]
-          }
-        >
-          <Text
-            accessible={true}
-            allowFontScaling={true}
-            ellipsizeMode="tail"
-            fontSize={3}
-            lineHeight={5}
-            mb={2}
-            style={
-              Array [
-                Object {
-                  "fontFamily": "AGaramondPro-Regular",
-                  "fontSize": 16,
-                  "lineHeight": 24,
-                  "marginBottom": 5,
-                },
-                undefined,
-              ]
-            }
-          >
-            Address line 2 (optional)
-          </Text>
-          <TextInput
-            allowFontScaling={true}
-            autoCapitalize="words"
-            border={1}
-            borderColor="black10"
-            createCustomRef={[Function]}
-            customOnBlur={[Function]}
-            error={false}
-            fontSize={3}
-            mb={3}
-            onBlur={[Function]}
-            onChangeText={[Function]}
-            onFocus={[Function]}
-            onSubmitEditing={[Function]}
-            p={3}
-            pb={2}
-<<<<<<< HEAD
-            placeholder="Add your apt, floor, suite, etc."
-=======
-            placeholder="Enter your apt, floor, suite, etc."
-            refName="addressLine2"
-            returnKeyType="next"
->>>>>>> adds scroll view to billing address and moves button above keyboard
-            style={
-              Array [
-                Object {
-                  "borderColor": "#E5E5E5",
-                  "borderStyle": "solid",
-                  "borderWidth": 1,
-                  "fontFamily": "AGaramondPro-Regular",
-                  "fontSize": 16,
-                  "height": 40,
-                  "marginBottom": 10,
-                  "paddingBottom": 5,
-                  "paddingLeft": 10,
-                  "paddingRight": 10,
-                  "paddingTop": 10,
-                },
-                undefined,
-              ]
-            }
-            value={undefined}
-          />
-        </View>
-        <View
-          mb={4}
-          style={
-            Array [
-              Object {
-                "marginBottom": 20,
-              },
-              undefined,
-            ]
-          }
-        >
-          <Text
-            accessible={true}
-            allowFontScaling={true}
-            ellipsizeMode="tail"
-            fontSize={3}
-            lineHeight={5}
-            mb={2}
-            style={
-              Array [
-                Object {
-                  "fontFamily": "AGaramondPro-Regular",
-                  "fontSize": 16,
-                  "lineHeight": 24,
-                  "marginBottom": 5,
-                },
-                undefined,
-              ]
-            }
-          >
-            City
-          </Text>
-          <TextInput
-            allowFontScaling={true}
-            border={1}
-            borderColor="black10"
-            createCustomRef={[Function]}
-            customOnBlur={[Function]}
-            error={false}
-            fontSize={3}
-            mb={3}
-            onBlur={[Function]}
-            onChangeText={[Function]}
-            onFocus={[Function]}
-            onSubmitEditing={[Function]}
-            p={3}
-            pb={2}
-<<<<<<< HEAD
-            placeholder="Add your city"
-=======
-            placeholder="Enter city"
-            refName="city"
-            returnKeyType="next"
->>>>>>> fixes scroll behavior
-            style={
-              Array [
-                Object {
-                  "borderColor": "#E5E5E5",
-                  "borderStyle": "solid",
-                  "borderWidth": 1,
-                  "fontFamily": "AGaramondPro-Regular",
-                  "fontSize": 16,
-                  "height": 40,
-                  "marginBottom": 10,
-                  "paddingBottom": 5,
-                  "paddingLeft": 10,
-                  "paddingRight": 10,
-                  "paddingTop": 10,
-                },
-                undefined,
-              ]
-            }
-            value={undefined}
-          />
-        </View>
-        <View
-          mb={4}
-          style={
-            Array [
-              Object {
-                "marginBottom": 20,
-              },
-              undefined,
-            ]
-          }
-        >
-          <Text
-            accessible={true}
-            allowFontScaling={true}
-            ellipsizeMode="tail"
-            fontSize={3}
-            lineHeight={5}
-            mb={2}
-            style={
-              Array [
-                Object {
-                  "fontFamily": "AGaramondPro-Regular",
-                  "fontSize": 16,
-                  "lineHeight": 24,
-                  "marginBottom": 5,
-                },
-                undefined,
-              ]
-            }
-          >
-            State, Province, or Region
-          </Text>
-          <TextInput
-            allowFontScaling={true}
-            autoCapitalize="words"
-            border={1}
-            borderColor="black10"
-            createCustomRef={[Function]}
-            customOnBlur={[Function]}
-            error={false}
-            fontSize={3}
-            mb={3}
-            onBlur={[Function]}
-            onChangeText={[Function]}
-            onFocus={[Function]}
-            onSubmitEditing={[Function]}
-            p={3}
-            pb={2}
-<<<<<<< HEAD
-            placeholder="Add your state, province, or region"
-=======
-            placeholder="Enter state, province, or region"
-            refName="stateProvinceRegion"
-            returnKeyType="next"
->>>>>>> adds scroll view to billing address and moves button above keyboard
-            style={
-              Array [
-                Object {
-                  "borderColor": "#E5E5E5",
-                  "borderStyle": "solid",
-                  "borderWidth": 1,
-                  "fontFamily": "AGaramondPro-Regular",
-                  "fontSize": 16,
-                  "height": 40,
-                  "marginBottom": 10,
-                  "paddingBottom": 5,
-                  "paddingLeft": 10,
-                  "paddingRight": 10,
-                  "paddingTop": 10,
-                },
-                undefined,
-              ]
-            }
-            value={undefined}
-          />
-        </View>
-        <View
-          mb={4}
-          style={
-            Array [
-              Object {
-                "marginBottom": 20,
-              },
-              undefined,
-            ]
-          }
-        >
-          <Text
-            accessible={true}
-            allowFontScaling={true}
-            ellipsizeMode="tail"
-            fontSize={3}
-            lineHeight={5}
-            mb={2}
-            style={
-              Array [
-                Object {
-                  "fontFamily": "AGaramondPro-Regular",
-                  "fontSize": 16,
-                  "lineHeight": 24,
-                  "marginBottom": 5,
-                },
-                undefined,
-              ]
-            }
-          >
-            Postal code
-          </Text>
-          <TextInput
-            allowFontScaling={true}
-            autoCapitalize="words"
-            border={1}
-            borderColor="black10"
-            createCustomRef={[Function]}
-            customOnBlur={[Function]}
-            error={false}
-            fontSize={3}
-            mb={3}
-            onBlur={[Function]}
-            onChangeText={[Function]}
-            onFocus={[Function]}
-            p={3}
-            pb={2}
-<<<<<<< HEAD
-            placeholder="Add your postal code"
-=======
-            placeholder="Enter your postal code"
-            refName="postalCode"
->>>>>>> fixes scroll behavior
-            style={
-              Array [
-                Object {
-                  "borderColor": "#E5E5E5",
-                  "borderStyle": "solid",
-                  "borderWidth": 1,
-                  "fontFamily": "AGaramondPro-Regular",
-                  "fontSize": 16,
-                  "height": 40,
-                  "marginBottom": 10,
-                  "paddingBottom": 5,
-                  "paddingLeft": 10,
-                  "paddingRight": 10,
-                  "paddingTop": 10,
-                },
-                undefined,
-              ]
-            }
-            value={undefined}
-          />
-        </View>
-        <View
-          height={50}
-          style={
-            Array [
-              Object {
-                "height": 50,
-              },
-              undefined,
-            ]
-          }
-        >
           <View
-            accessibilityComponentType={undefined}
-            accessibilityLabel={undefined}
-            accessibilityTraits={undefined}
-            accessible={true}
-            hasTVPreferredFocus={undefined}
-            hitSlop={undefined}
-            isTVSelectable={true}
-            nativeID={undefined}
-            onLayout={undefined}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
+            mb={4}
             style={
-              Object {
-                "alignItems": "center",
-                "backgroundColor": "rgba(0, 0, 0, 1)",
-                "borderRadius": 2,
-                "flex": 1,
-                "justifyContent": "center",
-              }
+              Array [
+                Object {
+                  "marginBottom": 20,
+                },
+                undefined,
+              ]
             }
-            testID={undefined}
-            tvParallaxProperties={undefined}
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              fontSize={3}
+              lineHeight={5}
+              mb={2}
+              style={
+                Array [
+                  Object {
+                    "fontFamily": "AGaramondPro-Regular",
+                    "fontSize": 16,
+                    "lineHeight": 24,
+                    "marginBottom": 5,
+                  },
+                  undefined,
+                ]
+              }
+            >
+              Full name
+            </Text>
+            <TextInput
+              allowFontScaling={true}
+              autoCapitalize="words"
+              autoFocus={true}
+              border={1}
+              borderColor="black10"
+              createCustomRef={[Function]}
+              customOnBlur={[Function]}
+              error={false}
+              fontSize={3}
+              mb={3}
+              onBlur={[Function]}
+              onChangeText={[Function]}
+              onFocus={[Function]}
+              onSubmitEditing={[Function]}
+              p={3}
+              pb={2}
+              placeholder="Add your full name"
+              refName="fullName"
+              returnKeyType="next"
+              style={
+                Array [
+                  Object {
+                    "borderColor": "#E5E5E5",
+                    "borderStyle": "solid",
+                    "borderWidth": 1,
+                    "fontFamily": "AGaramondPro-Regular",
+                    "fontSize": 16,
+                    "height": 40,
+                    "marginBottom": 10,
+                    "paddingBottom": 5,
+                    "paddingLeft": 10,
+                    "paddingRight": 10,
+                    "paddingTop": 10,
+                  },
+                  undefined,
+                ]
+              }
+              value={undefined}
+            />
+          </View>
+          <View
+            mb={4}
+            style={
+              Array [
+                Object {
+                  "marginBottom": 20,
+                },
+                undefined,
+              ]
+            }
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              fontSize={3}
+              lineHeight={5}
+              mb={2}
+              style={
+                Array [
+                  Object {
+                    "fontFamily": "AGaramondPro-Regular",
+                    "fontSize": 16,
+                    "lineHeight": 24,
+                    "marginBottom": 5,
+                  },
+                  undefined,
+                ]
+              }
+            >
+              Address line 1
+            </Text>
+            <TextInput
+              allowFontScaling={true}
+              autoCapitalize="words"
+              border={1}
+              borderColor="black10"
+              createCustomRef={[Function]}
+              customOnBlur={[Function]}
+              error={false}
+              fontSize={3}
+              mb={3}
+              onBlur={[Function]}
+              onChangeText={[Function]}
+              onFocus={[Function]}
+              onSubmitEditing={[Function]}
+              p={3}
+              pb={2}
+              placeholder="Add your street address"
+              refName="addressLine1"
+              returnKeyType="next"
+              style={
+                Array [
+                  Object {
+                    "borderColor": "#E5E5E5",
+                    "borderStyle": "solid",
+                    "borderWidth": 1,
+                    "fontFamily": "AGaramondPro-Regular",
+                    "fontSize": 16,
+                    "height": 40,
+                    "marginBottom": 10,
+                    "paddingBottom": 5,
+                    "paddingLeft": 10,
+                    "paddingRight": 10,
+                    "paddingTop": 10,
+                  },
+                  undefined,
+                ]
+              }
+              value={undefined}
+            />
+          </View>
+          <View
+            mb={4}
+            style={
+              Array [
+                Object {
+                  "marginBottom": 20,
+                },
+                undefined,
+              ]
+            }
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              fontSize={3}
+              lineHeight={5}
+              mb={2}
+              style={
+                Array [
+                  Object {
+                    "fontFamily": "AGaramondPro-Regular",
+                    "fontSize": 16,
+                    "lineHeight": 24,
+                    "marginBottom": 5,
+                  },
+                  undefined,
+                ]
+              }
+            >
+              Address line 2 (optional)
+            </Text>
+            <TextInput
+              allowFontScaling={true}
+              autoCapitalize="words"
+              border={1}
+              borderColor="black10"
+              createCustomRef={[Function]}
+              customOnBlur={[Function]}
+              error={false}
+              fontSize={3}
+              mb={3}
+              onBlur={[Function]}
+              onChangeText={[Function]}
+              onFocus={[Function]}
+              onSubmitEditing={[Function]}
+              p={3}
+              pb={2}
+              placeholder="Add your apt, floor, suite, etc."
+              refName="addressLine2"
+              returnKeyType="next"
+              style={
+                Array [
+                  Object {
+                    "borderColor": "#E5E5E5",
+                    "borderStyle": "solid",
+                    "borderWidth": 1,
+                    "fontFamily": "AGaramondPro-Regular",
+                    "fontSize": 16,
+                    "height": 40,
+                    "marginBottom": 10,
+                    "paddingBottom": 5,
+                    "paddingLeft": 10,
+                    "paddingRight": 10,
+                    "paddingTop": 10,
+                  },
+                  undefined,
+                ]
+              }
+              value={undefined}
+            />
+          </View>
+          <View
+            mb={4}
+            style={
+              Array [
+                Object {
+                  "marginBottom": 20,
+                },
+                undefined,
+              ]
+            }
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              fontSize={3}
+              lineHeight={5}
+              mb={2}
+              style={
+                Array [
+                  Object {
+                    "fontFamily": "AGaramondPro-Regular",
+                    "fontSize": 16,
+                    "lineHeight": 24,
+                    "marginBottom": 5,
+                  },
+                  undefined,
+                ]
+              }
+            >
+              City
+            </Text>
+            <TextInput
+              allowFontScaling={true}
+              border={1}
+              borderColor="black10"
+              createCustomRef={[Function]}
+              customOnBlur={[Function]}
+              error={false}
+              fontSize={3}
+              mb={3}
+              onBlur={[Function]}
+              onChangeText={[Function]}
+              onFocus={[Function]}
+              onSubmitEditing={[Function]}
+              p={3}
+              pb={2}
+              placeholder="Add your city"
+              refName="city"
+              returnKeyType="next"
+              style={
+                Array [
+                  Object {
+                    "borderColor": "#E5E5E5",
+                    "borderStyle": "solid",
+                    "borderWidth": 1,
+                    "fontFamily": "AGaramondPro-Regular",
+                    "fontSize": 16,
+                    "height": 40,
+                    "marginBottom": 10,
+                    "paddingBottom": 5,
+                    "paddingLeft": 10,
+                    "paddingRight": 10,
+                    "paddingTop": 10,
+                  },
+                  undefined,
+                ]
+              }
+              value={undefined}
+            />
+          </View>
+          <View
+            mb={4}
+            style={
+              Array [
+                Object {
+                  "marginBottom": 20,
+                },
+                undefined,
+              ]
+            }
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              fontSize={3}
+              lineHeight={5}
+              mb={2}
+              style={
+                Array [
+                  Object {
+                    "fontFamily": "AGaramondPro-Regular",
+                    "fontSize": 16,
+                    "lineHeight": 24,
+                    "marginBottom": 5,
+                  },
+                  undefined,
+                ]
+              }
+            >
+              State, Province, or Region
+            </Text>
+            <TextInput
+              allowFontScaling={true}
+              autoCapitalize="words"
+              border={1}
+              borderColor="black10"
+              createCustomRef={[Function]}
+              customOnBlur={[Function]}
+              error={false}
+              fontSize={3}
+              mb={3}
+              onBlur={[Function]}
+              onChangeText={[Function]}
+              onFocus={[Function]}
+              onSubmitEditing={[Function]}
+              p={3}
+              pb={2}
+              placeholder="Add your state, province, or region"
+              refName="stateProvinceRegion"
+              returnKeyType="next"
+              style={
+                Array [
+                  Object {
+                    "borderColor": "#E5E5E5",
+                    "borderStyle": "solid",
+                    "borderWidth": 1,
+                    "fontFamily": "AGaramondPro-Regular",
+                    "fontSize": 16,
+                    "height": 40,
+                    "marginBottom": 10,
+                    "paddingBottom": 5,
+                    "paddingLeft": 10,
+                    "paddingRight": 10,
+                    "paddingTop": 10,
+                  },
+                  undefined,
+                ]
+              }
+              value={undefined}
+            />
+          </View>
+          <View
+            mb={4}
+            style={
+              Array [
+                Object {
+                  "marginBottom": 20,
+                },
+                undefined,
+              ]
+            }
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              fontSize={3}
+              lineHeight={5}
+              mb={2}
+              style={
+                Array [
+                  Object {
+                    "fontFamily": "AGaramondPro-Regular",
+                    "fontSize": 16,
+                    "lineHeight": 24,
+                    "marginBottom": 5,
+                  },
+                  undefined,
+                ]
+              }
+            >
+              Postal code
+            </Text>
+            <TextInput
+              allowFontScaling={true}
+              autoCapitalize="words"
+              border={1}
+              borderColor="black10"
+              createCustomRef={[Function]}
+              customOnBlur={[Function]}
+              error={false}
+              fontSize={3}
+              mb={3}
+              onBlur={[Function]}
+              onChangeText={[Function]}
+              onFocus={[Function]}
+              p={3}
+              pb={2}
+              placeholder="Add your postal code"
+              refName="postalCode"
+              style={
+                Array [
+                  Object {
+                    "borderColor": "#E5E5E5",
+                    "borderStyle": "solid",
+                    "borderWidth": 1,
+                    "fontFamily": "AGaramondPro-Regular",
+                    "fontSize": 16,
+                    "height": 40,
+                    "marginBottom": 10,
+                    "paddingBottom": 5,
+                    "paddingLeft": 10,
+                    "paddingRight": 10,
+                    "paddingTop": 10,
+                  },
+                  undefined,
+                ]
+              }
+              value={undefined}
+            />
+          </View>
+          <View
+            height={50}
+            style={
+              Array [
+                Object {
+                  "height": 50,
+                },
+                undefined,
+              ]
+            }
           >
             <View
-              style={null}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "fontSize": 14,
-                    },
-                    Object {
-                      "color": "white",
-                      "opacity": 1,
-                    },
-                    Object {
-                      "fontFamily": "Unica77LL-Medium",
-                    },
-                  ]
+              accessibilityComponentType={undefined}
+              accessibilityLabel={undefined}
+              accessibilityTraits={undefined}
+              accessible={true}
+              hasTVPreferredFocus={undefined}
+              hitSlop={undefined}
+              isTVSelectable={true}
+              nativeID={undefined}
+              onLayout={undefined}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Object {
+                  "alignItems": "center",
+                  "backgroundColor": "rgba(0, 0, 0, 1)",
+                  "borderRadius": 2,
+                  "flex": 1,
+                  "justifyContent": "center",
                 }
+              }
+              testID={undefined}
+              tvParallaxProperties={undefined}
+            >
+              <View
+                style={null}
               >
-                Add billing address
-              </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "fontSize": 14,
+                      },
+                      Object {
+                        "color": "white",
+                        "opacity": 1,
+                      },
+                      Object {
+                        "fontFamily": "Unica77LL-Medium",
+                      },
+                    ]
+                  }
+                >
+                  Add billing address
+                </Text>
+              </View>
             </View>
           </View>
         </View>
       </View>
-    </View>
-  </RCTScrollView>
+    </RCTScrollView>
+  </View>
 </View>
-`
+`;

--- a/src/lib/Components/Consignments/Components/BottomAlignedButton.tsx
+++ b/src/lib/Components/Consignments/Components/BottomAlignedButton.tsx
@@ -33,7 +33,7 @@ export interface BottomAlignedProps extends React.Props<JSX.Element> {
   verticalOffset?: number
 }
 
-// TODO: Remove this once React Native has beem updated
+// TODO: Remove this once React Native has been updated
 const isPhoneX = Dimensions.get("window").height === 812 && Dimensions.get("window").width === 375
 const defaultVerticalOffset = isPhoneX ? 30 : 15
 


### PR DESCRIPTION
This PR:
- Updates the billing address form so you can scroll the elements above the keyboard
- Updates the billing address form to have "next" as the CTA and to advance to the next field when it is pressed

It was a little tricky to get that second part working. Major props to @orta for getting me started/helping (we do a similar thing on the consignments view).

I also found some weird behavior around the border colors on the input view, which I fixed by making sure we're passing through the `onBlur` as a differently-named-prop so we still get the default handler on the `TextInput`.

It's unfortunately difficult to test these things since I don't think we have `focus` and `blur` available in our test environment (in fact jest throws a warning saying so).

![billing-address](https://user-images.githubusercontent.com/2081340/42222727-f3e7def2-7ea3-11e8-9917-85a191228216.gif)
