### PR TITLE
Updates registration view to advance to correct result screen #trivial

### DIFF
--- a/src/lib/Components/Bidding/Screens/RegistrationResult.tsx
+++ b/src/lib/Components/Bidding/Screens/RegistrationResult.tsx
@@ -18,6 +18,7 @@ export enum RegistrationStatus {
   RegistrationStatusComplete = "RegistrationStatusComplete",
   RegistrationStatusPending = "RegistrationStatusPending",
   RegistrationStatusError = "RegistrationStatusError",
+  RegistrationStatusNetworkError = "RegistrationStatusNetworkError",
 }
 
 const Icons = {
@@ -44,6 +45,11 @@ const registrationErrorMessage = {
   description: "Please contact [support@artsy.net](mailto:support@artsy.net)\n" + "with any questions.",
 }
 
+const registrationNetworkErrorMessage = {
+  title: "An error occurred",
+  description: "Please\ncheck your internet connection\nand try again.",
+}
+
 export class RegistrationResult extends React.Component<RegistrationResultProps, null> {
   render() {
     const status = this.props.status
@@ -59,6 +65,9 @@ export class RegistrationResult extends React.Component<RegistrationResultProps,
         title = registrationPendingMessage.title
         msg = registrationPendingMessage.description
         break
+      case RegistrationStatus.RegistrationStatusNetworkError:
+        title = registrationNetworkErrorMessage.title
+        msg = registrationNetworkErrorMessage.description
       default:
         title = registrationErrorMessage.title
         msg = registrationErrorMessage.description

--- a/src/lib/Components/Bidding/__stories__/BidFlow.story.tsx
+++ b/src/lib/Components/Bidding/__stories__/BidFlow.story.tsx
@@ -17,7 +17,7 @@ import { MaxBidScreen } from "../Screens/SelectMaxBid"
 
 const testSaleArtworkID = "5b1e4d29275b2446aa139f37"
 const testArtworkID = "david-lynch-hand"
-const testSaleID = "david-lynch-foundation-benefit-auction-2018"
+const testSaleID = "shared-live-mocktion-k8s"
 
 const selectMaxBidQuery = graphql`
   query BidFlowSelectMaxBidRendererQuery($saleArtworkID: String!) {


### PR DESCRIPTION
This PR adds the "glue", meaning it hooks up the transition between the registration screen and the results screen.

@mennenia 's [PR](https://github.com/artsy/emission/pull/1137) added a nice abstraction around the `RegistrationResult` screen. Since the use-case is a bit simpler here (we're not trying to map error messages returned from MP with ones defined in Emission), it works nicely to have all of the statuses and messages defined in the `RegistrationResult` component. We can just pass the `status` and it will handle all of the display.