### PR TITLE
fix incorrect notification name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Master
 
+* Fix incorrect NSNotification name for sale registration - erikdstock
+
 ### 1.5.8
 
 * There should be more space visually between conditions of sale checkbox and place bid button - yuki24

--- a/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
@@ -297,7 +297,7 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
       ARAuctionID: this.props.sale_artwork.sale.id,
       ARAuctionArtworkID: this.props.sale_artwork.artwork.id,
     })
-    NativeModules.ARNotificationsManager.postNotificationName("ARAuctionArtworkRegistrationUpdatedNotification", {
+    NativeModules.ARNotificationsManager.postNotificationName("ARAuctionArtworkRegistrationUpdated", {
       ARAuctionID: this.props.sale_artwork.sale.id,
     })
 

--- a/src/lib/Components/Bidding/Screens/__tests__/ConfirmBid-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/ConfirmBid-tests.tsx
@@ -319,7 +319,7 @@ describe("polling to verify bid position", () => {
       component.root.findByType(Button).instance.props.onPress()
       jest.runAllTicks()
 
-      expect(mockPostNotificationName).toHaveBeenCalledWith("ARAuctionArtworkRegistrationUpdatedNotification", {
+      expect(mockPostNotificationName).toHaveBeenCalledWith("ARAuctionArtworkRegistrationUpdated", {
         ARAuctionID: "best-art-sale-in-town",
       })
       expect(mockPostNotificationName).toHaveBeenCalledWith("ARAuctionArtworkBidUpdated", {


### PR DESCRIPTION
@sweir27 - this line notifies the sale screen that the registration status has been updated. We had the name wrong due to a misreading of [this line](https://github.com/artsy/eigen/blob/master/Artsy/Constants/ARAppConstants.m#L19-L20) in emission:
```objc
NSString *const ARAuctionArtworkRegistrationUpdatedNotification = @"ARAuctionArtworkRegistrationUpdated";
```