### PR TITLE
Allow for editing the max bid once on the ConfirmBid screen without losing information #trivial

### DIFF
--- a/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
@@ -24,6 +24,7 @@ import { Title } from "../Components/Title"
 import { Address, Bid, BidderPositionResult, PaymentCardTextFieldParams, StripeToken } from "../types"
 
 import { BidResultScreen } from "./BidResult"
+import { SelectMaxBidEdit } from "./SelectMaxBidEdit"
 
 import { ConfirmBid_me } from "__generated__/ConfirmBid_me.graphql"
 import { ConfirmBid_sale_artwork } from "__generated__/ConfirmBid_sale_artwork.graphql"
@@ -35,10 +36,11 @@ stripe.setOptions({ publishableKey: Emission.stripePublishableKey })
 export interface ConfirmBidProps extends ViewProperties {
   sale_artwork: ConfirmBid_sale_artwork
   me: ConfirmBid_me
-  bid: Bid
   relay?: RelayRefetchProp
   navigator?: NavigatorIOS
   refreshSaleArtwork?: () => void
+  increments: any
+  selectedBidIndex: number
 }
 
 interface ConfirmBidState {
@@ -49,6 +51,7 @@ interface ConfirmBidState {
   isLoading: boolean
   requiresCheckbox: boolean
   requiresPaymentInformation: boolean
+  selectedBidIndex: number
 }
 
 const MAX_POLL_ATTEMPTS = 20
@@ -139,6 +142,7 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
       isLoading: false,
       requiresCheckbox,
       requiresPaymentInformation,
+      selectedBidIndex: this.props.selectedBidIndex,
     }
   }
 
@@ -198,7 +202,7 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
         input: {
           sale_id: this.props.sale_artwork.sale.id,
           artwork_id: this.props.sale_artwork.artwork.id,
-          max_bid_amount_cents: this.props.bid.cents,
+          max_bid_amount_cents: this.selectedBid().cents,
         },
       },
     })
@@ -271,7 +275,15 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
   }
 
   goBackToSelectMaxBid() {
-    this.props.navigator.pop()
+    this.props.navigator.push({
+      component: SelectMaxBidEdit,
+      title: "",
+      passProps: {
+        increments: this.props.increments,
+        selectedBidIndex: this.state.selectedBidIndex,
+        updateSelectedBid: this.updateSelectedBid.bind(this),
+      },
+    })
   }
 
   presentErrorResult(error) {
@@ -315,6 +327,10 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
     this.setState({ isLoading: false })
   }
 
+  updateSelectedBid(newBidIndex: number) {
+    this.setState({ selectedBidIndex: newBidIndex })
+  }
+
   render() {
     const { artwork, lot_label, sale } = this.props.sale_artwork
     const { requiresPaymentInformation, requiresCheckbox } = this.state
@@ -339,7 +355,11 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
 
             <Divider />
 
-            <BidInfoRow label="Max bid" value={this.props.bid.display} onPress={() => this.goBackToSelectMaxBid()} />
+            <BidInfoRow
+              label="Max bid"
+              value={this.selectedBid().display}
+              onPress={() => this.goBackToSelectMaxBid()}
+            />
 
             {requiresPaymentInformation ? (
               <PaymentInfo
@@ -387,6 +407,10 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
         </Container>
       </BiddingThemeProvider>
     )
+  }
+
+  private selectedBid(): Bid {
+    return this.props.increments[this.state.selectedBidIndex]
   }
 
   private determineDisplayRequirements(bidders: ReadonlyArray<any>, hasQualifiedCreditCards: boolean) {

--- a/src/lib/Components/Bidding/Screens/SelectMaxBid.tsx
+++ b/src/lib/Components/Bidding/Screens/SelectMaxBid.tsx
@@ -58,7 +58,8 @@ export class SelectMaxBid extends React.Component<SelectMaxBidProps, SelectMaxBi
       title: "",
       passProps: {
         ...this.props,
-        bid: this.props.sale_artwork.increments[this.state.selectedBidIndex],
+        increments: this.props.sale_artwork.increments,
+        selectedBidIndex: this.state.selectedBidIndex,
         refreshSaleArtwork: this.refreshSaleArtwork,
       },
     })

--- a/src/lib/Components/Bidding/Screens/SelectMaxBidEdit.tsx
+++ b/src/lib/Components/Bidding/Screens/SelectMaxBidEdit.tsx
@@ -1,10 +1,11 @@
 import React from "react"
-import { NavigatorIOS, ViewProperties } from "react-native"
+import { NavigatorIOS, View, ViewProperties } from "react-native"
 
 import { Schema, screenTrack } from "../../../utils/track"
 
 import { Flex } from "../Elements/Flex"
 
+import { BackButton } from "lib/Components/Bidding/Components/BackButton"
 import { BiddingThemeProvider } from "../Components/BiddingThemeProvider"
 import { Button } from "../Components/Button"
 import { Container } from "../Components/Containers"
@@ -42,7 +43,10 @@ export class SelectMaxBidEdit extends React.Component<SelectMaxBidProps, SelectM
     return (
       <BiddingThemeProvider>
         <Container m={0}>
-          <Title>Your max bid</Title>
+          <View>
+            <BackButton navigator={this.props.navigator} />
+            <Title>Your max bid</Title>
+          </View>
 
           <MaxBidPicker
             bids={bids}

--- a/src/lib/Components/Bidding/Screens/SelectMaxBidEdit.tsx
+++ b/src/lib/Components/Bidding/Screens/SelectMaxBidEdit.tsx
@@ -1,0 +1,60 @@
+import React from "react"
+import { NavigatorIOS, ViewProperties } from "react-native"
+
+import { Schema, screenTrack } from "../../../utils/track"
+
+import { Flex } from "../Elements/Flex"
+
+import { BiddingThemeProvider } from "../Components/BiddingThemeProvider"
+import { Button } from "../Components/Button"
+import { Container } from "../Components/Containers"
+import { MaxBidPicker } from "../Components/MaxBidPicker"
+import { Title } from "../Components/Title"
+
+interface SelectMaxBidProps extends ViewProperties {
+  increments: any[]
+  navigator: NavigatorIOS
+  updateSelectedBid: (selectedBidIndex: number) => void
+  selectedBidIndex: number
+}
+
+interface SelectMaxBidState {
+  selectedBidIndex: number
+}
+
+@screenTrack({
+  context_screen: Schema.PageNames.BidFlowMaxBidPage,
+  context_screen_owner_type: null,
+})
+export class SelectMaxBidEdit extends React.Component<SelectMaxBidProps, SelectMaxBidState> {
+  state = {
+    selectedBidIndex: this.props.selectedBidIndex || 0,
+  }
+
+  onPressNext = () => {
+    this.props.updateSelectedBid(this.state.selectedBidIndex)
+    this.props.navigator.pop()
+  }
+
+  render() {
+    const bids = this.props.increments || []
+
+    return (
+      <BiddingThemeProvider>
+        <Container m={0}>
+          <Title>Your max bid</Title>
+
+          <MaxBidPicker
+            bids={bids}
+            onValueChange={(_, index) => this.setState({ selectedBidIndex: index })}
+            selectedValue={this.state.selectedBidIndex}
+          />
+
+          <Flex m={4}>
+            <Button text="Select bid" onPress={this.onPressNext} />
+          </Flex>
+        </Container>
+      </BiddingThemeProvider>
+    )
+  }
+}

--- a/src/lib/Components/Bidding/Screens/SelectMaxBidEdit.tsx
+++ b/src/lib/Components/Bidding/Screens/SelectMaxBidEdit.tsx
@@ -55,7 +55,7 @@ export class SelectMaxBidEdit extends React.Component<SelectMaxBidProps, SelectM
           />
 
           <Flex m={4}>
-            <Button text="Select bid" onPress={this.onPressNext} />
+            <Button text="Next" onPress={this.onPressNext} />
           </Flex>
         </Container>
       </BiddingThemeProvider>

--- a/src/lib/Components/Bidding/Screens/__tests__/ConfirmBid-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/ConfirmBid-tests.tsx
@@ -217,8 +217,8 @@ describe("editing bid amount", () => {
 
     editScreen.root.findByType(Button).instance.props.onPress()
 
-    const confirmScreen = fakeNavigator.nextStep()
-    expect(confirmScreen.root.type).toEqual(ConfirmBid)
+    const updatedBidRow = component.root.findAllByType(TouchableWithoutFeedback)[0]
+    expect(updatedBidRow.findByType(Serif16).props.children).toEqual("$46,000")
   })
 })
 

--- a/src/lib/Components/Bidding/Screens/__tests__/ConfirmBid-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/ConfirmBid-tests.tsx
@@ -33,6 +33,8 @@ import stripe from "tipsi-stripe"
 
 import objectContaining = jasmine.objectContaining
 import any = jasmine.any
+import { FakeNavigator } from "lib/Components/Bidding/__tests__/Helpers/FakeNavigator"
+import { SelectMaxBidEdit } from "../SelectMaxBidEdit"
 
 let nextStep
 const mockNavigator = { push: route => (nextStep = route) }
@@ -190,6 +192,33 @@ describe("when pressing bid button", () => {
         )
       })
     })
+  })
+})
+
+describe("editing bid amount", () => {
+  it("allows you to go to the max bid edit screen and select a new max bid", () => {
+    const fakeNavigator = new FakeNavigator()
+    const fakeNavigatorProps = {
+      ...initialPropsForRegisteredUser,
+      navigator: fakeNavigator,
+    }
+    fakeNavigator.push({ component: ConfirmBid, id: "", title: "", passProps: fakeNavigatorProps })
+
+    const component = renderer.create(<ConfirmBid {...initialPropsForRegisteredUser} navigator={fakeNavigator} />)
+
+    const selectMaxBidRow = component.root.findAllByType(TouchableWithoutFeedback)[0]
+    expect(selectMaxBidRow.findByType(Serif16).props.children).toEqual("$45,000")
+    selectMaxBidRow.instance.props.onPress()
+
+    const editScreen = fakeNavigator.nextStep()
+    expect(editScreen.root.type).toEqual(SelectMaxBidEdit)
+    expect(editScreen.root.props.selectedBidIndex).toEqual(0)
+    editScreen.root.instance.setState({ selectedBidIndex: 1 })
+
+    editScreen.root.findByType(Button).instance.props.onPress()
+
+    const confirmScreen = fakeNavigator.nextStep()
+    expect(confirmScreen.root.type).toEqual(ConfirmBid)
   })
 })
 
@@ -573,10 +602,17 @@ const stripeToken = {
 
 const initialProps = {
   sale_artwork: saleArtwork,
-  bid: {
-    cents: 450000,
-    display: "$45,000",
-  },
+  increments: [
+    {
+      cents: 450000,
+      display: "$45,000",
+    },
+    {
+      cents: 460000,
+      display: "$46,000",
+    },
+  ],
+  selectedBidIndex: 0,
   relay: {
     environment: null,
   },

--- a/src/lib/Components/Bidding/Screens/__tests__/SelectMaxBidEdit-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/SelectMaxBidEdit-tests.tsx
@@ -1,0 +1,55 @@
+import React from "react"
+import "react-native"
+import * as renderer from "react-test-renderer"
+import { FakeNavigator } from "../../__tests__/Helpers/FakeNavigator"
+
+import { MaxBidPicker } from "../../Components/MaxBidPicker"
+import { SelectMaxBidEdit } from "../SelectMaxBidEdit"
+
+const SaleArtwork = {
+  increments: [
+    {
+      display: "$35,000",
+      cents: 3500000,
+    },
+    {
+      display: "$40,000",
+      cents: 4000000,
+    },
+    {
+      display: "$45,000",
+      cents: 4500000,
+    },
+    {
+      display: "$50,000",
+      cents: 5000000,
+    },
+    {
+      display: "$55,000",
+      cents: 5500000,
+    },
+  ],
+}
+
+let fakeNavigator
+
+beforeEach(() => {
+  fakeNavigator = new FakeNavigator()
+})
+
+it("renders properly", () => {
+  const component = renderer.create(<SelectMaxBidEdit {...initialProps} />).toJSON()
+  expect(component).toMatchSnapshot()
+})
+
+it("passes the correct selection", () => {
+  const component = renderer.create(<SelectMaxBidEdit {...initialProps} selectedBidIndex={3} />)
+  expect(component.root.findByType(MaxBidPicker).props.selectedValue).toEqual(3)
+})
+
+const initialProps = {
+  increments: SaleArtwork.increments,
+  navigator: fakeNavigator as any,
+  updateSelectedBid: jest.fn(),
+  selectedBidIndex: 0,
+}

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/SelectMaxBidEdit-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/SelectMaxBidEdit-tests.tsx.snap
@@ -212,7 +212,7 @@ exports[`renders properly 1`] = `
               ]
             }
           >
-            Select bid
+            Next
           </Text>
         </View>
       </View>

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/SelectMaxBidEdit-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/SelectMaxBidEdit-tests.tsx.snap
@@ -1,0 +1,186 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders properly 1`] = `
+<View
+  flex={1}
+  flexDirection="column"
+  justifyContent="space-between"
+  m={0}
+  style={
+    Array [
+      Object {
+        "flexBasis": 0,
+        "flexGrow": 1,
+        "flexShrink": 1,
+        "marginBottom": 0,
+        "marginLeft": 0,
+        "marginRight": 0,
+        "marginTop": 0,
+      },
+      undefined,
+    ]
+  }
+>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    fontSize={5}
+    lineHeight={7}
+    m={4}
+    style={
+      Array [
+        Object {
+          "fontFamily": "AGaramondPro-Semibold",
+          "fontSize": 22,
+          "lineHeight": 28,
+          "marginBottom": 20,
+          "marginLeft": 20,
+          "marginRight": 20,
+          "marginTop": 20,
+          "textAlign": "center",
+        },
+        undefined,
+      ]
+    }
+    textAlign="center"
+  >
+    Your max bid
+  </Text>
+  <View
+    style={
+      Array [
+        Object {
+          "width": "100%",
+        },
+        undefined,
+      ]
+    }
+  >
+    <RCTPicker
+      items={
+        Array [
+          Object {
+            "label": "$35,000",
+            "textColor": undefined,
+            "value": 0,
+          },
+          Object {
+            "label": "$40,000",
+            "textColor": undefined,
+            "value": 1,
+          },
+          Object {
+            "label": "$45,000",
+            "textColor": undefined,
+            "value": 2,
+          },
+          Object {
+            "label": "$50,000",
+            "textColor": undefined,
+            "value": 3,
+          },
+          Object {
+            "label": "$55,000",
+            "textColor": undefined,
+            "value": 4,
+          },
+        ]
+      }
+      onChange={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      selectedIndex={0}
+      style={
+        Array [
+          Object {
+            "height": 216,
+          },
+          undefined,
+        ]
+      }
+    />
+  </View>
+  <View
+    m={4}
+    style={
+      Array [
+        Object {
+          "marginBottom": 20,
+          "marginLeft": 20,
+          "marginRight": 20,
+          "marginTop": 20,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      height={50}
+      style={
+        Array [
+          Object {
+            "height": 50,
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hasTVPreferredFocus={undefined}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        nativeID={undefined}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "rgba(0, 0, 0, 1)",
+            "borderRadius": 2,
+            "flex": 1,
+            "justifyContent": "center",
+          }
+        }
+        testID={undefined}
+        tvParallaxProperties={undefined}
+      >
+        <View
+          style={null}
+        >
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "fontSize": 14,
+                },
+                Object {
+                  "color": "white",
+                  "opacity": 1,
+                },
+                Object {
+                  "fontFamily": "Unica77LL-Medium",
+                },
+              ]
+            }
+          >
+            Select bid
+          </Text>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/SelectMaxBidEdit-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/SelectMaxBidEdit-tests.tsx.snap
@@ -21,32 +21,68 @@ exports[`renders properly 1`] = `
     ]
   }
 >
-  <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
-    fontSize={5}
-    lineHeight={7}
-    m={4}
-    style={
-      Array [
+  <View>
+    <Image
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      left={10}
+      nativeID={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      position="absolute"
+      source={
         Object {
-          "fontFamily": "AGaramondPro-Semibold",
-          "fontSize": 22,
-          "lineHeight": 28,
-          "marginBottom": 20,
-          "marginLeft": 20,
-          "marginRight": 20,
-          "marginTop": 20,
-          "textAlign": "center",
-        },
-        undefined,
-      ]
-    }
-    textAlign="center"
-  >
-    Your max bid
-  </Text>
+          "testUri": "../../../images/angle-left.png",
+        }
+      }
+      style={
+        Array [
+          Object {
+            "position": "absolute",
+          },
+          Object {
+            "zIndex": 10,
+          },
+        ]
+      }
+      testID={undefined}
+      top={10}
+    />
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      fontSize={5}
+      lineHeight={7}
+      m={4}
+      style={
+        Array [
+          Object {
+            "fontFamily": "AGaramondPro-Semibold",
+            "fontSize": 22,
+            "lineHeight": 28,
+            "marginBottom": 20,
+            "marginLeft": 20,
+            "marginRight": 20,
+            "marginTop": 20,
+            "textAlign": "center",
+          },
+          undefined,
+        ]
+      }
+      textAlign="center"
+    >
+      Your max bid
+    </Text>
+  </View>
   <View
     style={
       Array [

--- a/src/lib/Components/Bidding/__stories__/BidFlow.story.tsx
+++ b/src/lib/Components/Bidding/__stories__/BidFlow.story.tsx
@@ -15,9 +15,9 @@ import { Registration } from "../Screens/Registration"
 import { RegistrationResult, RegistrationStatus } from "../Screens/RegistrationResult"
 import { MaxBidScreen } from "../Screens/SelectMaxBid"
 
-const testSaleArtworkID = "5b1e4d29275b2446aa139f37"
-const testArtworkID = "david-lynch-hand"
-const testSaleID = "shared-live-mocktion-k8s"
+const testSaleArtworkID = "5b329f757622dd41e6670006"
+const testArtworkID = "john-aldridge-evergreens"
+const testSaleID = "sworders-modern-british-and-20th-century-art"
 
 const selectMaxBidQuery = graphql`
   query BidFlowSelectMaxBidRendererQuery($saleArtworkID: String!) {
@@ -52,7 +52,8 @@ storiesOf("Bidding")
           lot_label: "2",
         }}
         me={{ has_qualified_credit_cards: false, bidders: [{ qualified_for_bidding: true }] }}
-        bid={{ display: "$45,000", cents: 4500000 }}
+        increments={[{ display: "$45,000", cents: 4500000 }]}
+        selectedBidIndex={0}
       />
     )
   })
@@ -70,7 +71,8 @@ storiesOf("Bidding")
               lot_label: "1",
             },
             me: { has_qualified_credit_cards: false, bidders: [] },
-            bid: { display: "$45,000", cents: 4500000 },
+            increments: [{ display: "$45,000", cents: 4500000 }],
+            selectedBidIndex: 0,
           },
         }}
         style={{ flex: 1 }}
@@ -103,7 +105,8 @@ storiesOf("Bidding")
               has_qualified_credit_cards: true,
               bidders: [],
             },
-            bid: { display: "$45,000", cents: 4500000 },
+            increments: [{ display: "$45,000", cents: 4500000 }],
+            selectedBidIndex: 0,
           },
         }}
         style={{ flex: 1 }}


### PR DESCRIPTION
The goal of this PR is to address https://artsyproduct.atlassian.net/browse/PURCHASE-236 -- you should be able to navigate between the `ConfirmBid` screen and the `SelectMaxBid` screen in order to update your bid, without all of your information being lost in between.

@yuki24 and I went through many potential implementations of this. This is what seemed to be simplest (a potential more ideal version in the _future_, if the interaction becomes more complex, would be to introduce something like redux to hold state globally).

This PR:
- Adds a new component `SelectMaxBidEdit` which is _not_ relay-based. It shows the `MaxBidPicker` and updates the `selectedBidIndex` on the `ConfirmBid` component.
- Changes the `ConfirmBid` component to store `increments` and a `selectedBidIndex` instead of a `bid` object, as we'll need to pass the increments and the index to the new `SelectMaxBidEdit` component, and this felt cleanest.

Some more comments are inline!

gif here:
![edit-max-bid](https://user-images.githubusercontent.com/2081340/42400570-14582d56-8140-11e8-8420-26aa59296088.gif)
