### PR TITLE
Continue button on the registration flow dismisses the modal #trivial

### DIFF
--- a/src/lib/Components/Bidding/Screens/RegistrationResult.tsx
+++ b/src/lib/Components/Bidding/Screens/RegistrationResult.tsx
@@ -10,6 +10,7 @@ import { Container } from "../Components/Containers"
 import { Markdown } from "../Components/Markdown"
 import { Title } from "../Components/Title"
 
+import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { Schema, screenTrack } from "../../../utils/track"
 
 interface RegistrationResultProps {
@@ -71,6 +72,10 @@ const resultEnumToPageName = (result: RegistrationStatus) => {
   context_screen_owner_type: null,
 }))
 export class RegistrationResult extends React.Component<RegistrationResultProps, null> {
+  exitBidFlow = async () => {
+    await SwitchBoard.dismissModalViewController(this)
+  }
+
   render() {
     const status = this.props.status
     let title: string
@@ -106,7 +111,7 @@ export class RegistrationResult extends React.Component<RegistrationResultProps,
               <Markdown mb={5}>{msg}</Markdown>
             </Flex>
           </View>
-          <BidGhostButton text="Continue" onPress={null} />
+          <BidGhostButton text="Continue" onPress={this.exitBidFlow} />
         </Container>
       </BiddingThemeProvider>
     )

--- a/src/lib/Components/Bidding/Screens/__tests__/RegistrationResult-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/RegistrationResult-tests.tsx
@@ -1,7 +1,14 @@
 import React from "react"
 import * as renderer from "react-test-renderer"
 
+import { BidGhostButton } from "lib/Components/Bidding/Components/Button"
 import { RegistrationResult, RegistrationStatus } from "../RegistrationResult"
+
+jest.mock("lib/NativeModules/SwitchBoard", () => ({
+  dismissModalViewController: jest.fn(),
+  presentModalViewController: jest.fn(),
+}))
+import SwitchBoard from "lib/NativeModules/SwitchBoard"
 
 describe("Registration result component", () => {
   it("renders registration pending properly", () => {
@@ -21,5 +28,18 @@ describe("Registration result component", () => {
       .create(<RegistrationResult status={RegistrationStatus.RegistrationStatusError} />)
       .toJSON()
     expect(component).toMatchSnapshot()
+  })
+
+  it("dismisses the controller when the continue button is pressed", () => {
+    jest.useFakeTimers()
+    const component = renderer.create(<RegistrationResult status={RegistrationStatus.RegistrationStatusComplete} />)
+    const mockDismiss = SwitchBoard.dismissModalViewController as jest.Mock<any>
+    mockDismiss.mockReturnValueOnce(Promise.resolve())
+
+    component.root.findByType(BidGhostButton).instance.props.onPress()
+    jest.runAllTicks()
+
+    expect(SwitchBoard.dismissModalViewController).toHaveBeenCalled()
+    expect(SwitchBoard.presentModalViewController).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
I copied exactly [what we do](https://github.com/artsy/emission/blob/master/src/lib/Components/Bidding/Screens/BidResult.tsx#L60) for the `BidResult` component, without the special case for it being a live sale since we don't handle that case separately.