### PR TITLE
WIP: User can navigate to Select country screen and type a country name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Add secondary outline button style - maxim
 * Adds `inputRef` to the styled `<Input>` component - yuki24
 * Add analytics to registration screens - maxim
+* Now users can add thier country = yuki24
 
 ### 1.5.8
 

--- a/src/lib/Components/Bidding/Elements/types.d.ts
+++ b/src/lib/Components/Bidding/Elements/types.d.ts
@@ -166,7 +166,7 @@ export interface FlexDirectionProps {
 
 export function flexDirection(...args: any[]): any
 
-export type FlexValue = string
+export type FlexValue = number
 export type ResponsiveFlexValue = ResponsiveValue<FlexValue>
 
 export interface FlexProps {

--- a/src/lib/Components/Bidding/Screens/BillingAddress.tsx
+++ b/src/lib/Components/Bidding/Screens/BillingAddress.tsx
@@ -2,7 +2,7 @@ import React from "react"
 
 import { Schema, screenTrack, track } from "../../../utils/track"
 
-import { Dimensions, KeyboardAvoidingView, NavigatorIOS, ScrollView } from "react-native"
+import { Dimensions, KeyboardAvoidingView, NavigatorIOS, ScrollView, TouchableWithoutFeedback } from "react-native"
 
 import { Flex } from "../Elements/Flex"
 import { Sans12, Serif16 } from "../Elements/Typography"
@@ -15,7 +15,9 @@ import { Button } from "../Components/Button"
 import { Container } from "../Components/Containers"
 import { Input } from "../Components/Input"
 import { Title } from "../Components/Title"
-import { Address } from "../types"
+import { Address, Country } from "../types"
+
+import { SelectCountry } from "./SelectCountry"
 
 interface StyledInputInterface {
   /** The object which styled components wraps */
@@ -47,6 +49,7 @@ interface BillingAddressState {
     addressLine2?: string
     city?: string
     state?: string
+    country?: string
     postalCode?: string
   }
 }
@@ -72,13 +75,14 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
   }
 
   validateAddress(address: Address) {
-    const { fullName, addressLine1, city, state, postalCode } = address
+    const { fullName, addressLine1, city, state, country, postalCode } = address
 
     return {
       fullName: validatePresence(fullName),
       addressLine1: validatePresence(addressLine1),
       city: validatePresence(city),
       state: validatePresence(state),
+      country: validatePresence(country && country.shortName),
       postalCode: validatePresence(postalCode),
     }
   }
@@ -99,6 +103,10 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
     }
   }
 
+  onCountrySelected(country: Country) {
+    this.setState({ values: { ...this.state.values, country } })
+  }
+
   @track({
     action_type: Schema.ActionTypes.Success,
     action_name: Schema.ActionNames.BidFlowSaveBillingAddress,
@@ -108,7 +116,19 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
     this.props.navigator.pop()
   }
 
+  presentSelectCountry() {
+    this.props.navigator.push({
+      component: SelectCountry,
+      title: "",
+      passProps: {
+        onCountrySelected: this.onCountrySelected.bind(this),
+      },
+    })
+  }
+
   render() {
+    const errorForCountry = this.state.errors.country
+
     // TODO: Remove this once React Native has been updated
     const isPhoneX = Dimensions.get("window").height === 812 && Dimensions.get("window").width === 375
     const defaultVerticalOffset = isPhoneX ? 30 : 15
@@ -167,6 +187,22 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
                 placeholder="Add your postal code"
                 returnKeyType="default"
               />
+
+              <Flex mb={4}>
+                <Serif16 mb={2}>Country</Serif16>
+
+                <TouchableWithoutFeedback onPress={() => this.presentSelectCountry()}>
+                  <Flex mb={3} p={3} pb={2} border={1} borderColor={errorForCountry ? "red100" : "black10"}>
+                    {this.state.values.country ? (
+                      <Serif16>{this.state.values.country.longName}</Serif16>
+                    ) : (
+                      <Serif16 color="black30">Select your country</Serif16>
+                    )}
+                  </Flex>
+                </TouchableWithoutFeedback>
+
+                {errorForCountry && <Sans12 color="red100">{errorForCountry}</Sans12>}
+              </Flex>
 
               <Button text="Add billing address" onPress={() => this.onSubmit()} />
             </Container>

--- a/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
@@ -180,6 +180,7 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
         addressCity: billingAddress.city,
         addressState: billingAddress.state,
         addressZip: billingAddress.postalCode,
+        addressCountry: billingAddress.country.shortName,
       })
 
       commitMutation(this.props.relay.environment, {

--- a/src/lib/Components/Bidding/Screens/SelectCountry.tsx
+++ b/src/lib/Components/Bidding/Screens/SelectCountry.tsx
@@ -1,0 +1,125 @@
+import { stringify } from "qs"
+import React from "react"
+import { ActivityIndicator, NativeModules, NavigatorIOS, ScrollView, TouchableWithoutFeedback } from "react-native"
+
+import { Flex } from "../Elements/Flex"
+
+import { BackButton } from "../Components/BackButton"
+import { BiddingThemeProvider } from "../Components/BiddingThemeProvider"
+import { Container } from "../Components/Containers"
+import { Input } from "../Components/Input"
+import { Title } from "../Components/Title"
+import { Serif18, SerifItalic18 } from "../Elements/Typography"
+import { Country, SearchResult } from "../types"
+
+const { Emission } = NativeModules
+
+interface SelectCountryProps {
+  navigator: NavigatorIOS
+  onCountrySelected?: (country: any) => void
+}
+
+interface SelectCountryState {
+  query: string
+  isLoading: boolean
+  results: SearchResult[]
+}
+
+// https://developers.google.com/places/
+// https://developers.google.com/places/web-service/details
+const fetchFromGoogleMaps = async (path: string, queryParams: { [key: string]: string }) => {
+  // The extra key is from a throwaway google account,
+  // it should only get used in Emission dev mode
+  queryParams.key = Emission.googleMapsAPIKey || "AIzaSyBJRIy_zCXQ7XYt9Ubn8bpUIEAxEOKUmx8"
+
+  const response = await fetch(`https://maps.googleapis.com${path}?${stringify(queryParams)}`)
+  return await response.json()
+}
+
+export class SelectCountry extends React.Component<SelectCountryProps, SelectCountryState> {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      query: null,
+      isLoading: false,
+      results: [],
+    }
+  }
+
+  locationSelected = async (result: SearchResult) => {
+    const results = await fetchFromGoogleMaps("/maps/api/place/details/json", { placeid: result.id })
+    const country = results.result.address_components.find(comp => comp.types[0] === "country")
+
+    this.props.onCountrySelected({ longName: country.long_name, shortName: country.short_name } as Country)
+    this.props.navigator.pop()
+  }
+
+  textChanged = async (text: string) => {
+    this.setState({ query: text, isLoading: text.length > 0 })
+    this.searchForQuery(text)
+  }
+
+  searchForQuery = async (input: string) => {
+    const results = await fetchFromGoogleMaps("/maps/api/place/autocomplete/json", {
+      language: "en",
+      types: "(regions)",
+      input,
+    })
+
+    const predictions = (results.predictions || [])
+      .filter(prediction => prediction.types[0] === "country")
+      .map(prediction => ({ id: prediction.place_id, name: prediction.description }))
+
+    this.setState({
+      results: predictions,
+      isLoading: false,
+    })
+  }
+
+  render() {
+    const { results, isLoading, query } = this.state
+
+    return (
+      <BiddingThemeProvider>
+        <Flex flex={1}>
+          <BackButton navigator={this.props.navigator} />
+
+          <Container mb={0}>
+            <Title mt={0}>Select country</Title>
+
+            <Input
+              mb={3}
+              autoCorrect={false}
+              clearButtonMode="while-editing"
+              placeholder="Country"
+              returnKeyType="search"
+              value={query}
+              onChangeText={this.textChanged}
+              autoFocus={typeof jest === "undefined" /* TODO: https://github.com/facebook/jest/issues/3707 */}
+            />
+
+            {isLoading && <ActivityIndicator animating={isLoading} />}
+
+            <ScrollView scrollEnabled={results.length > 0} keyboardShouldPersistTaps="always">
+              {results.length > 0 && !isLoading
+                ? results.map(result => (
+                    <TouchableWithoutFeedback key={result.id} onPress={() => this.locationSelected(result)}>
+                      <Serif18 ml={3} mb={3}>
+                        {result.name}
+                      </Serif18>
+                    </TouchableWithoutFeedback>
+                  ))
+                : query &&
+                  !isLoading && (
+                    <Serif18 ml={3} color="black30">
+                      Could not find <SerifItalic18>{query}</SerifItalic18>
+                    </Serif18>
+                  )}
+            </ScrollView>
+          </Container>
+        </Flex>
+      </BiddingThemeProvider>
+    )
+  }
+}

--- a/src/lib/Components/Bidding/Screens/__tests__/BillingAddress-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/BillingAddress-tests.tsx
@@ -1,10 +1,12 @@
 import React from "react"
-import { TextInput } from "react-native"
+import { TextInput, TouchableWithoutFeedback } from "react-native"
 import * as renderer from "react-test-renderer"
 
 import { Button } from "../../Components/Button"
-import { Sans12 } from "../../Elements/Typography"
+import { Sans12, Serif16 } from "../../Elements/Typography"
 import { BillingAddress } from "../BillingAddress"
+
+import { FakeNavigator } from "../../__tests__/Helpers/FakeNavigator"
 
 it("renders properly", () => {
   const component = renderer.create(<BillingAddress />).toJSON()
@@ -24,8 +26,10 @@ it("shows an error message for each field", () => {
 })
 
 it("calls the onSubmit() callback with billing address when ADD BILLING ADDRESS is tapped", () => {
+  const fakeNavigator = new FakeNavigator()
   const onSubmitMock = jest.fn()
-  const component = renderer.create(<BillingAddress onSubmit={onSubmitMock} navigator={{ pop: () => null } as any} />)
+
+  const component = renderer.create(<BillingAddress onSubmit={onSubmitMock} navigator={fakeNavigator as any} />)
 
   textInputComponent(component, "Full name").props.onChangeText("Yuki Stockmeier")
   textInputComponent(component, "Address line 1").props.onChangeText("401 Broadway")
@@ -33,6 +37,12 @@ it("calls the onSubmit() callback with billing address when ADD BILLING ADDRESS 
   textInputComponent(component, "City").props.onChangeText("New York")
   textInputComponent(component, "State, Province, or Region").props.onChangeText("NY")
   textInputComponent(component, "Postal code").props.onChangeText("10013")
+
+  // The second `<TouchableWithoutFeedback>` is a button that pushes a new `<SelectCountry>` instance.
+  component.root.findAllByType(TouchableWithoutFeedback)[1].instance.props.onPress()
+
+  const selectCountry = fakeNavigator.nextStep()
+  selectCountry.root.instance.props.onCountrySelected(billingAddress.country)
   component.root.findByType(Button).instance.props.onPress()
 
   expect(onSubmitMock).toHaveBeenCalledWith(billingAddress)
@@ -47,6 +57,10 @@ it("pre-fills the fields if initial billing address is provided", () => {
   expect(textInputComponent(component, "City").props.value).toEqual("New York")
   expect(textInputComponent(component, "State, Province, or Region").props.value).toEqual("NY")
   expect(textInputComponent(component, "Postal code").props.value).toEqual("10013")
+
+  const countryField = component.root.findAllByType(Serif16)[7]
+
+  expect(countryField.props.children).toEqual("United States")
 })
 
 const errorTextComponent = (component, label) => findFieldForInput(component, { label }).findByType(Sans12)
@@ -62,4 +76,8 @@ const billingAddress = {
   city: "New York",
   state: "NY",
   postalCode: "10013",
+  country: {
+    longName: "United States",
+    shortName: "US",
+  },
 }

--- a/src/lib/Components/Bidding/Screens/__tests__/ConfirmBid-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/ConfirmBid-tests.tsx
@@ -610,6 +610,10 @@ const billingAddress = {
   city: "New York",
   state: "NY",
   postalCode: "10013",
+  country: {
+    longName: "United States",
+    shortName: "US",
+  },
 }
 
 const stripeToken = {

--- a/src/lib/Components/Bidding/Screens/__tests__/SelectCountry-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/SelectCountry-tests.tsx
@@ -1,0 +1,11 @@
+import React from "react"
+import "react-native"
+import * as renderer from "react-test-renderer"
+import { SelectCountry } from "../SelectCountry"
+
+it("Sets up the right view hierarchy", () => {
+  const nav = {} as any
+
+  const component = renderer.create(<SelectCountry navigator={nav} />).toJSON()
+  expect(component).toMatchSnapshot()
+})

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/BillingAddress-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/BillingAddress-tests.tsx.snap
@@ -521,6 +521,97 @@ exports[`renders properly 1`] = `
           />
         </View>
         <View
+          mb={4}
+          style={
+            Array [
+              Object {
+                "marginBottom": 20,
+              },
+              undefined,
+            ]
+          }
+        >
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            fontSize={3}
+            lineHeight={5}
+            mb={2}
+            style={
+              Array [
+                Object {
+                  "fontFamily": "AGaramondPro-Regular",
+                  "fontSize": 16,
+                  "lineHeight": 24,
+                  "marginBottom": 5,
+                },
+                undefined,
+              ]
+            }
+          >
+            Country
+          </Text>
+          <View
+            accessibilityComponentType={undefined}
+            accessibilityLabel={undefined}
+            accessibilityTraits={undefined}
+            accessible={true}
+            border={1}
+            borderColor="black10"
+            hitSlop={undefined}
+            mb={3}
+            nativeID={undefined}
+            onLayout={undefined}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            p={3}
+            pb={2}
+            style={
+              Array [
+                Object {
+                  "borderColor": "#E5E5E5",
+                  "borderStyle": "solid",
+                  "borderWidth": 1,
+                  "marginBottom": 10,
+                  "paddingBottom": 5,
+                  "paddingLeft": 10,
+                  "paddingRight": 10,
+                  "paddingTop": 10,
+                },
+                undefined,
+              ]
+            }
+            testID={undefined}
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              color="black30"
+              ellipsizeMode="tail"
+              fontSize={3}
+              lineHeight={5}
+              style={
+                Array [
+                  Object {
+                    "color": "#C2C2C2",
+                    "fontFamily": "AGaramondPro-Regular",
+                    "fontSize": 16,
+                    "lineHeight": 24,
+                  },
+                  undefined,
+                ]
+              }
+            >
+              Select your country
+            </Text>
+          </View>
+        </View>
+        <View
           height={50}
           style={
             Array [

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/SelectCountry-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/SelectCountry-tests.tsx.snap
@@ -1,0 +1,143 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Sets up the right view hierarchy 1`] = `
+<View
+  flex={1}
+  style={
+    Array [
+      Object {
+        "flexBasis": 0,
+        "flexGrow": 1,
+        "flexShrink": 1,
+      },
+      undefined,
+    ]
+  }
+>
+  <Image
+    accessibilityComponentType={undefined}
+    accessibilityLabel={undefined}
+    accessibilityTraits={undefined}
+    accessible={true}
+    hitSlop={undefined}
+    left={10}
+    nativeID={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    position="absolute"
+    source={
+      Object {
+        "testUri": "../../../images/angle-left.png",
+      }
+    }
+    style={
+      Array [
+        Object {
+          "position": "absolute",
+        },
+        Object {
+          "zIndex": 10,
+        },
+      ]
+    }
+    testID={undefined}
+    top={10}
+  />
+  <View
+    flex={1}
+    flexDirection="column"
+    justifyContent="space-between"
+    m={4}
+    mb={0}
+    style={
+      Array [
+        Object {
+          "flexBasis": 0,
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "marginBottom": 0,
+          "marginLeft": 20,
+          "marginRight": 20,
+          "marginTop": 20,
+        },
+        undefined,
+      ]
+    }
+  >
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      fontSize={5}
+      lineHeight={7}
+      m={4}
+      mt={0}
+      style={
+        Array [
+          Object {
+            "fontFamily": "AGaramondPro-Semibold",
+            "fontSize": 22,
+            "lineHeight": 28,
+            "marginBottom": 20,
+            "marginLeft": 20,
+            "marginRight": 20,
+            "marginTop": 0,
+            "textAlign": "center",
+          },
+          undefined,
+        ]
+      }
+      textAlign="center"
+    >
+      Select country
+    </Text>
+    <TextInput
+      allowFontScaling={true}
+      autoCorrect={false}
+      autoFocus={false}
+      border={1}
+      borderColor="black10"
+      clearButtonMode="while-editing"
+      fontSize={3}
+      mb={3}
+      onBlur={[Function]}
+      onChangeText={[Function]}
+      onFocus={[Function]}
+      p={3}
+      pb={2}
+      placeholder="Country"
+      returnKeyType="search"
+      style={
+        Array [
+          Object {
+            "borderColor": "#E5E5E5",
+            "borderStyle": "solid",
+            "borderWidth": 1,
+            "fontFamily": "AGaramondPro-Regular",
+            "fontSize": 16,
+            "height": 40,
+            "marginBottom": 10,
+            "paddingBottom": 5,
+            "paddingLeft": 10,
+            "paddingRight": 10,
+            "paddingTop": 10,
+          },
+          undefined,
+        ]
+      }
+      value={null}
+    />
+    <RCTScrollView
+      keyboardShouldPersistTaps="always"
+      scrollEnabled={false}
+    >
+      <View />
+    </RCTScrollView>
+  </View>
+</View>
+`;

--- a/src/lib/Components/Bidding/__tests__/BidFlow-tests.tsx
+++ b/src/lib/Components/Bidding/__tests__/BidFlow-tests.tsx
@@ -112,6 +112,7 @@ it("allows bidders without a qualified credit card to register a card and bid", 
     addressCity: billingAddress.city,
     addressState: billingAddress.state,
     addressZip: billingAddress.postalCode,
+    addressCountry: billingAddress.country.shortName,
   })
 
   screen = fakeNavigator.nextStep()
@@ -136,6 +137,10 @@ const billingAddress = {
   city: "New York",
   state: "NY",
   postalCode: "10013",
+  country: {
+    longName: "United States",
+    shortName: "US",
+  },
 }
 
 const creditCardFormParams = {

--- a/src/lib/Components/Bidding/types.d.ts
+++ b/src/lib/Components/Bidding/types.d.ts
@@ -4,7 +4,21 @@ export interface Address {
   addressLine2?: string
   city: string
   state: string
+  country: Country
   postalCode: string
+}
+
+export interface Country {
+  /*
+   * the full text description or name of the address component as returned by the Geocoder.
+   */
+  longName: string
+
+  /*
+   * An abbreviated textual name for the address component, if available. For example, an address component for the
+   * state of Alaska may have a long_name of "Alaska" and a short_name of "AK" using the 2-letter postal abbreviation.
+   */
+  shortName: string
 }
 
 export interface Bid {
@@ -67,6 +81,11 @@ export interface PaymentCardTextFieldParams {
   addressCity?: string
   addressState?: string
   addressZip?: string
+}
+
+export interface SearchResult {
+  id: string
+  name: string
 }
 
 interface StripeToken {


### PR DESCRIPTION
This is a spike on https://artsyproduct.atlassian.net/browse/PURCHASE-251

This adds a new `<SelectCountry>` component. The visual part of mostly done, but the parent `<BillingAddress>` component needs to pass a callback function to the child to get the country field updated.

 * [x] Check in with @briansw about the UI
 * [x] Make sure we send a country value in the appropriate format Stripe accepts
 * [x] Add more test coverage for the `<BillingAddress>` component (find the `TODO` in `src/lib/Components/Bidding/Screens/__tests__/BillingAddress-tests.tsx`)
 * [x] Add new tests for the `<SelectCountry>` component

<img src="https://user-images.githubusercontent.com/386234/42401946-13b8eb1e-8146-11e8-9348-d15c25b7369c.gif" width="414" height="808">

#skip_new_tests