### PR TITLE
Handle errors returned from Stripe during tokenization #trivial

### DIFF
--- a/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
@@ -166,26 +166,31 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
 
   async createCreditCardAndBidderPosition() {
     const { billingAddress, creditCardFormParams } = this.state
-    const token = await stripe.createTokenWithCard({
-      ...creditCardFormParams,
-      name: billingAddress.fullName,
-      addressLine1: billingAddress.addressLine1,
-      addressLine2: billingAddress.addressLine2,
-      addressCity: billingAddress.city,
-      addressState: billingAddress.state,
-      addressZip: billingAddress.postalCode,
-    })
 
-    commitMutation(this.props.relay.environment, {
-      onCompleted: (_, errors) => (isEmpty(errors) ? this.createBidderPosition() : this.presentErrorResult(errors)),
-      onError: this.presentErrorResult.bind(this),
-      mutation: creditCardMutation,
-      variables: {
-        input: {
-          token: token.tokenId,
+    try {
+      const token = await stripe.createTokenWithCard({
+        ...creditCardFormParams,
+        name: billingAddress.fullName,
+        addressLine1: billingAddress.addressLine1,
+        addressLine2: billingAddress.addressLine2,
+        addressCity: billingAddress.city,
+        addressState: billingAddress.state,
+        addressZip: billingAddress.postalCode,
+      })
+
+      commitMutation(this.props.relay.environment, {
+        onCompleted: (_, errors) => (isEmpty(errors) ? this.createBidderPosition() : this.presentErrorResult(errors)),
+        onError: this.presentErrorResult.bind(this),
+        mutation: creditCardMutation,
+        variables: {
+          input: {
+            token: token.tokenId,
+          },
         },
-      },
-    })
+      })
+    } catch (error) {
+      this.presentErrorResult(error)
+    }
   }
 
   createBidderPosition() {

--- a/src/lib/Components/Bidding/Screens/Registration.tsx
+++ b/src/lib/Components/Bidding/Screens/Registration.tsx
@@ -126,31 +126,35 @@ export class Registration extends React.Component<RegistrationProps, Registratio
 
   async createCreditCardAndBidder() {
     const { billingAddress, creditCardFormParams } = this.state
-    const token = await stripe.createTokenWithCard({
-      ...creditCardFormParams,
-      name: billingAddress.fullName,
-      addressLine1: billingAddress.addressLine1,
-      addressLine2: billingAddress.addressLine2,
-      addressCity: billingAddress.city,
-      addressState: billingAddress.state,
-      addressZip: billingAddress.postalCode,
-    })
+    try {
+      const token = await stripe.createTokenWithCard({
+        ...creditCardFormParams,
+        name: billingAddress.fullName,
+        addressLine1: billingAddress.addressLine1,
+        addressLine2: billingAddress.addressLine2,
+        addressCity: billingAddress.city,
+        addressState: billingAddress.state,
+        addressZip: billingAddress.postalCode,
+      })
 
-    commitMutation(this.props.relay.environment, {
-      onCompleted: (_, errors) =>
-        isEmpty(errors)
-          ? this.createBidder()
-          : this.presentRegistrationResult(RegistrationStatus.RegistrationStatusError),
-      onError: error => {
-        this.presentRegistrationError(error, RegistrationStatus.RegistrationStatusError)
-      },
-      mutation: creditCardMutation,
-      variables: {
-        input: {
-          token: token.tokenId,
+      commitMutation(this.props.relay.environment, {
+        onCompleted: (_, errors) =>
+          isEmpty(errors)
+            ? this.createBidder()
+            : this.presentRegistrationResult(RegistrationStatus.RegistrationStatusError),
+        onError: error => {
+          this.presentRegistrationError(error, RegistrationStatus.RegistrationStatusError)
         },
-      },
-    })
+        mutation: creditCardMutation,
+        variables: {
+          input: {
+            token: token.tokenId,
+          },
+        },
+      })
+    } catch (error) {
+      this.presentRegistrationError(error, RegistrationStatus.RegistrationStatusError)
+    }
   }
 
   createBidder() {

--- a/src/lib/Components/Bidding/Screens/__tests__/CreditCardForm-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/CreditCardForm-tests.tsx
@@ -9,6 +9,7 @@ jest.mock("tipsi-stripe", () => ({
   PaymentCardTextField: () => "PaymentCardTextField",
   createTokenWithCard: jest.fn(),
 }))
+import { Sans12 } from "lib/Components/Bidding/Elements/Typography"
 import stripe from "tipsi-stripe"
 
 const onSubmitMock = jest.fn()
@@ -47,6 +48,21 @@ it("is enabled while the form is valid", () => {
 
   component.root.instance.setState({ valid: true, params: creditCard })
   expect(component.root.findByType(Button).props.disabled).toEqual(false)
+})
+
+it("shows an error when stripe's API returns an error", () => {
+  stripe.createTokenWithCard = jest.fn()
+  stripe.createTokenWithCard.mockImplementationOnce(() => {
+    throw new Error("Error tokenizing card")
+  })
+  jest.useFakeTimers()
+  const component = renderer.create(<CreditCardForm onSubmit={onSubmitMock} navigator={{ pop: () => null } as any} />)
+
+  component.root.instance.setState({ valid: true, params: creditCard })
+  component.root.findByType(Button).instance.props.onPress()
+
+  jest.runAllTicks()
+  expect(component.root.findByType(Sans12).props.children).toEqual("There was an error. Please try again.")
 })
 
 const creditCard = {

--- a/src/lib/Components/Bidding/Screens/__tests__/Registration-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/Registration-tests.tsx
@@ -111,8 +111,22 @@ describe("when pressing register button", () => {
     expect(component.root.findAllByType(Spinner).length).toEqual(1)
   })
 
-  xit("displays an error message on a stripe failure", () => {
-    // TODO: https://artsyproduct.atlassian.net/browse/PURCHASE-195
+  it("displays an error message on a stripe failure", () => {
+    stripe.createTokenWithCard.mockImplementation(() => {
+      throw new Error("Error tokenizing card")
+    })
+    console.error = jest.fn() // Silences component logging.
+    const component = renderer.create(<Registration {...initialPropsForUserWithoutCreditCard} />)
+
+    component.root.instance.setState({ billingAddress })
+    component.root.instance.setState({ creditCardToken: stripeToken })
+    component.root.findByType(Checkbox).instance.props.onPress()
+    component.root.findByType(Button).instance.props.onPress()
+
+    jest.runAllTicks()
+
+    expect(nextStep.component).toEqual(RegistrationResult)
+    expect(nextStep.passProps).toEqual({ status: RegistrationStatus.RegistrationStatusError })
   })
 
   it("displays an error message on a creditCardMutation failure", () => {


### PR DESCRIPTION
This PR addresses https://artsyproduct.atlassian.net/browse/PURCHASE-195 by explicitly catching errors from Stripe's API.

Note that we are not _charging_ the cards that we tokenize (so most of the potential checks won't surface at this stage), and Stripe will successfully tokenize any card that passes the same validations that are implemented for free in the form element we're using. Therefore, the errors that we're catching are more likely to do with us being unable to access stripe's API at all and as such there's not really a need to clear the credit card form when this happens.

Here's a helpful stackoverflow answer that discusses the types of validations Stripe does while tokenizing (same as what the form implements): https://stackoverflow.com/a/50878951

Already discussed this behavior with @briansw in slack!

The behavior addressed by this PR is:
- When you are on the `CreditCardForm`, you will already see validation errors as you enter your card information. If Stripe's API returns an error (like I said, this won't be due to any kind of extra validation on the card), we display an error message asking you to try again. This should also handle network errors and things like that. There's a video of this below.
- When you are on the `ConfirmBid` screen or the `Registration` screen and something happens when we try to access Stripe's API, we show the generic `error` screen for that flow.

![cc-error](https://user-images.githubusercontent.com/2081340/42404127-9028c580-8154-11e8-9fb4-d624329f9ff1.gif)
