### PR TITLE
Adjust bid button copy on outbid and confirm bid screens #trivial

### DIFF
--- a/src/lib/Components/Bidding/Screens/BidResult.tsx
+++ b/src/lib/Components/Bidding/Screens/BidResult.tsx
@@ -47,6 +47,8 @@ export class BidResult extends React.Component<BidResultProps> {
     if (this.props.refreshBidderInfo) {
       this.props.refreshBidderInfo()
     }
+
+    // fetch the latest increments for the select max bid screen
     if (this.props.refreshSaleArtwork()) {
       this.props.refreshSaleArtwork()
     }
@@ -67,9 +69,7 @@ export class BidResult extends React.Component<BidResultProps> {
   render() {
     const { sale_artwork, bidderPositionResult } = this.props
     const { live_start_at, end_at } = sale_artwork.sale
-    const { status, message_header, message_description_md, position } = bidderPositionResult
-
-    const nextBid = ((position && position.suggested_next_bid) || sale_artwork.minimum_next_bid || ({} as any)).display
+    const { status, message_header, message_description_md } = bidderPositionResult
 
     return (
       <BiddingThemeProvider>
@@ -92,7 +92,7 @@ export class BidResult extends React.Component<BidResultProps> {
             </Flex>
           </View>
           {this.canBidAgain(status) ? (
-            <Button text={`Bid ${nextBid} or more`} onPress={() => this.onPressBidAgain()} />
+            <Button text="Bid again" onPress={() => this.onPressBidAgain()} />
           ) : (
             <BidGhostButton text="Continue" onPress={this.exitBidFlow} />
           )}

--- a/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
@@ -290,9 +290,6 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
   }
 
   presentBidResult(bidderPositionResult: BidderPositionResult) {
-    if (this.props.refreshSaleArtwork) {
-      this.props.refreshSaleArtwork()
-    }
     NativeModules.ARNotificationsManager.postNotificationName("ARAuctionArtworkBidUpdated", {
       ARAuctionID: this.props.sale_artwork.sale.id,
       ARAuctionArtworkID: this.props.sale_artwork.artwork.id,
@@ -376,7 +373,7 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
 
             <Flex m={4}>
               <Button
-                text="Place bid"
+                text="Bid"
                 inProgress={this.state.isLoading}
                 selected={this.state.isLoading}
                 onPress={this.canPlaceBid() ? () => this.placeBid() : null}

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmBid-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmBid-tests.tsx.snap
@@ -574,7 +574,7 @@ exports[`renders properly 1`] = `
                 ]
               }
             >
-              Place bid
+              Bid
             </Text>
           </View>
         </View>


### PR DESCRIPTION
This PR addresses: https://artsyproduct.atlassian.net/browse/PURCHASE-150

I removed the `refreshSaleArtwork` call between the `ConfirmBid` screen and the `BidResult` screen. As we are no longer giving you a CTA to "Bid above x", we don't need updated information just yet and this can save us a network call.

![image](https://user-images.githubusercontent.com/2081340/42457262-02547160-8365-11e8-8ad9-093d84937dc2.png)
