### PR TITLE
account for null date in artworks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Master
 
+* Fix trailing comma on confirm bid screen when artwork does not have a date
+
 ### 1.5.9
 
 * Fix incorrect NSNotification name for sale registration - erikdstock

--- a/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
@@ -352,7 +352,8 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
               <SerifSemibold14>Lot {lot_label}</SerifSemibold14>
 
               <SerifItalic14 color="black60" textAlign="center">
-                {artwork.title}, <Serif14>{artwork.date}</Serif14>
+                {artwork.title}
+                {artwork.date && <Serif14>, {artwork.date}</Serif14>}
               </SerifItalic14>
             </Flex>
 

--- a/src/lib/Components/Bidding/Screens/__tests__/ConfirmBid-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/ConfirmBid-tests.tsx
@@ -1,4 +1,4 @@
-import { times } from "lodash"
+import { merge, times } from "lodash"
 import React from "react"
 import { NativeModules, TouchableWithoutFeedback } from "react-native"
 import "react-native"
@@ -67,6 +67,29 @@ it("enables the bid button by default if the user is registered", () => {
   const component = renderer.create(<ConfirmBid {...initialPropsForRegisteredUser} />)
 
   expect(component.root.findByType(Button).instance.props.onPress).toBeDefined()
+})
+
+it("displays the artwork title correctly with date", () => {
+  const component = renderer.create(<ConfirmBid {...initialProps} />)
+
+  expect(
+    component.root
+      .findAllByType(Serif14)
+      .map(c => c.props.children.join(""))
+      .join(" ")
+  ).toContain(", 2015")
+})
+
+it("displays the artwork title correctly without date", () => {
+  const datelessProps = merge({}, initialProps, { sale_artwork: { artwork: { date: null } } })
+  const component = renderer.create(<ConfirmBid {...datelessProps} />)
+
+  expect(
+    component.root
+      .findAllByType(Serif14)
+      .map(c => c.props.children.join(""))
+      .join(" ")
+  ).not.toContain(",")
 })
 
 describe("checkbox and payment info display", () => {

--- a/src/lib/Components/Bidding/Screens/__tests__/ConfirmBid-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/ConfirmBid-tests.tsx
@@ -72,24 +72,14 @@ it("enables the bid button by default if the user is registered", () => {
 it("displays the artwork title correctly with date", () => {
   const component = renderer.create(<ConfirmBid {...initialProps} />)
 
-  expect(
-    component.root
-      .findAllByType(Serif14)
-      .map(c => c.props.children.join(""))
-      .join(" ")
-  ).toContain(", 2015")
+  expect(serif14Children(component)).toContain(", 2015")
 })
 
 it("displays the artwork title correctly without date", () => {
   const datelessProps = merge({}, initialProps, { sale_artwork: { artwork: { date: null } } })
   const component = renderer.create(<ConfirmBid {...datelessProps} />)
 
-  expect(
-    component.root
-      .findAllByType(Serif14)
-      .map(c => c.props.children.join(""))
-      .join(" ")
-  ).not.toContain(",")
+  expect(serif14Children(component)).not.toContain(",")
 })
 
 describe("checkbox and payment info display", () => {
@@ -547,6 +537,12 @@ describe("ConfirmBid for unqualified user", () => {
     })
   })
 })
+
+const serif14Children = comp =>
+  comp.root
+    .findAllByType(Serif14)
+    .map(c => c.props.children.join(""))
+    .join(" ")
 
 const saleArtwork = {
   artwork: {

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmBid-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmBid-tests.tsx.snap
@@ -194,7 +194,6 @@ exports[`renders properly 1`] = `
         textAlign="center"
       >
         Meteor Shower
-        , 
         <Text
           accessible={true}
           allowFontScaling={true}
@@ -212,6 +211,7 @@ exports[`renders properly 1`] = `
             ]
           }
         >
+          , 
           2015
         </Text>
       </Text>

--- a/src/lib/Components/Bidding/__stories__/BidFlow.story.tsx
+++ b/src/lib/Components/Bidding/__stories__/BidFlow.story.tsx
@@ -57,6 +57,7 @@ storiesOf("Bidding")
       />
     )
   })
+
   .add("Confirm Bid (no artwork date)", () => {
     return (
       <ConfirmBid
@@ -67,7 +68,8 @@ storiesOf("Bidding")
           lot_label: "2",
         }}
         me={{ has_qualified_credit_cards: false, bidders: [{ qualified_for_bidding: true }] }}
-        bid={{ display: "$45,000", cents: 4500000 }}
+        increments={[{ display: "$45,000", cents: 4500000 }]}
+        selectedBidIndex={0}
       />
     )
   })

--- a/src/lib/Components/Bidding/__stories__/BidFlow.story.tsx
+++ b/src/lib/Components/Bidding/__stories__/BidFlow.story.tsx
@@ -57,6 +57,20 @@ storiesOf("Bidding")
       />
     )
   })
+  .add("Confirm Bid (no artwork date)", () => {
+    return (
+      <ConfirmBid
+        sale_artwork={{
+          _id: "saleartwork12345",
+          sale: { id: "sale-id", live_start_at: "2018-08-11T01:00:00+00:00", end_at: null },
+          artwork: { id: "artwork-id", title: "Morgan Hill (Prototype)", date: null, artist_names: "Lewis balts" },
+          lot_label: "2",
+        }}
+        me={{ has_qualified_credit_cards: false, bidders: [{ qualified_for_bidding: true }] }}
+        bid={{ display: "$45,000", cents: 4500000 }}
+      />
+    )
+  })
   .add("Confirm Bid (not registered, no qualified cc)", () => {
     return (
       <NavigatorIOS


### PR DESCRIPTION
This updates the ConfirmBid screen to not show a ',' in the case of no date on the "title, date" line.
My solution is straightforward but I'm not sure if my tests are practical.

Example:
With date: 
![image](https://user-images.githubusercontent.com/9088720/42473675-46e93792-8393-11e8-92e4-186b3b543b53.png)

New story with `null` date:
![image](https://user-images.githubusercontent.com/9088720/42473610-12cc368a-8393-11e8-8f33-4897d3a24d73.png)

