### PR TITLE
Make sure to re-validate the country field on country selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Master
 
+* Fixes a bug where the error message for the country field remains even after selecting country - yuki24
+
 ### 1.5.10
 
 * Fix trailing comma on confirm bid screen when artwork does not have a date - erikdstock

--- a/src/lib/Components/Bidding/Screens/BillingAddress.tsx
+++ b/src/lib/Components/Bidding/Screens/BillingAddress.tsx
@@ -104,7 +104,12 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
   }
 
   onCountrySelected(country: Country) {
-    this.setState({ values: { ...this.state.values, country } })
+    const values = { ...this.state.values, country }
+
+    this.setState({
+      values,
+      errors: this.validateAddress(values),
+    })
   }
 
   @track({

--- a/src/lib/Components/Bidding/Screens/__tests__/BillingAddress-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/BillingAddress-tests.tsx
@@ -8,6 +8,13 @@ import { BillingAddress } from "../BillingAddress"
 
 import { FakeNavigator } from "../../__tests__/Helpers/FakeNavigator"
 
+const selectCountry = (component, navigator, country) => {
+  // The second `<TouchableWithoutFeedback>` is a button that pushes a new `<SelectCountry>` instance.
+  component.root.findAllByType(TouchableWithoutFeedback)[1].instance.props.onPress()
+
+  navigator.nextStep().root.instance.props.onCountrySelected(country)
+}
+
 it("renders properly", () => {
   const component = renderer.create(<BillingAddress />).toJSON()
   expect(component).toMatchSnapshot()
@@ -37,15 +44,33 @@ it("calls the onSubmit() callback with billing address when ADD BILLING ADDRESS 
   textInputComponent(component, "City").props.onChangeText("New York")
   textInputComponent(component, "State, Province, or Region").props.onChangeText("NY")
   textInputComponent(component, "Postal code").props.onChangeText("10013")
+  selectCountry(component, fakeNavigator, billingAddress.country)
 
-  // The second `<TouchableWithoutFeedback>` is a button that pushes a new `<SelectCountry>` instance.
-  component.root.findAllByType(TouchableWithoutFeedback)[1].instance.props.onPress()
-
-  const selectCountry = fakeNavigator.nextStep()
-  selectCountry.root.instance.props.onCountrySelected(billingAddress.country)
   component.root.findByType(Button).instance.props.onPress()
 
   expect(onSubmitMock).toHaveBeenCalledWith(billingAddress)
+})
+
+it("updates the validation for country when coming back from the select country screen", () => {
+  const fakeNavigator = new FakeNavigator()
+
+  const component = renderer.create(<BillingAddress onSubmit={() => null} navigator={fakeNavigator as any} />)
+
+  textInputComponent(component, "Full name").props.onChangeText("Yuki Stockmeier")
+  textInputComponent(component, "Address line 1").props.onChangeText("401 Broadway")
+  textInputComponent(component, "Address line 2 (optional)").props.onChangeText("25th floor")
+  textInputComponent(component, "City").props.onChangeText("New York")
+  textInputComponent(component, "State, Province, or Region").props.onChangeText("NY")
+  textInputComponent(component, "Postal code").props.onChangeText("10013")
+
+  component.root.findByType(Button).instance.props.onPress()
+
+  expect(component.root.findByType(Sans12).props.children).toEqual("This field is required")
+
+  selectCountry(component, fakeNavigator, billingAddress.country)
+
+  // The <Sans12> instances in the BillingAddress screen display error messages
+  expect(component.root.findAllByType(Sans12).length).toEqual(0)
 })
 
 it("pre-fills the fields if initial billing address is provided", () => {


### PR DESCRIPTION
I noticed the following edge case:

## Steps to re-produce

1. Go to Your billing address screen
2. Tap on Add billing address button without filling out any fields
3. Make sure the country field has an error message
4. Tap on the country field and select country
5. Observe

## Actual

The field does not get updated and displays an error even when the country name is properly displayed in the field.

![img_5037](https://user-images.githubusercontent.com/386234/42531271-8d10046c-8451-11e8-9c36-71648fbfd698.png)


## Expected

The error message for the country field should disappear.
