### PR TITLE
[Bidding flow] Make country picker pop up automatically after pressing "next" from the postal code field #trivial

### DIFF
--- a/src/lib/Components/Bidding/Components/__stories__/Markdown.story.tsx
+++ b/src/lib/Components/Bidding/Components/__stories__/Markdown.story.tsx
@@ -11,18 +11,14 @@ storiesOf("App Style/Utils").add("Markdown", () => (
     <ScrollView>
       <Markdown m={4} alignItems="center">
         Another bidder placed a higher max bid{"\n"}
-        or the same max bid before you did.{"\n"}
-        {"\n"}
-        Bid again to take the lead.
+        or the same max bid before you did.
       </Markdown>
 
       <Divider />
 
       <Markdown m={4} alignItems="center">
         Your bid didn’t meet the reserve price{"\n"}
-        for this work.{"\n"}
-        {"\n"}
-        Bid again to take the lead.
+        for this work.
       </Markdown>
 
       <Divider />

--- a/src/lib/Components/Bidding/Screens/BillingAddress.tsx
+++ b/src/lib/Components/Bidding/Screens/BillingAddress.tsx
@@ -190,7 +190,7 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
                 {...this.defaultPropsForInput("postalCode")}
                 label="Postal code"
                 placeholder="Add your postal code"
-                returnKeyType="default"
+                onSubmitEditing={() => this.presentSelectCountry()}
               />
 
               <Flex mb={4}>

--- a/src/lib/Components/Bidding/Screens/__stories__/BidResult.story.tsx
+++ b/src/lib/Components/Bidding/Screens/__stories__/BidResult.story.tsx
@@ -52,7 +52,7 @@ const Statuses = {
   outbid: {
     status: "OUTBID",
     message_header: "Your bid wasn’t high enough",
-    message_description_md: `Another bidder placed a higher max bid\nor the same max bid before you did.\n\nBid again to take the lead.`,
+    message_description_md: `Another bidder placed a higher max bid\nor the same max bid before you did.`,
   } as BidderPositionResult,
   live_bidding_started: {
     status: "LIVE_BIDDING_STARTED",

--- a/src/lib/Components/Bidding/Screens/__tests__/BidResult-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/BidResult-tests.tsx
@@ -221,7 +221,6 @@ const Statuses = {
     message_header: "Your bid wasn’t high enough",
     message_description_md: `
       Another bidder placed a higher max bid or the same max bid before you did.
-      Bid again to take the lead.
     `,
     position: null,
   } as BidderPositionResult,

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/BillingAddress-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/BillingAddress-tests.tsx.snap
@@ -495,10 +495,11 @@ exports[`renders properly 1`] = `
             onBlur={[Function]}
             onChangeText={[Function]}
             onFocus={[Function]}
+            onSubmitEditing={[Function]}
             p={3}
             pb={2}
             placeholder="Add your postal code"
-            returnKeyType="default"
+            returnKeyType="next"
             style={
               Array [
                 Object {


### PR DESCRIPTION
This PR:
- gets rid of references to "Bid again to take the lead." (only in mocks/stories, but it no longer reflects reality so seemed important to remove)
- updates the postal code field to have a "next" button and when pressed, to bring up the country picker per https://artsyproduct.atlassian.net/browse/PURCHASE-257

![next-billing](https://user-images.githubusercontent.com/2081340/42595187-76e0fa1a-851f-11e8-9cdc-a48db1f9cc0c.gif)
