### PR TITLE
Notify eigen on completion of registration #trivial

### DIFF
--- a/src/lib/Components/Bidding/Components/__tests__/Timer-tests.tsx
+++ b/src/lib/Components/Bidding/Components/__tests__/Timer-tests.tsx
@@ -3,6 +3,7 @@ import React from "react"
 import "react-native"
 import * as renderer from "react-test-renderer"
 
+import { mockTimezone } from "lib/tests/mockTimezone"
 import { SansMedium12, SansMedium16t } from "../../Elements/Typography"
 import { Timer } from "../Timer"
 
@@ -14,15 +15,6 @@ const dateNow = 1525983752000 // Thursday, May 10, 2018 8:22:32.000 PM UTC in mi
 const getTimerLabel = timerComponent => timerComponent.root.findByType(SansMedium12).props.children
 
 const getTimerText = timerComponent => timerComponent.root.findByType(SansMedium16t).props.children.join("")
-
-const mockTimezone = timezone => {
-  const mutatedResolvedOptions: any = Intl.DateTimeFormat().resolvedOptions()
-  const mutatedDateTimeFormat: any = Intl.DateTimeFormat()
-
-  mutatedResolvedOptions.timeZone = timezone
-  mutatedDateTimeFormat.resolvedOptions = () => mutatedResolvedOptions
-  Intl.DateTimeFormat = (() => mutatedDateTimeFormat) as any
-}
 
 let pastTime
 let futureTime

--- a/src/lib/Components/Bidding/Screens/Registration.tsx
+++ b/src/lib/Components/Bidding/Screens/Registration.tsx
@@ -172,6 +172,10 @@ export class Registration extends React.Component<RegistrationProps, Registratio
   }
 
   presentRegistrationSuccess({ createBidder }) {
+    NativeModules.ARNotificationsManager.postNotificationName("ARAuctionArtworkRegistrationUpdated", {
+      ARAuctionID: this.props.sale.id,
+    })
+
     const qualifiedForBidding = createBidder.bidder.qualified_for_bidding
     if (qualifiedForBidding === true) {
       this.presentRegistrationResult(RegistrationStatus.RegistrationStatusComplete)

--- a/src/lib/Components/Bidding/Screens/__tests__/Registration-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/Registration-tests.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { NativeModules } from "react-native"
 import * as renderer from "react-test-renderer"
 
 import Spinner from "../../../Spinner"
@@ -29,10 +30,15 @@ import stripe from "tipsi-stripe"
 let nextStep
 const mockNavigator = { push: route => (nextStep = route), pop: () => null }
 jest.useFakeTimers()
+const mockPostNotificationName = jest.fn()
 
 beforeEach(() => {
+  Date.now = jest.fn(() => 1525983752116)
   // Because of how we mock metaphysics, the mocked value from one test can bleed into another.
   mockphysics.mockReset()
+  mockPostNotificationName.mockReset()
+
+  NativeModules.ARNotificationsManager = { postNotificationName: mockPostNotificationName }
 })
 
 it("renders properly for a user without a credit card", () => {
@@ -198,6 +204,10 @@ describe("when pressing register button", () => {
 
     jest.runAllTicks()
 
+    expect(mockPostNotificationName).toHaveBeenCalledWith("ARAuctionArtworkRegistrationUpdated", {
+      ARAuctionID: "sale-id",
+    })
+
     expect(nextStep.component).toEqual(RegistrationResult)
     expect(nextStep.passProps).toEqual({ status: RegistrationStatus.RegistrationStatusPending })
   })
@@ -213,6 +223,10 @@ describe("when pressing register button", () => {
     component.root.findByType(Button).instance.props.onPress()
 
     jest.runAllTicks()
+
+    expect(mockPostNotificationName).toHaveBeenCalledWith("ARAuctionArtworkRegistrationUpdated", {
+      ARAuctionID: "sale-id",
+    })
 
     expect(nextStep.component).toEqual(RegistrationResult)
     expect(nextStep.passProps).toEqual({ status: RegistrationStatus.RegistrationStatusComplete })
@@ -241,14 +255,12 @@ const stripeToken = {
 }
 
 const sale = {
-  sale: {
-    id: "1",
-    live_start_at: "2029-06-11T01:00:00+00:00",
-    end_at: null,
-    name: "Phillips New Now",
-    start_at: "2018-06-11T01:00:00+00:00",
-    is_preview: true,
-  },
+  id: "sale-id",
+  live_start_at: "2029-06-11T01:00:00+00:00",
+  end_at: null,
+  name: "Phillips New Now",
+  start_at: "2018-06-11T01:00:00+00:00",
+  is_preview: true,
 }
 
 const mockRequestResponses = {

--- a/src/lib/Components/Bidding/Screens/__tests__/Registration-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/Registration-tests.tsx
@@ -11,6 +11,8 @@ import { BillingAddress } from "../BillingAddress"
 import { CreditCardForm } from "../CreditCardForm"
 import { Registration } from "../Registration"
 
+import { mockTimezone } from "lib/tests/mockTimezone"
+
 jest.mock("../../../../metaphysics", () => ({ metaphysics: jest.fn() }))
 import { metaphysics } from "../../../../metaphysics"
 const mockphysics = metaphysics as jest.Mock<any>
@@ -34,6 +36,8 @@ const mockPostNotificationName = jest.fn()
 
 beforeEach(() => {
   Date.now = jest.fn(() => 1525983752116)
+  mockTimezone("America/New_York")
+
   // Because of how we mock metaphysics, the mocked value from one test can bleed into another.
   mockphysics.mockReset()
   mockPostNotificationName.mockReset()

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/Registration-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/Registration-tests.tsx.snap
@@ -84,16 +84,16 @@ exports[`renders properly for a user with a credit card 1`] = `
             ]
           }
         >
-          NaN
+          00
           d
             
-          NaN
+          04
           h
             
-          NaN
+          37
           m
             
-          NaN
+          27
           s
         </Text>
         <Text
@@ -113,7 +113,7 @@ exports[`renders properly for a user with a credit card 1`] = `
             ]
           }
         >
-          Ends Invalid date
+          Starts Jun 10, 9 PM
         </Text>
       </View>
       <Text
@@ -142,7 +142,9 @@ exports[`renders properly for a user with a credit card 1`] = `
           ]
         }
         textAlign="center"
-      />
+      >
+        Phillips New Now
+      </Text>
     </View>
   </View>
   <View>
@@ -414,16 +416,16 @@ exports[`renders properly for a user without a credit card 1`] = `
             ]
           }
         >
-          NaN
+          00
           d
             
-          NaN
+          04
           h
             
-          NaN
+          37
           m
             
-          NaN
+          27
           s
         </Text>
         <Text
@@ -443,7 +445,7 @@ exports[`renders properly for a user without a credit card 1`] = `
             ]
           }
         >
-          Ends Invalid date
+          Starts Jun 10, 9 PM
         </Text>
       </View>
       <Text
@@ -472,7 +474,9 @@ exports[`renders properly for a user without a credit card 1`] = `
           ]
         }
         textAlign="center"
-      />
+      >
+        Phillips New Now
+      </Text>
     </View>
     <View>
       <View

--- a/src/lib/tests/mockTimezone.tsx
+++ b/src/lib/tests/mockTimezone.tsx
@@ -1,0 +1,8 @@
+export const mockTimezone = timezone => {
+  const mutatedResolvedOptions: any = Intl.DateTimeFormat().resolvedOptions()
+  const mutatedDateTimeFormat: any = Intl.DateTimeFormat()
+
+  mutatedResolvedOptions.timeZone = timezone
+  mutatedDateTimeFormat.resolvedOptions = () => mutatedResolvedOptions
+  Intl.DateTimeFormat = (() => mutatedDateTimeFormat) as any
+}


### PR DESCRIPTION
I borrowed this completely from what we do in the `ConfirmBid` flow (which I _think_ works as confirmed by @erikdstock yesterday).

Addresses: https://artsyproduct.atlassian.net/browse/PURCHASE-254

#skip_new_tests