### PR TITLE
Show spinner when pulling up bidding and registration flow #trivial

### DIFF
--- a/src/lib/relay/QueryRenderers.tsx
+++ b/src/lib/relay/QueryRenderers.tsx
@@ -87,6 +87,8 @@ export const RegistrationFlowRenderer: React.SFC<BidderFlowRendererProps> = ({ r
       render={({ props, error }) => {
         if (error) {
           console.error(error)
+        } else if (!props) {
+          return render({ props, error }) // So that we show the spinner
         } else if (props) {
           return render({
             props: {
@@ -126,6 +128,8 @@ export const BidFlowRenderer: React.SFC<BidderFlowRendererProps> = ({ render, ar
       render={({ props, error }) => {
         if (error) {
           console.error(error)
+        } else if (!props) {
+          return render({ props, error }) // So that we show the spinner
         } else if (props) {
           // Note that we need to flatten the query above before passing into the BidFlow component.
           // i.e.: the `sale_artwork` is nested within `artwork`, but we want the sale_artwork itself as a prop.
@@ -137,7 +141,6 @@ export const BidFlowRenderer: React.SFC<BidderFlowRendererProps> = ({ render, ar
             error,
           })
         }
-        return null
       }}
     />
   )


### PR DESCRIPTION
This PR addresses: https://artsyproduct.atlassian.net/browse/PURCHASE-249

The bid/registration flows are slightly different than the others because we are explicitly sending props in our query renderer (as they are different from what's received). This caused us to always [skip](https://github.com/artsy/emission/blob/master/src/lib/utils/renderWithLoadProgress.tsx#L33) showing the `Spinner` on those views unless we explicitly pass the render function with null values here.