### PR TITLE
Sets artwork and artist name labels on ConfirmBid component to use only one line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Adds an error modal to the bid flow - sweir27
 * The country select form should pre-populate if user have already selected a country - yuki2
 * Update graphql + use new argument to fetch increments - sweir27
+* Sets artwork and artist name labels on ConfirmBid component to use only one line, and truncate the tail - ash
 
 ### 1.5.10
 

--- a/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
@@ -364,10 +364,12 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
 
           <View>
             <Flex m={4} mt={0} alignItems="center">
-              <SerifSemibold18t>{artwork.artist_names}</SerifSemibold18t>
+              <SerifSemibold18t numberOfLines={1} ellipsizeMode={"tail"}>
+                {artwork.artist_names}
+              </SerifSemibold18t>
               <SerifSemibold14>Lot {lot_label}</SerifSemibold14>
 
-              <SerifItalic14 color="black60" textAlign="center">
+              <SerifItalic14 color="black60" textAlign="center" numberOfLines={1} ellipsizeMode={"tail"}>
                 {artwork.title}
                 {artwork.date && <Serif14>, {artwork.date}</Serif14>}
               </SerifItalic14>

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmBid-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmBid-tests.tsx.snap
@@ -139,6 +139,7 @@ exports[`renders properly 1`] = `
         ellipsizeMode="tail"
         fontSize={4}
         lineHeight={4}
+        numberOfLines={1}
         style={
           Array [
             Object {
@@ -179,6 +180,7 @@ exports[`renders properly 1`] = `
         ellipsizeMode="tail"
         fontSize={2}
         lineHeight={2}
+        numberOfLines={1}
         style={
           Array [
             Object {


### PR DESCRIPTION
Fixes [PURCHASE-239](https://artsyproduct.atlassian.net/browse/PURCHASE-239).

Here's before:

![simulator screen shot - iphone se - 2018-07-13 at 15 24 11](https://user-images.githubusercontent.com/498212/42710261-54b7e654-86b1-11e8-9c2b-dde796b3b623.png)

And here's after:

![simulator screen shot - iphone se - 2018-07-13 at 15 23 41](https://user-images.githubusercontent.com/498212/42710263-5684e810-86b1-11e8-943c-34c279066c5d.png)
