### PR TITLE
User should not be able to click into the billing address/cc/max bid edit forms while your bid is being placed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Sets artwork and artist name labels on ConfirmBid component to use only one line, and truncate the tail - ash
 * Show error message when your credit card can't be added - sweir27
 * Now Emission uses metaphysics system time to consider offset for auction timer - yuki24
+* Now users are not allowed to click into the billing address/cc/max bid edit forms while your bid is being placed - yuki24
 
 ### 1.5.10
 

--- a/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
@@ -371,7 +371,7 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
 
   render() {
     const { artwork, lot_label, sale } = this.props.sale_artwork
-    const { requiresPaymentInformation, requiresCheckbox } = this.state
+    const { requiresPaymentInformation, requiresCheckbox, isLoading } = this.state
 
     return (
       <BiddingThemeProvider>
@@ -399,12 +399,12 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
             <BidInfoRow
               label="Max bid"
               value={this.selectedBid().display}
-              onPress={() => this.goBackToSelectMaxBid()}
+              onPress={isLoading ? () => null : () => this.goBackToSelectMaxBid()}
             />
 
             {requiresPaymentInformation ? (
               <PaymentInfo
-                navigator={this.props.navigator}
+                navigator={isLoading ? ({ push: () => null } as any) : this.props.navigator}
                 onCreditCardAdded={this.onCreditCardAdded.bind(this)}
                 onBillingAddressAdded={this.onBillingAddressAdded.bind(this)}
                 billingAddress={this.state.billingAddress}

--- a/src/lib/Components/Bidding/Screens/Registration.tsx
+++ b/src/lib/Components/Bidding/Screens/Registration.tsx
@@ -255,7 +255,7 @@ export class Registration extends React.Component<RegistrationProps, Registratio
 
             {this.state.requiresPaymentInformation && (
               <PaymentInfo
-                navigator={this.props.navigator}
+                navigator={this.state.isLoading ? ({ push: () => null } as any) : this.props.navigator}
                 onCreditCardAdded={this.onCreditCardAdded.bind(this)}
                 onBillingAddressAdded={this.onBillingAddressAdded.bind(this)}
                 billingAddress={this.state.billingAddress}

--- a/src/lib/Components/Bidding/Screens/__tests__/ConfirmBid-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/ConfirmBid-tests.tsx
@@ -131,6 +131,37 @@ describe("when pressing bid button", () => {
     expect(component.root.findAllByType(Spinner).length).toEqual(1)
   })
 
+  it("disables tap events while a spinner is being shown", () => {
+    const navigator = { push: jest.fn() } as any
+    relay.commitMutation = jest.fn()
+
+    const component = renderer.create(<ConfirmBid {...initialPropsForUnqualifiedUser} navigator={navigator} />)
+
+    component.root.instance.setState({
+      conditionsOfSaleChecked: true,
+      creditCardToken: stripeToken,
+      billingAddress,
+    })
+
+    component.root.findByType(Button).instance.props.onPress()
+
+    const yourMaxBidRow = component.root.findAllByType(TouchableWithoutFeedback)[0]
+    const creditCardRow = component.root.findAllByType(TouchableWithoutFeedback)[1]
+    const billingAddressRow = component.root.findAllByType(TouchableWithoutFeedback)[2]
+
+    yourMaxBidRow.instance.props.onPress()
+
+    expect(navigator.push).not.toHaveBeenCalled()
+
+    creditCardRow.instance.props.onPress()
+
+    expect(navigator.push).not.toHaveBeenCalled()
+
+    billingAddressRow.instance.props.onPress()
+
+    expect(navigator.push).not.toHaveBeenCalled()
+  })
+
   describe("when pressing bid", () => {
     it("commits the mutation", () => {
       const component = renderer.create(<ConfirmBid {...initialProps} />)

--- a/src/lib/Components/Bidding/Screens/__tests__/Registration-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/Registration-tests.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { NativeModules, Text } from "react-native"
+import { NativeModules, Text, TouchableWithoutFeedback } from "react-native"
 import * as renderer from "react-test-renderer"
 
 import Spinner from "../../../Spinner"
@@ -155,6 +155,37 @@ describe("when pressing register button", () => {
     component.root.findByType(Button).instance.props.onPress()
 
     expect(component.root.findAllByType(Spinner).length).toEqual(1)
+  })
+
+  it("disables tap events while a spinner is being shown", () => {
+    const navigator = { push: jest.fn() } as any
+    relay.commitMutation = jest.fn()
+
+    const component = renderer.create(<Registration {...initialPropsForUserWithoutCreditCard} navigator={navigator} />)
+
+    component.root.instance.setState({
+      conditionsOfSaleChecked: true,
+      creditCardToken: stripeToken,
+      billingAddress,
+    })
+
+    component.root.findByType(Button).instance.props.onPress()
+
+    const yourMaxBidRow = component.root.findAllByType(TouchableWithoutFeedback)[0]
+    const creditCardRow = component.root.findAllByType(TouchableWithoutFeedback)[1]
+    const billingAddressRow = component.root.findAllByType(TouchableWithoutFeedback)[2]
+
+    yourMaxBidRow.instance.props.onPress()
+
+    expect(navigator.push).not.toHaveBeenCalled()
+
+    creditCardRow.instance.props.onPress()
+
+    expect(navigator.push).not.toHaveBeenCalled()
+
+    billingAddressRow.instance.props.onPress()
+
+    expect(navigator.push).not.toHaveBeenCalled()
   })
 
   it("displays an error message on a stripe failure", () => {


### PR DESCRIPTION
finishes https://artsyproduct.atlassian.net/browse/PURCHASE-260

This PR just updates the `<BillingAddress>` and `<Registration>` components to not call any callbacks or just inject a null navigator when `isLoading` is true so users won't be able to launch other screens.