### PR TITLE
dispatch notifications on the main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Master
 
+* Fixes an issue related to posting NSNotificationCenter notifications on not-main threads - erikdstock
+
 ### 1.5.11
 
 * Fixes a bug where the error message for the country field remains even after selecting country - yuki24

--- a/Pod/Classes/EigenCommunications/ARNotificationsManager.m
+++ b/Pod/Classes/EigenCommunications/ARNotificationsManager.m
@@ -28,7 +28,9 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(postNotificationName:(nonnull NSString *)notificationName userInfo:(NSDictionary *)userInfo)
 {
-    [[NSNotificationCenter defaultCenter] postNotificationName:notificationName object:nil userInfo:userInfo];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[NSNotificationCenter defaultCenter] postNotificationName:notificationName object:nil userInfo:userInfo];
+    });
 }
 
 @end

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "emission",
   "version": "1.5.11",
-  "native-code-version": 5,
+  "native-code-version": 6,
   "description": "Artsy React(Native) components.",
   "engines": {
     "node": "8.4.x",


### PR DESCRIPTION
#trivial 

cc @ashfurrow - The changes you requested to prevent eigen ui updates from running off the main thread.