### PR TITLE
Fix the "Continue" button on the "Live bidding has started" screen #trivial

### DIFF
--- a/src/lib/Components/Bidding/Screens/BidResult.tsx
+++ b/src/lib/Components/Bidding/Screens/BidResult.tsx
@@ -59,13 +59,13 @@ export class BidResult extends React.Component<BidResultProps> {
   }
 
   exitBidFlow = async () => {
-    await SwitchBoard.dismissModalViewController(this)
-
     if (this.props.bidderPositionResult.status === "LIVE_BIDDING_STARTED") {
       const Emission = NativeModules.Emission || {}
       const saleID = this.props.sale_artwork.sale.id
       const url = `${Emission.predictionURL}/${saleID}`
       SwitchBoard.presentModalViewController(this, url)
+    } else {
+      SwitchBoard.dismissModalViewController(this)
     }
   }
 


### PR DESCRIPTION
As we found yesterday, the pattern of dismissing the modal view controller and pulling up a new one in a single method doesn't work as we expected (which actually makes some sense). This updates that button to either pop the live auctions view on top of the current one, or dismiss it entirely (but never both).