### PR TITLE
Ignores cache when loading BidFlow query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Master
 
 * Conditions of sale link and checkbox are now disabled while bid is processing - yuki24
+* Ignores cache when loading BidFlow query - ash
 
 ### 1.5.12
 

--- a/src/lib/relay/QueryRenderers.tsx
+++ b/src/lib/relay/QueryRenderers.tsx
@@ -81,6 +81,7 @@ export const RegistrationFlowRenderer: React.SFC<BidderFlowRendererProps> = ({ r
           }
         }
       `}
+      cacheConfig={{ force: true }} // We want to always fetch latest sale registration status, CC info, etc.
       variables={{
         saleID,
       }}
@@ -121,6 +122,7 @@ export const BidFlowRenderer: React.SFC<BidderFlowRendererProps> = ({ render, ar
           }
         }
       `}
+      cacheConfig={{ force: true }} // We want to always fetch latest bid increments.
       variables={{
         artworkID,
         saleID,


### PR DESCRIPTION
I took a stab at [Purchase-297](https://artsyproduct.atlassian.net/browse/PURCHASE-297). Based on what I read in [the docs](https://facebook.github.io/relay/docs/en/query-renderer.html), this is how Relay expects us to indicate that we want to bypass the cache for this query. **However**, I was unable to reproduce the original bug at all (it appears intermittent). My guess is this has something to do with debug vs. production builds of the app.

So, this PR _should_ fix the bug _in theory_, but we should test in the next beta to be sure.