### PR TITLE
Disables condition of sale link if the user has previously accepted them #trivial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Master
 
 * Fixes back button asset for BidFlow - ash
+* Disables condition of sale link if the user has previously accepted them - ash
 
 ### 1.5.14
 

--- a/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
@@ -443,7 +443,9 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
               <Flex alignItems="center">
                 <Serif14 mt={2} color="black60">
                   You agree to{" "}
-                  <LinkText onPress={() => this.onConditionsOfSaleLinkPressed()}>Conditions of Sale</LinkText>
+                  <LinkText onPress={isLoading ? null : () => this.onConditionsOfSaleLinkPressed()}>
+                    Conditions of Sale
+                  </LinkText>
                   .
                 </Serif14>
               </Flex>


### PR DESCRIPTION
This PR fixes a slight omission from #1172 where the conditions of sale link was enabled in the case where the user had previously accepted them and now checkbox was rendered. [Here](https://github.com/artsy/emission/pull/1172/files#diff-8a3a841add9adeac68c88de41a452cc4R446) is the line of code.

Self-assigning because everyone else is out and this is trivial. Wonder if merge on green works in PR bodies?