### PR TITLE
[Toolchain] Update Typescript to 3.0.3

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 src/__generated__/*.ts
 src/__generated__/*.json
+src/__generated__/*.graphql.ts
 node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Adding artwork badges to brick - matt
 * Add @artsy/palette - yuki/orta/chris
 * Adds a Labs setting UI to the example app - orta
+* Updates Typescript version to 3.0.3
 
 ### 1.5.15
 

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   "homepage": "https://github.com/artsy/emission#readme",
   "files": ["index.js", "data", "lib"],
   "resolutions": {
+    "parse5": "5.1.0",
     "graphql": "^0.13",
     "relay-runtime": "https://github.com/alloy/relay/releases/download/v1.5.0-artsy.5/relay-runtime-1.5.0-artsy.5.tgz"
   },

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "stylelint-config-standard": "^18.0.0",
     "stylelint-processor-styled-components": "^1.2.2",
     "ts-jest": "^22.0.2",
-    "tslint": "^5.8.0",
+    "tslint": "^5.11.0",
     "tslint-config-prettier": "^1.6.0",
     "typescript": "^3.0.3",
     "typescript-styled-plugin": "^0.1.2"

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "ts-jest": "^22.0.2",
     "tslint": "^5.8.0",
     "tslint-config-prettier": "^1.6.0",
-    "typescript": "^2.5.3",
+    "typescript": "^3.0.3",
     "typescript-styled-plugin": "^0.1.2"
   },
   "jest": {

--- a/patches/@types/react-native+0.52.1.patch
+++ b/patches/@types/react-native+0.52.1.patch
@@ -1,0 +1,15 @@
+patch-package
+--- a/node_modules/@types/react-native/index.d.ts
++++ b/node_modules/@types/react-native/index.d.ts
+@@ -8435,8 +8435,9 @@ export type Clipboard = ClipboardStatic;
+ export var DatePickerAndroid: DatePickerAndroidStatic;
+ export type DatePickerAndroid = DatePickerAndroidStatic;
+ 
+-export var Geolocation: GeolocationStatic;
+-export type Geolocation = GeolocationStatic;
++// https://github.com/DefinitelyTyped/DefinitelyTyped/issues/24573
++// export var Geolocation: GeolocationStatic;
++// export type Geolocation = GeolocationStatic;
+ 
+ /** http://facebook.github.io/react-native/blog/2016/08/19/right-to-left-support-for-react-native-apps.html */
+ export var I18nManager: I18nManagerStatic;

--- a/src/__generated__/About_artist.graphql.ts
+++ b/src/__generated__/About_artist.graphql.ts
@@ -5,10 +5,8 @@ export type About_artist = {
     readonly has_metadata: boolean | null;
     readonly is_display_auction_link: boolean | null;
     readonly id: string;
-    readonly related_artists: ReadonlyArray<({
-        }) | null> | null;
-    readonly articles: ReadonlyArray<({
-        }) | null> | null;
+    readonly related_artists: ReadonlyArray<({}) | null> | null;
+    readonly articles: ReadonlyArray<({}) | null> | null;
 };
 
 

--- a/src/__generated__/About_artist.graphql.ts
+++ b/src/__generated__/About_artist.graphql.ts
@@ -5,8 +5,10 @@ export type About_artist = {
     readonly has_metadata: boolean | null;
     readonly is_display_auction_link: boolean | null;
     readonly id: string;
-    readonly related_artists: ReadonlyArray<({}) | null> | null;
-    readonly articles: ReadonlyArray<({}) | null> | null;
+    readonly related_artists: ReadonlyArray<({
+        }) | null> | null;
+    readonly articles: ReadonlyArray<({
+        }) | null> | null;
 };
 
 

--- a/src/__generated__/About_gene.graphql.ts
+++ b/src/__generated__/About_gene.graphql.ts
@@ -2,8 +2,7 @@
 
 import { ConcreteFragment } from "relay-runtime";
 export type About_gene = {
-    readonly trending_artists: ReadonlyArray<({
-        }) | null> | null;
+    readonly trending_artists: ReadonlyArray<({}) | null> | null;
 };
 
 

--- a/src/__generated__/About_gene.graphql.ts
+++ b/src/__generated__/About_gene.graphql.ts
@@ -2,7 +2,8 @@
 
 import { ConcreteFragment } from "relay-runtime";
 export type About_gene = {
-    readonly trending_artists: ReadonlyArray<({}) | null> | null;
+    readonly trending_artists: ReadonlyArray<({
+        }) | null> | null;
 };
 
 

--- a/src/__generated__/ActiveBidsQuery.graphql.ts
+++ b/src/__generated__/ActiveBidsQuery.graphql.ts
@@ -1,11 +1,9 @@
 /* tslint:disable */
 
 import { ConcreteRequest } from "relay-runtime";
-export type ActiveBidsQueryVariables = {
-};
+export type ActiveBidsQueryVariables = {};
 export type ActiveBidsQueryResponse = {
-    readonly me: ({
-    }) | null;
+    readonly me: ({}) | null;
 };
 
 

--- a/src/__generated__/ActiveBidsQuery.graphql.ts
+++ b/src/__generated__/ActiveBidsQuery.graphql.ts
@@ -1,9 +1,11 @@
 /* tslint:disable */
 
 import { ConcreteRequest } from "relay-runtime";
-export type ActiveBidsQueryVariables = {};
+export type ActiveBidsQueryVariables = {
+};
 export type ActiveBidsQueryResponse = {
-    readonly me: ({}) | null;
+    readonly me: ({
+    }) | null;
 };
 
 

--- a/src/__generated__/ActiveBidsRefetchQuery.graphql.ts
+++ b/src/__generated__/ActiveBidsRefetchQuery.graphql.ts
@@ -1,11 +1,9 @@
 /* tslint:disable */
 
 import { ConcreteRequest } from "relay-runtime";
-export type ActiveBidsRefetchQueryVariables = {
-};
+export type ActiveBidsRefetchQueryVariables = {};
 export type ActiveBidsRefetchQueryResponse = {
-    readonly me: ({
-    }) | null;
+    readonly me: ({}) | null;
 };
 
 

--- a/src/__generated__/ActiveBidsRefetchQuery.graphql.ts
+++ b/src/__generated__/ActiveBidsRefetchQuery.graphql.ts
@@ -1,9 +1,11 @@
 /* tslint:disable */
 
 import { ConcreteRequest } from "relay-runtime";
-export type ActiveBidsRefetchQueryVariables = {};
+export type ActiveBidsRefetchQueryVariables = {
+};
 export type ActiveBidsRefetchQueryResponse = {
-    readonly me: ({}) | null;
+    readonly me: ({
+    }) | null;
 };
 
 

--- a/src/__generated__/ActiveBids_me.graphql.ts
+++ b/src/__generated__/ActiveBids_me.graphql.ts
@@ -3,10 +3,10 @@
 import { ConcreteFragment } from "relay-runtime";
 export type ActiveBids_me = {
     readonly lot_standings: ReadonlyArray<({
-        readonly most_recent_bid: ({
-            readonly __id: string;
-        }) | null;
-    }) | null> | null;
+            readonly most_recent_bid: ({
+                readonly __id: string;
+            }) | null;
+        }) | null> | null;
 };
 
 

--- a/src/__generated__/ActiveBids_me.graphql.ts
+++ b/src/__generated__/ActiveBids_me.graphql.ts
@@ -3,10 +3,10 @@
 import { ConcreteFragment } from "relay-runtime";
 export type ActiveBids_me = {
     readonly lot_standings: ReadonlyArray<({
-            readonly most_recent_bid: ({
-                readonly __id: string;
-            }) | null;
-        }) | null> | null;
+        readonly most_recent_bid: ({
+            readonly __id: string;
+        }) | null;
+    }) | null> | null;
 };
 
 

--- a/src/__generated__/Articles_articles.graphql.ts
+++ b/src/__generated__/Articles_articles.graphql.ts
@@ -2,8 +2,8 @@
 
 import { ConcreteFragment } from "relay-runtime";
 export type Articles_articles = ReadonlyArray<{
-    readonly __id: string;
-}>;
+        readonly __id: string;
+    }>;
 
 
 

--- a/src/__generated__/Articles_articles.graphql.ts
+++ b/src/__generated__/Articles_articles.graphql.ts
@@ -2,8 +2,8 @@
 
 import { ConcreteFragment } from "relay-runtime";
 export type Articles_articles = ReadonlyArray<{
-        readonly __id: string;
-    }>;
+    readonly __id: string;
+}>;
 
 
 

--- a/src/__generated__/ArtistForSaleArtworksGridQuery.graphql.ts
+++ b/src/__generated__/ArtistForSaleArtworksGridQuery.graphql.ts
@@ -9,8 +9,7 @@ export type ArtistForSaleArtworksGridQueryVariables = {
     readonly filter?: ReadonlyArray<ArtistArtworksFilters | null> | null;
 };
 export type ArtistForSaleArtworksGridQueryResponse = {
-    readonly node: ({
-    }) | null;
+    readonly node: ({}) | null;
 };
 
 

--- a/src/__generated__/ArtistForSaleArtworksGridQuery.graphql.ts
+++ b/src/__generated__/ArtistForSaleArtworksGridQuery.graphql.ts
@@ -9,7 +9,8 @@ export type ArtistForSaleArtworksGridQueryVariables = {
     readonly filter?: ReadonlyArray<ArtistArtworksFilters | null> | null;
 };
 export type ArtistForSaleArtworksGridQueryResponse = {
-    readonly node: ({}) | null;
+    readonly node: ({
+    }) | null;
 };
 
 

--- a/src/__generated__/ArtistForSaleArtworksGrid_artist.graphql.ts
+++ b/src/__generated__/ArtistForSaleArtworksGrid_artist.graphql.ts
@@ -10,14 +10,14 @@ export type ArtistForSaleArtworksGrid_artist = {
             readonly endCursor: string | null;
         };
         readonly edges: ReadonlyArray<({
-                readonly node: ({
-                    readonly id: string;
-                    readonly __id: string;
-                    readonly image: ({
-                        readonly aspect_ratio: number | null;
-                    }) | null;
+            readonly node: ({
+                readonly id: string;
+                readonly __id: string;
+                readonly image: ({
+                    readonly aspect_ratio: number | null;
                 }) | null;
-            }) | null> | null;
+            }) | null;
+        }) | null> | null;
     }) | null;
 };
 

--- a/src/__generated__/ArtistForSaleArtworksGrid_artist.graphql.ts
+++ b/src/__generated__/ArtistForSaleArtworksGrid_artist.graphql.ts
@@ -10,14 +10,14 @@ export type ArtistForSaleArtworksGrid_artist = {
             readonly endCursor: string | null;
         };
         readonly edges: ReadonlyArray<({
-            readonly node: ({
-                readonly id: string;
-                readonly __id: string;
-                readonly image: ({
-                    readonly aspect_ratio: number | null;
+                readonly node: ({
+                    readonly id: string;
+                    readonly __id: string;
+                    readonly image: ({
+                        readonly aspect_ratio: number | null;
+                    }) | null;
                 }) | null;
-            }) | null;
-        }) | null> | null;
+            }) | null> | null;
     }) | null;
 };
 

--- a/src/__generated__/ArtistHeaderQuery.graphql.ts
+++ b/src/__generated__/ArtistHeaderQuery.graphql.ts
@@ -5,8 +5,7 @@ export type ArtistHeaderQueryVariables = {
     readonly artistID: string;
 };
 export type ArtistHeaderQueryResponse = {
-    readonly artist: ({
-    }) | null;
+    readonly artist: ({}) | null;
 };
 
 

--- a/src/__generated__/ArtistHeaderQuery.graphql.ts
+++ b/src/__generated__/ArtistHeaderQuery.graphql.ts
@@ -5,7 +5,8 @@ export type ArtistHeaderQueryVariables = {
     readonly artistID: string;
 };
 export type ArtistHeaderQueryResponse = {
-    readonly artist: ({}) | null;
+    readonly artist: ({
+    }) | null;
 };
 
 

--- a/src/__generated__/ArtistNotForSaleArtworksGridQuery.graphql.ts
+++ b/src/__generated__/ArtistNotForSaleArtworksGridQuery.graphql.ts
@@ -9,8 +9,7 @@ export type ArtistNotForSaleArtworksGridQueryVariables = {
     readonly filter?: ReadonlyArray<ArtistArtworksFilters | null> | null;
 };
 export type ArtistNotForSaleArtworksGridQueryResponse = {
-    readonly node: ({
-    }) | null;
+    readonly node: ({}) | null;
 };
 
 

--- a/src/__generated__/ArtistNotForSaleArtworksGridQuery.graphql.ts
+++ b/src/__generated__/ArtistNotForSaleArtworksGridQuery.graphql.ts
@@ -9,7 +9,8 @@ export type ArtistNotForSaleArtworksGridQueryVariables = {
     readonly filter?: ReadonlyArray<ArtistArtworksFilters | null> | null;
 };
 export type ArtistNotForSaleArtworksGridQueryResponse = {
-    readonly node: ({}) | null;
+    readonly node: ({
+    }) | null;
 };
 
 

--- a/src/__generated__/ArtistNotForSaleArtworksGrid_artist.graphql.ts
+++ b/src/__generated__/ArtistNotForSaleArtworksGrid_artist.graphql.ts
@@ -10,14 +10,14 @@ export type ArtistNotForSaleArtworksGrid_artist = {
             readonly endCursor: string | null;
         };
         readonly edges: ReadonlyArray<({
-            readonly node: ({
-                readonly id: string;
-                readonly __id: string;
-                readonly image: ({
-                    readonly aspect_ratio: number | null;
+                readonly node: ({
+                    readonly id: string;
+                    readonly __id: string;
+                    readonly image: ({
+                        readonly aspect_ratio: number | null;
+                    }) | null;
                 }) | null;
-            }) | null;
-        }) | null> | null;
+            }) | null> | null;
     }) | null;
 };
 

--- a/src/__generated__/ArtistNotForSaleArtworksGrid_artist.graphql.ts
+++ b/src/__generated__/ArtistNotForSaleArtworksGrid_artist.graphql.ts
@@ -10,14 +10,14 @@ export type ArtistNotForSaleArtworksGrid_artist = {
             readonly endCursor: string | null;
         };
         readonly edges: ReadonlyArray<({
-                readonly node: ({
-                    readonly id: string;
-                    readonly __id: string;
-                    readonly image: ({
-                        readonly aspect_ratio: number | null;
-                    }) | null;
+            readonly node: ({
+                readonly id: string;
+                readonly __id: string;
+                readonly image: ({
+                    readonly aspect_ratio: number | null;
                 }) | null;
-            }) | null> | null;
+            }) | null;
+        }) | null> | null;
     }) | null;
 };
 

--- a/src/__generated__/ArtistQuery.graphql.ts
+++ b/src/__generated__/ArtistQuery.graphql.ts
@@ -5,8 +5,7 @@ export type ArtistQueryVariables = {
     readonly artistID: string;
 };
 export type ArtistQueryResponse = {
-    readonly artist: ({
-    }) | null;
+    readonly artist: ({}) | null;
 };
 
 

--- a/src/__generated__/ArtistQuery.graphql.ts
+++ b/src/__generated__/ArtistQuery.graphql.ts
@@ -5,7 +5,8 @@ export type ArtistQueryVariables = {
     readonly artistID: string;
 };
 export type ArtistQueryResponse = {
-    readonly artist: ({}) | null;
+    readonly artist: ({
+    }) | null;
 };
 
 

--- a/src/__generated__/ArtistRail_rail.graphql.ts
+++ b/src/__generated__/ArtistRail_rail.graphql.ts
@@ -5,9 +5,9 @@ export type ArtistRail_rail = {
     readonly __id: string;
     readonly key: string | null;
     readonly results: ReadonlyArray<({
-        readonly _id: string;
-        readonly __id: string;
-    }) | null> | null;
+            readonly _id: string;
+            readonly __id: string;
+        }) | null> | null;
 };
 
 

--- a/src/__generated__/ArtistRail_rail.graphql.ts
+++ b/src/__generated__/ArtistRail_rail.graphql.ts
@@ -5,9 +5,9 @@ export type ArtistRail_rail = {
     readonly __id: string;
     readonly key: string | null;
     readonly results: ReadonlyArray<({
-            readonly _id: string;
-            readonly __id: string;
-        }) | null> | null;
+        readonly _id: string;
+        readonly __id: string;
+    }) | null> | null;
 };
 
 

--- a/src/__generated__/ArtistsMeQuery.graphql.ts
+++ b/src/__generated__/ArtistsMeQuery.graphql.ts
@@ -6,7 +6,8 @@ export type ArtistsMeQueryVariables = {
     readonly cursor?: string | null;
 };
 export type ArtistsMeQueryResponse = {
-    readonly me: ({}) | null;
+    readonly me: ({
+    }) | null;
 };
 
 

--- a/src/__generated__/ArtistsMeQuery.graphql.ts
+++ b/src/__generated__/ArtistsMeQuery.graphql.ts
@@ -6,8 +6,7 @@ export type ArtistsMeQueryVariables = {
     readonly cursor?: string | null;
 };
 export type ArtistsMeQueryResponse = {
-    readonly me: ({
-    }) | null;
+    readonly me: ({}) | null;
 };
 
 

--- a/src/__generated__/Artists_me.graphql.ts
+++ b/src/__generated__/Artists_me.graphql.ts
@@ -8,18 +8,18 @@ export type Artists_me = {
             readonly hasNextPage: boolean;
         };
         readonly edges: ReadonlyArray<({
-            readonly node: ({
-                readonly artist: ({
-                    readonly id: string;
-                    readonly __id: string;
-                    readonly name: string | null;
-                    readonly href: string | null;
-                    readonly image: ({
-                        readonly url: string | null;
+                readonly node: ({
+                    readonly artist: ({
+                        readonly id: string;
+                        readonly __id: string;
+                        readonly name: string | null;
+                        readonly href: string | null;
+                        readonly image: ({
+                            readonly url: string | null;
+                        }) | null;
                     }) | null;
                 }) | null;
-            }) | null;
-        }) | null> | null;
+            }) | null> | null;
     }) | null;
 };
 

--- a/src/__generated__/Artists_me.graphql.ts
+++ b/src/__generated__/Artists_me.graphql.ts
@@ -8,18 +8,18 @@ export type Artists_me = {
             readonly hasNextPage: boolean;
         };
         readonly edges: ReadonlyArray<({
-                readonly node: ({
-                    readonly artist: ({
-                        readonly id: string;
-                        readonly __id: string;
-                        readonly name: string | null;
-                        readonly href: string | null;
-                        readonly image: ({
-                            readonly url: string | null;
-                        }) | null;
+            readonly node: ({
+                readonly artist: ({
+                    readonly id: string;
+                    readonly __id: string;
+                    readonly name: string | null;
+                    readonly href: string | null;
+                    readonly image: ({
+                        readonly url: string | null;
                     }) | null;
                 }) | null;
-            }) | null> | null;
+            }) | null;
+        }) | null> | null;
     }) | null;
 };
 

--- a/src/__generated__/ArtworkCarousel_rail.graphql.ts
+++ b/src/__generated__/ArtworkCarousel_rail.graphql.ts
@@ -14,7 +14,8 @@ export type ArtworkCarousel_rail = {
         }) | null;
         readonly href?: string | null;
     }) | null;
-    readonly results: ReadonlyArray<({}) | null> | null;
+    readonly results: ReadonlyArray<({
+        }) | null> | null;
 };
 
 

--- a/src/__generated__/ArtworkCarousel_rail.graphql.ts
+++ b/src/__generated__/ArtworkCarousel_rail.graphql.ts
@@ -14,8 +14,7 @@ export type ArtworkCarousel_rail = {
         }) | null;
         readonly href?: string | null;
     }) | null;
-    readonly results: ReadonlyArray<({
-        }) | null> | null;
+    readonly results: ReadonlyArray<({}) | null> | null;
 };
 
 

--- a/src/__generated__/ArtworkRailRefetchQuery.graphql.ts
+++ b/src/__generated__/ArtworkRailRefetchQuery.graphql.ts
@@ -6,8 +6,7 @@ export type ArtworkRailRefetchQueryVariables = {
     readonly fetchContent: boolean;
 };
 export type ArtworkRailRefetchQueryResponse = {
-    readonly node: ({
-    }) | null;
+    readonly node: ({}) | null;
 };
 
 

--- a/src/__generated__/ArtworkRailRefetchQuery.graphql.ts
+++ b/src/__generated__/ArtworkRailRefetchQuery.graphql.ts
@@ -6,7 +6,8 @@ export type ArtworkRailRefetchQueryVariables = {
     readonly fetchContent: boolean;
 };
 export type ArtworkRailRefetchQueryResponse = {
-    readonly node: ({}) | null;
+    readonly node: ({
+    }) | null;
 };
 
 

--- a/src/__generated__/ArtworkRail_rail.graphql.ts
+++ b/src/__generated__/ArtworkRail_rail.graphql.ts
@@ -14,7 +14,8 @@ export type ArtworkRail_rail = {
         }) | null;
         readonly href?: string | null;
     }) | null;
-    readonly results?: ReadonlyArray<({}) | null> | null;
+    readonly results?: ReadonlyArray<({
+        }) | null> | null;
 };
 
 

--- a/src/__generated__/ArtworkRail_rail.graphql.ts
+++ b/src/__generated__/ArtworkRail_rail.graphql.ts
@@ -14,8 +14,7 @@ export type ArtworkRail_rail = {
         }) | null;
         readonly href?: string | null;
     }) | null;
-    readonly results?: ReadonlyArray<({
-        }) | null> | null;
+    readonly results?: ReadonlyArray<({}) | null> | null;
 };
 
 

--- a/src/__generated__/Artwork_artwork.graphql.ts
+++ b/src/__generated__/Artwork_artwork.graphql.ts
@@ -26,8 +26,8 @@ export type Artwork_artwork = {
         readonly aspect_ratio: number | null;
     }) | null;
     readonly artists: ReadonlyArray<({
-            readonly name: string | null;
-        }) | null> | null;
+        readonly name: string | null;
+    }) | null> | null;
     readonly partner: ({
         readonly name: string | null;
     }) | null;

--- a/src/__generated__/Artwork_artwork.graphql.ts
+++ b/src/__generated__/Artwork_artwork.graphql.ts
@@ -26,8 +26,8 @@ export type Artwork_artwork = {
         readonly aspect_ratio: number | null;
     }) | null;
     readonly artists: ReadonlyArray<({
-        readonly name: string | null;
-    }) | null> | null;
+            readonly name: string | null;
+        }) | null> | null;
     readonly partner: ({
         readonly name: string | null;
     }) | null;

--- a/src/__generated__/ArtworksQuery.graphql.ts
+++ b/src/__generated__/ArtworksQuery.graphql.ts
@@ -6,7 +6,8 @@ export type ArtworksQueryVariables = {
     readonly cursor?: string | null;
 };
 export type ArtworksQueryResponse = {
-    readonly me: ({}) | null;
+    readonly me: ({
+    }) | null;
 };
 
 

--- a/src/__generated__/ArtworksQuery.graphql.ts
+++ b/src/__generated__/ArtworksQuery.graphql.ts
@@ -6,8 +6,7 @@ export type ArtworksQueryVariables = {
     readonly cursor?: string | null;
 };
 export type ArtworksQueryResponse = {
-    readonly me: ({
-    }) | null;
+    readonly me: ({}) | null;
 };
 
 

--- a/src/__generated__/Artworks_me.graphql.ts
+++ b/src/__generated__/Artworks_me.graphql.ts
@@ -9,8 +9,9 @@ export type Artworks_me = {
                 readonly hasNextPage: boolean;
             };
             readonly edges: ReadonlyArray<({
-                readonly node: ({}) | null;
-            }) | null> | null;
+                    readonly node: ({
+                    }) | null;
+                }) | null> | null;
         }) | null;
     }) | null;
 };

--- a/src/__generated__/Artworks_me.graphql.ts
+++ b/src/__generated__/Artworks_me.graphql.ts
@@ -9,9 +9,8 @@ export type Artworks_me = {
                 readonly hasNextPage: boolean;
             };
             readonly edges: ReadonlyArray<({
-                    readonly node: ({
-                    }) | null;
-                }) | null> | null;
+                readonly node: ({}) | null;
+            }) | null> | null;
         }) | null;
     }) | null;
 };

--- a/src/__generated__/BidFlowSelectMaxBidRendererQuery.graphql.ts
+++ b/src/__generated__/BidFlowSelectMaxBidRendererQuery.graphql.ts
@@ -5,8 +5,7 @@ export type BidFlowSelectMaxBidRendererQueryVariables = {
     readonly saleArtworkID: string;
 };
 export type BidFlowSelectMaxBidRendererQueryResponse = {
-    readonly sale_artwork: ({
-    }) | null;
+    readonly sale_artwork: ({}) | null;
 };
 
 

--- a/src/__generated__/BidFlowSelectMaxBidRendererQuery.graphql.ts
+++ b/src/__generated__/BidFlowSelectMaxBidRendererQuery.graphql.ts
@@ -5,7 +5,8 @@ export type BidFlowSelectMaxBidRendererQueryVariables = {
     readonly saleArtworkID: string;
 };
 export type BidFlowSelectMaxBidRendererQueryResponse = {
-    readonly sale_artwork: ({}) | null;
+    readonly sale_artwork: ({
+    }) | null;
 };
 
 

--- a/src/__generated__/BidFlow_me.graphql.ts
+++ b/src/__generated__/BidFlow_me.graphql.ts
@@ -1,7 +1,8 @@
 /* tslint:disable */
 
 import { ConcreteFragment } from "relay-runtime";
-export type BidFlow_me = {};
+export type BidFlow_me = {
+};
 
 
 

--- a/src/__generated__/BidFlow_me.graphql.ts
+++ b/src/__generated__/BidFlow_me.graphql.ts
@@ -1,8 +1,7 @@
 /* tslint:disable */
 
 import { ConcreteFragment } from "relay-runtime";
-export type BidFlow_me = {
-};
+export type BidFlow_me = {};
 
 
 

--- a/src/__generated__/BidFlow_sale_artwork.graphql.ts
+++ b/src/__generated__/BidFlow_sale_artwork.graphql.ts
@@ -1,8 +1,7 @@
 /* tslint:disable */
 
 import { ConcreteFragment } from "relay-runtime";
-export type BidFlow_sale_artwork = {
-};
+export type BidFlow_sale_artwork = {};
 
 
 

--- a/src/__generated__/BidFlow_sale_artwork.graphql.ts
+++ b/src/__generated__/BidFlow_sale_artwork.graphql.ts
@@ -1,7 +1,8 @@
 /* tslint:disable */
 
 import { ConcreteFragment } from "relay-runtime";
-export type BidFlow_sale_artwork = {};
+export type BidFlow_sale_artwork = {
+};
 
 
 

--- a/src/__generated__/CategoriesMeQuery.graphql.ts
+++ b/src/__generated__/CategoriesMeQuery.graphql.ts
@@ -6,8 +6,7 @@ export type CategoriesMeQueryVariables = {
     readonly cursor?: string | null;
 };
 export type CategoriesMeQueryResponse = {
-    readonly me: ({
-    }) | null;
+    readonly me: ({}) | null;
 };
 
 

--- a/src/__generated__/CategoriesMeQuery.graphql.ts
+++ b/src/__generated__/CategoriesMeQuery.graphql.ts
@@ -6,7 +6,8 @@ export type CategoriesMeQueryVariables = {
     readonly cursor?: string | null;
 };
 export type CategoriesMeQueryResponse = {
-    readonly me: ({}) | null;
+    readonly me: ({
+    }) | null;
 };
 
 

--- a/src/__generated__/Categories_me.graphql.ts
+++ b/src/__generated__/Categories_me.graphql.ts
@@ -8,18 +8,18 @@ export type Categories_me = {
             readonly hasNextPage: boolean;
         };
         readonly edges: ReadonlyArray<({
-            readonly node: ({
-                readonly gene: ({
-                    readonly id: string;
-                    readonly __id: string;
-                    readonly name: string | null;
-                    readonly href: string | null;
-                    readonly image: ({
-                        readonly url: string | null;
+                readonly node: ({
+                    readonly gene: ({
+                        readonly id: string;
+                        readonly __id: string;
+                        readonly name: string | null;
+                        readonly href: string | null;
+                        readonly image: ({
+                            readonly url: string | null;
+                        }) | null;
                     }) | null;
                 }) | null;
-            }) | null;
-        }) | null> | null;
+            }) | null> | null;
     }) | null;
 };
 

--- a/src/__generated__/Categories_me.graphql.ts
+++ b/src/__generated__/Categories_me.graphql.ts
@@ -8,18 +8,18 @@ export type Categories_me = {
             readonly hasNextPage: boolean;
         };
         readonly edges: ReadonlyArray<({
-                readonly node: ({
-                    readonly gene: ({
-                        readonly id: string;
-                        readonly __id: string;
-                        readonly name: string | null;
-                        readonly href: string | null;
-                        readonly image: ({
-                            readonly url: string | null;
-                        }) | null;
+            readonly node: ({
+                readonly gene: ({
+                    readonly id: string;
+                    readonly __id: string;
+                    readonly name: string | null;
+                    readonly href: string | null;
+                    readonly image: ({
+                        readonly url: string | null;
                     }) | null;
                 }) | null;
-            }) | null> | null;
+            }) | null;
+        }) | null> | null;
     }) | null;
 };
 

--- a/src/__generated__/ConfirmBidRefetchQuery.graphql.ts
+++ b/src/__generated__/ConfirmBidRefetchQuery.graphql.ts
@@ -8,8 +8,8 @@ export type ConfirmBidRefetchQueryResponse = {
     readonly me: ({
         readonly has_qualified_credit_cards: boolean | null;
         readonly bidders: ReadonlyArray<({
-            readonly qualified_for_bidding: boolean | null;
-        }) | null> | null;
+                readonly qualified_for_bidding: boolean | null;
+            }) | null> | null;
     }) | null;
 };
 

--- a/src/__generated__/ConfirmBidRefetchQuery.graphql.ts
+++ b/src/__generated__/ConfirmBidRefetchQuery.graphql.ts
@@ -8,8 +8,8 @@ export type ConfirmBidRefetchQueryResponse = {
     readonly me: ({
         readonly has_qualified_credit_cards: boolean | null;
         readonly bidders: ReadonlyArray<({
-                readonly qualified_for_bidding: boolean | null;
-            }) | null> | null;
+            readonly qualified_for_bidding: boolean | null;
+        }) | null> | null;
     }) | null;
 };
 

--- a/src/__generated__/ConfirmBid_me.graphql.ts
+++ b/src/__generated__/ConfirmBid_me.graphql.ts
@@ -4,8 +4,8 @@ import { ConcreteFragment } from "relay-runtime";
 export type ConfirmBid_me = {
     readonly has_qualified_credit_cards: boolean | null;
     readonly bidders: ReadonlyArray<({
-        readonly qualified_for_bidding: boolean | null;
-    }) | null> | null;
+            readonly qualified_for_bidding: boolean | null;
+        }) | null> | null;
 };
 
 

--- a/src/__generated__/ConfirmBid_me.graphql.ts
+++ b/src/__generated__/ConfirmBid_me.graphql.ts
@@ -4,8 +4,8 @@ import { ConcreteFragment } from "relay-runtime";
 export type ConfirmBid_me = {
     readonly has_qualified_credit_cards: boolean | null;
     readonly bidders: ReadonlyArray<({
-            readonly qualified_for_bidding: boolean | null;
-        }) | null> | null;
+        readonly qualified_for_bidding: boolean | null;
+    }) | null> | null;
 };
 
 

--- a/src/__generated__/ConversationSnippet_conversation.graphql.ts
+++ b/src/__generated__/ConversationSnippet_conversation.graphql.ts
@@ -10,29 +10,29 @@ export type ConversationSnippet_conversation = {
     readonly last_message_at: string | null;
     readonly unread: boolean | null;
     readonly items: ReadonlyArray<({
-            readonly item: ({
-                readonly __typename: "Artwork";
-                readonly date: string | null;
-                readonly title: string | null;
-                readonly artist_names: string | null;
-                readonly image: ({
-                    readonly url: string | null;
-                }) | null;
-            } | {
-                readonly __typename: "Show";
-                readonly fair: ({
-                    readonly name: string | null;
-                }) | null;
-                readonly name: string | null;
-                readonly cover_image: ({
-                    readonly url: string | null;
-                }) | null;
-            } | {
-                /*This will never be '% other', but we need some
-                value in case none of the concrete values match.*/
-                readonly __typename: "%other";
+        readonly item: ({
+            readonly __typename: "Artwork";
+            readonly date: string | null;
+            readonly title: string | null;
+            readonly artist_names: string | null;
+            readonly image: ({
+                readonly url: string | null;
             }) | null;
-        }) | null> | null;
+        } | {
+            readonly __typename: "Show";
+            readonly fair: ({
+                readonly name: string | null;
+            }) | null;
+            readonly name: string | null;
+            readonly cover_image: ({
+                readonly url: string | null;
+            }) | null;
+        } | {
+            /*This will never be '% other', but we need some
+            value in case none of the concrete values match.*/
+            readonly __typename: "%other";
+        }) | null;
+    }) | null> | null;
 };
 
 

--- a/src/__generated__/ConversationSnippet_conversation.graphql.ts
+++ b/src/__generated__/ConversationSnippet_conversation.graphql.ts
@@ -10,29 +10,29 @@ export type ConversationSnippet_conversation = {
     readonly last_message_at: string | null;
     readonly unread: boolean | null;
     readonly items: ReadonlyArray<({
-        readonly item: ({
-            readonly __typename: "Artwork";
-            readonly date: string | null;
-            readonly title: string | null;
-            readonly artist_names: string | null;
-            readonly image: ({
-                readonly url: string | null;
-            }) | null;
-        } | {
-            readonly __typename: "Show";
-            readonly fair: ({
+            readonly item: ({
+                readonly __typename: "Artwork";
+                readonly date: string | null;
+                readonly title: string | null;
+                readonly artist_names: string | null;
+                readonly image: ({
+                    readonly url: string | null;
+                }) | null;
+            } | {
+                readonly __typename: "Show";
+                readonly fair: ({
+                    readonly name: string | null;
+                }) | null;
                 readonly name: string | null;
+                readonly cover_image: ({
+                    readonly url: string | null;
+                }) | null;
+            } | {
+                /*This will never be '% other', but we need some
+                value in case none of the concrete values match.*/
+                readonly __typename: "%other";
             }) | null;
-            readonly name: string | null;
-            readonly cover_image: ({
-                readonly url: string | null;
-            }) | null;
-        } | {
-            /*This will never be '% other', but we need some
-            value in case none of the concrete values match.*/
-            readonly __typename: "%other";
-        }) | null;
-    }) | null> | null;
+        }) | null> | null;
 };
 
 

--- a/src/__generated__/ConversationsQuery.graphql.ts
+++ b/src/__generated__/ConversationsQuery.graphql.ts
@@ -6,8 +6,7 @@ export type ConversationsQueryVariables = {
     readonly cursor?: string | null;
 };
 export type ConversationsQueryResponse = {
-    readonly me: ({
-    }) | null;
+    readonly me: ({}) | null;
 };
 
 

--- a/src/__generated__/ConversationsQuery.graphql.ts
+++ b/src/__generated__/ConversationsQuery.graphql.ts
@@ -6,7 +6,8 @@ export type ConversationsQueryVariables = {
     readonly cursor?: string | null;
 };
 export type ConversationsQueryResponse = {
-    readonly me: ({}) | null;
+    readonly me: ({
+    }) | null;
 };
 
 

--- a/src/__generated__/Conversations_me.graphql.ts
+++ b/src/__generated__/Conversations_me.graphql.ts
@@ -8,11 +8,11 @@ export type Conversations_me = {
             readonly hasNextPage: boolean;
         };
         readonly edges: ReadonlyArray<({
-                readonly node: ({
-                    readonly id: string | null;
-                    readonly last_message: string | null;
-                }) | null;
-            }) | null> | null;
+            readonly node: ({
+                readonly id: string | null;
+                readonly last_message: string | null;
+            }) | null;
+        }) | null> | null;
     }) | null;
 };
 

--- a/src/__generated__/Conversations_me.graphql.ts
+++ b/src/__generated__/Conversations_me.graphql.ts
@@ -8,11 +8,11 @@ export type Conversations_me = {
             readonly hasNextPage: boolean;
         };
         readonly edges: ReadonlyArray<({
-            readonly node: ({
-                readonly id: string | null;
-                readonly last_message: string | null;
-            }) | null;
-        }) | null> | null;
+                readonly node: ({
+                    readonly id: string | null;
+                    readonly last_message: string | null;
+                }) | null;
+            }) | null> | null;
     }) | null;
 };
 

--- a/src/__generated__/FairsRail_fairs_module.graphql.ts
+++ b/src/__generated__/FairsRail_fairs_module.graphql.ts
@@ -3,16 +3,16 @@
 import { ConcreteFragment } from "relay-runtime";
 export type FairsRail_fairs_module = {
     readonly results: ReadonlyArray<({
-            readonly id: string;
-            readonly name: string | null;
-            readonly profile: ({
-                readonly href: string | null;
-            }) | null;
-            readonly mobile_image: ({
-                readonly id: string | null;
-                readonly url: string | null;
-            }) | null;
-        }) | null>;
+        readonly id: string;
+        readonly name: string | null;
+        readonly profile: ({
+            readonly href: string | null;
+        }) | null;
+        readonly mobile_image: ({
+            readonly id: string | null;
+            readonly url: string | null;
+        }) | null;
+    }) | null>;
 };
 
 

--- a/src/__generated__/FairsRail_fairs_module.graphql.ts
+++ b/src/__generated__/FairsRail_fairs_module.graphql.ts
@@ -3,16 +3,16 @@
 import { ConcreteFragment } from "relay-runtime";
 export type FairsRail_fairs_module = {
     readonly results: ReadonlyArray<({
-        readonly id: string;
-        readonly name: string | null;
-        readonly profile: ({
-            readonly href: string | null;
-        }) | null;
-        readonly mobile_image: ({
-            readonly id: string | null;
-            readonly url: string | null;
-        }) | null;
-    }) | null>;
+            readonly id: string;
+            readonly name: string | null;
+            readonly profile: ({
+                readonly href: string | null;
+            }) | null;
+            readonly mobile_image: ({
+                readonly id: string | null;
+                readonly url: string | null;
+            }) | null;
+        }) | null>;
 };
 
 

--- a/src/__generated__/FavoriteArtistsQuery.graphql.ts
+++ b/src/__generated__/FavoriteArtistsQuery.graphql.ts
@@ -1,9 +1,11 @@
 /* tslint:disable */
 
 import { ConcreteRequest } from "relay-runtime";
-export type FavoriteArtistsQueryVariables = {};
+export type FavoriteArtistsQueryVariables = {
+};
 export type FavoriteArtistsQueryResponse = {
-    readonly me: ({}) | null;
+    readonly me: ({
+    }) | null;
 };
 
 

--- a/src/__generated__/FavoriteArtistsQuery.graphql.ts
+++ b/src/__generated__/FavoriteArtistsQuery.graphql.ts
@@ -1,11 +1,9 @@
 /* tslint:disable */
 
 import { ConcreteRequest } from "relay-runtime";
-export type FavoriteArtistsQueryVariables = {
-};
+export type FavoriteArtistsQueryVariables = {};
 export type FavoriteArtistsQueryResponse = {
-    readonly me: ({
-    }) | null;
+    readonly me: ({}) | null;
 };
 
 

--- a/src/__generated__/FavoriteArtworksQuery.graphql.ts
+++ b/src/__generated__/FavoriteArtworksQuery.graphql.ts
@@ -1,11 +1,9 @@
 /* tslint:disable */
 
 import { ConcreteRequest } from "relay-runtime";
-export type FavoriteArtworksQueryVariables = {
-};
+export type FavoriteArtworksQueryVariables = {};
 export type FavoriteArtworksQueryResponse = {
-    readonly me: ({
-    }) | null;
+    readonly me: ({}) | null;
 };
 
 

--- a/src/__generated__/FavoriteArtworksQuery.graphql.ts
+++ b/src/__generated__/FavoriteArtworksQuery.graphql.ts
@@ -1,9 +1,11 @@
 /* tslint:disable */
 
 import { ConcreteRequest } from "relay-runtime";
-export type FavoriteArtworksQueryVariables = {};
+export type FavoriteArtworksQueryVariables = {
+};
 export type FavoriteArtworksQueryResponse = {
-    readonly me: ({}) | null;
+    readonly me: ({
+    }) | null;
 };
 
 

--- a/src/__generated__/FavoriteCategoriesQuery.graphql.ts
+++ b/src/__generated__/FavoriteCategoriesQuery.graphql.ts
@@ -1,9 +1,11 @@
 /* tslint:disable */
 
 import { ConcreteRequest } from "relay-runtime";
-export type FavoriteCategoriesQueryVariables = {};
+export type FavoriteCategoriesQueryVariables = {
+};
 export type FavoriteCategoriesQueryResponse = {
-    readonly me: ({}) | null;
+    readonly me: ({
+    }) | null;
 };
 
 

--- a/src/__generated__/FavoriteCategoriesQuery.graphql.ts
+++ b/src/__generated__/FavoriteCategoriesQuery.graphql.ts
@@ -1,11 +1,9 @@
 /* tslint:disable */
 
 import { ConcreteRequest } from "relay-runtime";
-export type FavoriteCategoriesQueryVariables = {
-};
+export type FavoriteCategoriesQueryVariables = {};
 export type FavoriteCategoriesQueryResponse = {
-    readonly me: ({
-    }) | null;
+    readonly me: ({}) | null;
 };
 
 

--- a/src/__generated__/ForYouRefetchQuery.graphql.ts
+++ b/src/__generated__/ForYouRefetchQuery.graphql.ts
@@ -1,11 +1,9 @@
 /* tslint:disable */
 
 import { ConcreteRequest } from "relay-runtime";
-export type ForYouRefetchQueryVariables = {
-};
+export type ForYouRefetchQueryVariables = {};
 export type ForYouRefetchQueryResponse = {
-    readonly forYou: ({
-    }) | null;
+    readonly forYou: ({}) | null;
 };
 
 

--- a/src/__generated__/ForYouRefetchQuery.graphql.ts
+++ b/src/__generated__/ForYouRefetchQuery.graphql.ts
@@ -1,9 +1,11 @@
 /* tslint:disable */
 
 import { ConcreteRequest } from "relay-runtime";
-export type ForYouRefetchQueryVariables = {};
+export type ForYouRefetchQueryVariables = {
+};
 export type ForYouRefetchQueryResponse = {
-    readonly forYou: ({}) | null;
+    readonly forYou: ({
+    }) | null;
 };
 
 

--- a/src/__generated__/ForYou_forYou.graphql.ts
+++ b/src/__generated__/ForYou_forYou.graphql.ts
@@ -3,13 +3,12 @@
 import { ConcreteFragment } from "relay-runtime";
 export type ForYou_forYou = {
     readonly artwork_modules: ReadonlyArray<({
-            readonly __id: string;
-        }) | null> | null;
+        readonly __id: string;
+    }) | null> | null;
     readonly artist_modules: ReadonlyArray<({
-            readonly __id: string;
-        }) | null> | null;
-    readonly fairs_module: ({
-    }) | null;
+        readonly __id: string;
+    }) | null> | null;
+    readonly fairs_module: ({}) | null;
 };
 
 

--- a/src/__generated__/ForYou_forYou.graphql.ts
+++ b/src/__generated__/ForYou_forYou.graphql.ts
@@ -3,12 +3,13 @@
 import { ConcreteFragment } from "relay-runtime";
 export type ForYou_forYou = {
     readonly artwork_modules: ReadonlyArray<({
-        readonly __id: string;
-    }) | null> | null;
+            readonly __id: string;
+        }) | null> | null;
     readonly artist_modules: ReadonlyArray<({
-        readonly __id: string;
-    }) | null> | null;
-    readonly fairs_module: ({}) | null;
+            readonly __id: string;
+        }) | null> | null;
+    readonly fairs_module: ({
+    }) | null;
 };
 
 

--- a/src/__generated__/GeneArtworksGridQuery.graphql.ts
+++ b/src/__generated__/GeneArtworksGridQuery.graphql.ts
@@ -8,7 +8,8 @@ export type GeneArtworksGridQueryVariables = {
     readonly sort?: string | null;
 };
 export type GeneArtworksGridQueryResponse = {
-    readonly node: ({}) | null;
+    readonly node: ({
+    }) | null;
 };
 
 

--- a/src/__generated__/GeneArtworksGridQuery.graphql.ts
+++ b/src/__generated__/GeneArtworksGridQuery.graphql.ts
@@ -8,8 +8,7 @@ export type GeneArtworksGridQueryVariables = {
     readonly sort?: string | null;
 };
 export type GeneArtworksGridQueryResponse = {
-    readonly node: ({
-    }) | null;
+    readonly node: ({}) | null;
 };
 
 

--- a/src/__generated__/GeneArtworksGrid_filtered_artworks.graphql.ts
+++ b/src/__generated__/GeneArtworksGrid_filtered_artworks.graphql.ts
@@ -10,14 +10,14 @@ export type GeneArtworksGrid_filtered_artworks = {
             readonly endCursor: string | null;
         };
         readonly edges: ReadonlyArray<({
-            readonly node: ({
-                readonly id: string;
-                readonly __id: string;
-                readonly image: ({
-                    readonly aspect_ratio: number | null;
+                readonly node: ({
+                    readonly id: string;
+                    readonly __id: string;
+                    readonly image: ({
+                        readonly aspect_ratio: number | null;
+                    }) | null;
                 }) | null;
-            }) | null;
-        }) | null> | null;
+            }) | null> | null;
     }) | null;
 };
 

--- a/src/__generated__/GeneArtworksGrid_filtered_artworks.graphql.ts
+++ b/src/__generated__/GeneArtworksGrid_filtered_artworks.graphql.ts
@@ -10,14 +10,14 @@ export type GeneArtworksGrid_filtered_artworks = {
             readonly endCursor: string | null;
         };
         readonly edges: ReadonlyArray<({
-                readonly node: ({
-                    readonly id: string;
-                    readonly __id: string;
-                    readonly image: ({
-                        readonly aspect_ratio: number | null;
-                    }) | null;
+            readonly node: ({
+                readonly id: string;
+                readonly __id: string;
+                readonly image: ({
+                    readonly aspect_ratio: number | null;
                 }) | null;
-            }) | null> | null;
+            }) | null;
+        }) | null> | null;
     }) | null;
 };
 

--- a/src/__generated__/GeneRefetchQuery.graphql.ts
+++ b/src/__generated__/GeneRefetchQuery.graphql.ts
@@ -8,7 +8,8 @@ export type GeneRefetchQueryVariables = {
     readonly price_range?: string | null;
 };
 export type GeneRefetchQueryResponse = {
-    readonly gene: ({}) | null;
+    readonly gene: ({
+    }) | null;
 };
 
 

--- a/src/__generated__/GeneRefetchQuery.graphql.ts
+++ b/src/__generated__/GeneRefetchQuery.graphql.ts
@@ -8,8 +8,7 @@ export type GeneRefetchQueryVariables = {
     readonly price_range?: string | null;
 };
 export type GeneRefetchQueryResponse = {
-    readonly gene: ({
-    }) | null;
+    readonly gene: ({}) | null;
 };
 
 

--- a/src/__generated__/Gene_gene.graphql.ts
+++ b/src/__generated__/Gene_gene.graphql.ts
@@ -6,13 +6,13 @@ export type Gene_gene = {
     readonly filtered_artworks: ({
         readonly total: number | null;
         readonly aggregations: ReadonlyArray<({
-                readonly slice: ArtworkAggregation | null;
-                readonly counts: ReadonlyArray<({
-                        readonly id: string;
-                        readonly name: string | null;
-                        readonly count: number | null;
-                    }) | null> | null;
+            readonly slice: ArtworkAggregation | null;
+            readonly counts: ReadonlyArray<({
+                readonly id: string;
+                readonly name: string | null;
+                readonly count: number | null;
             }) | null> | null;
+        }) | null> | null;
     }) | null;
 };
 

--- a/src/__generated__/Gene_gene.graphql.ts
+++ b/src/__generated__/Gene_gene.graphql.ts
@@ -6,13 +6,13 @@ export type Gene_gene = {
     readonly filtered_artworks: ({
         readonly total: number | null;
         readonly aggregations: ReadonlyArray<({
-            readonly slice: ArtworkAggregation | null;
-            readonly counts: ReadonlyArray<({
-                readonly id: string;
-                readonly name: string | null;
-                readonly count: number | null;
+                readonly slice: ArtworkAggregation | null;
+                readonly counts: ReadonlyArray<({
+                        readonly id: string;
+                        readonly name: string | null;
+                        readonly count: number | null;
+                    }) | null> | null;
             }) | null> | null;
-        }) | null> | null;
     }) | null;
 };
 

--- a/src/__generated__/GenericGrid_artworks.graphql.ts
+++ b/src/__generated__/GenericGrid_artworks.graphql.ts
@@ -2,12 +2,12 @@
 
 import { ConcreteFragment } from "relay-runtime";
 export type GenericGrid_artworks = ReadonlyArray<{
-    readonly __id: string;
-    readonly id: string;
-    readonly image: ({
-        readonly aspect_ratio: number | null;
-    }) | null;
-}>;
+        readonly __id: string;
+        readonly id: string;
+        readonly image: ({
+            readonly aspect_ratio: number | null;
+        }) | null;
+    }>;
 
 
 

--- a/src/__generated__/GenericGrid_artworks.graphql.ts
+++ b/src/__generated__/GenericGrid_artworks.graphql.ts
@@ -2,12 +2,12 @@
 
 import { ConcreteFragment } from "relay-runtime";
 export type GenericGrid_artworks = ReadonlyArray<{
-        readonly __id: string;
-        readonly id: string;
-        readonly image: ({
-            readonly aspect_ratio: number | null;
-        }) | null;
-    }>;
+    readonly __id: string;
+    readonly id: string;
+    readonly image: ({
+        readonly aspect_ratio: number | null;
+    }) | null;
+}>;
 
 
 

--- a/src/__generated__/HeroUnits_hero_units.graphql.ts
+++ b/src/__generated__/HeroUnits_hero_units.graphql.ts
@@ -2,13 +2,13 @@
 
 import { ConcreteFragment } from "relay-runtime";
 export type HeroUnits_hero_units = ReadonlyArray<{
-    readonly __id: string;
-    readonly href: string | null;
-    readonly title: string | null;
-    readonly heading: string | null;
-    readonly narrow_image_url: string | null;
-    readonly wide_image_url: string | null;
-}>;
+        readonly __id: string;
+        readonly href: string | null;
+        readonly title: string | null;
+        readonly heading: string | null;
+        readonly narrow_image_url: string | null;
+        readonly wide_image_url: string | null;
+    }>;
 
 
 

--- a/src/__generated__/HeroUnits_hero_units.graphql.ts
+++ b/src/__generated__/HeroUnits_hero_units.graphql.ts
@@ -2,13 +2,13 @@
 
 import { ConcreteFragment } from "relay-runtime";
 export type HeroUnits_hero_units = ReadonlyArray<{
-        readonly __id: string;
-        readonly href: string | null;
-        readonly title: string | null;
-        readonly heading: string | null;
-        readonly narrow_image_url: string | null;
-        readonly wide_image_url: string | null;
-    }>;
+    readonly __id: string;
+    readonly href: string | null;
+    readonly title: string | null;
+    readonly heading: string | null;
+    readonly narrow_image_url: string | null;
+    readonly wide_image_url: string | null;
+}>;
 
 
 

--- a/src/__generated__/InboxQuery.graphql.ts
+++ b/src/__generated__/InboxQuery.graphql.ts
@@ -5,8 +5,7 @@ export type InboxQueryVariables = {
     readonly cursor?: string | null;
 };
 export type InboxQueryResponse = {
-    readonly me: ({
-    }) | null;
+    readonly me: ({}) | null;
 };
 
 

--- a/src/__generated__/InboxQuery.graphql.ts
+++ b/src/__generated__/InboxQuery.graphql.ts
@@ -5,7 +5,8 @@ export type InboxQueryVariables = {
     readonly cursor?: string | null;
 };
 export type InboxQueryResponse = {
-    readonly me: ({}) | null;
+    readonly me: ({
+    }) | null;
 };
 
 

--- a/src/__generated__/InboxRefetchQuery.graphql.ts
+++ b/src/__generated__/InboxRefetchQuery.graphql.ts
@@ -1,11 +1,9 @@
 /* tslint:disable */
 
 import { ConcreteRequest } from "relay-runtime";
-export type InboxRefetchQueryVariables = {
-};
+export type InboxRefetchQueryVariables = {};
 export type InboxRefetchQueryResponse = {
-    readonly me: ({
-    }) | null;
+    readonly me: ({}) | null;
 };
 
 

--- a/src/__generated__/InboxRefetchQuery.graphql.ts
+++ b/src/__generated__/InboxRefetchQuery.graphql.ts
@@ -1,9 +1,11 @@
 /* tslint:disable */
 
 import { ConcreteRequest } from "relay-runtime";
-export type InboxRefetchQueryVariables = {};
+export type InboxRefetchQueryVariables = {
+};
 export type InboxRefetchQueryResponse = {
-    readonly me: ({}) | null;
+    readonly me: ({
+    }) | null;
 };
 
 

--- a/src/__generated__/Inbox_me.graphql.ts
+++ b/src/__generated__/Inbox_me.graphql.ts
@@ -3,16 +3,16 @@
 import { ConcreteFragment } from "relay-runtime";
 export type Inbox_me = {
     readonly lot_standings: ReadonlyArray<({
-            readonly most_recent_bid: ({
-                readonly __id: string;
-            }) | null;
-        }) | null> | null;
+        readonly most_recent_bid: ({
+            readonly __id: string;
+        }) | null;
+    }) | null> | null;
     readonly conversations_existence_check: ({
         readonly edges: ReadonlyArray<({
-                readonly node: ({
-                    readonly id: string | null;
-                }) | null;
-            }) | null> | null;
+            readonly node: ({
+                readonly id: string | null;
+            }) | null;
+        }) | null> | null;
     }) | null;
 };
 

--- a/src/__generated__/Inbox_me.graphql.ts
+++ b/src/__generated__/Inbox_me.graphql.ts
@@ -3,16 +3,16 @@
 import { ConcreteFragment } from "relay-runtime";
 export type Inbox_me = {
     readonly lot_standings: ReadonlyArray<({
-        readonly most_recent_bid: ({
-            readonly __id: string;
-        }) | null;
-    }) | null> | null;
-    readonly conversations_existence_check: ({
-        readonly edges: ReadonlyArray<({
-            readonly node: ({
-                readonly id: string | null;
+            readonly most_recent_bid: ({
+                readonly __id: string;
             }) | null;
         }) | null> | null;
+    readonly conversations_existence_check: ({
+        readonly edges: ReadonlyArray<({
+                readonly node: ({
+                    readonly id: string | null;
+                }) | null;
+            }) | null> | null;
     }) | null;
 };
 

--- a/src/__generated__/InvoicePreviewRefetchQuery.graphql.ts
+++ b/src/__generated__/InvoicePreviewRefetchQuery.graphql.ts
@@ -7,8 +7,7 @@ export type InvoicePreviewRefetchQueryVariables = {
 };
 export type InvoicePreviewRefetchQueryResponse = {
     readonly me: ({
-        readonly invoice: ({
-        }) | null;
+        readonly invoice: ({}) | null;
     }) | null;
 };
 

--- a/src/__generated__/InvoicePreviewRefetchQuery.graphql.ts
+++ b/src/__generated__/InvoicePreviewRefetchQuery.graphql.ts
@@ -7,7 +7,8 @@ export type InvoicePreviewRefetchQueryVariables = {
 };
 export type InvoicePreviewRefetchQueryResponse = {
     readonly me: ({
-        readonly invoice: ({}) | null;
+        readonly invoice: ({
+        }) | null;
     }) | null;
 };
 

--- a/src/__generated__/LotsByFollowedArtistsQuery.graphql.ts
+++ b/src/__generated__/LotsByFollowedArtistsQuery.graphql.ts
@@ -6,7 +6,8 @@ export type LotsByFollowedArtistsQueryVariables = {
     readonly cursor?: string | null;
 };
 export type LotsByFollowedArtistsQueryResponse = {
-    readonly viewer: ({}) | null;
+    readonly viewer: ({
+    }) | null;
 };
 
 

--- a/src/__generated__/LotsByFollowedArtistsQuery.graphql.ts
+++ b/src/__generated__/LotsByFollowedArtistsQuery.graphql.ts
@@ -6,8 +6,7 @@ export type LotsByFollowedArtistsQueryVariables = {
     readonly cursor?: string | null;
 };
 export type LotsByFollowedArtistsQueryResponse = {
-    readonly viewer: ({
-    }) | null;
+    readonly viewer: ({}) | null;
 };
 
 

--- a/src/__generated__/LotsByFollowedArtists_viewer.graphql.ts
+++ b/src/__generated__/LotsByFollowedArtists_viewer.graphql.ts
@@ -8,12 +8,11 @@ export type LotsByFollowedArtists_viewer = {
             readonly hasNextPage: boolean;
         };
         readonly edges: ReadonlyArray<({
-                readonly cursor: string;
-                readonly node: ({
-                    readonly artwork: ({
-                    }) | null;
-                }) | null;
-            }) | null> | null;
+            readonly cursor: string;
+            readonly node: ({
+                readonly artwork: ({}) | null;
+            }) | null;
+        }) | null> | null;
     }) | null;
 };
 

--- a/src/__generated__/LotsByFollowedArtists_viewer.graphql.ts
+++ b/src/__generated__/LotsByFollowedArtists_viewer.graphql.ts
@@ -8,11 +8,12 @@ export type LotsByFollowedArtists_viewer = {
             readonly hasNextPage: boolean;
         };
         readonly edges: ReadonlyArray<({
-            readonly cursor: string;
-            readonly node: ({
-                readonly artwork: ({}) | null;
-            }) | null;
-        }) | null> | null;
+                readonly cursor: string;
+                readonly node: ({
+                    readonly artwork: ({
+                    }) | null;
+                }) | null;
+            }) | null> | null;
     }) | null;
 };
 

--- a/src/__generated__/Message_message.graphql.ts
+++ b/src/__generated__/Message_message.graphql.ts
@@ -13,11 +13,11 @@ export type Message_message = {
         readonly payment_url: string | null;
     }) | null;
     readonly attachments: ReadonlyArray<({
-            readonly id: string;
-            readonly content_type: string;
-            readonly download_url: string;
-            readonly file_name: string;
-        }) | null> | null;
+        readonly id: string;
+        readonly content_type: string;
+        readonly download_url: string;
+        readonly file_name: string;
+    }) | null> | null;
 };
 
 

--- a/src/__generated__/Message_message.graphql.ts
+++ b/src/__generated__/Message_message.graphql.ts
@@ -13,11 +13,11 @@ export type Message_message = {
         readonly payment_url: string | null;
     }) | null;
     readonly attachments: ReadonlyArray<({
-        readonly id: string;
-        readonly content_type: string;
-        readonly download_url: string;
-        readonly file_name: string;
-    }) | null> | null;
+            readonly id: string;
+            readonly content_type: string;
+            readonly download_url: string;
+            readonly file_name: string;
+        }) | null> | null;
 };
 
 

--- a/src/__generated__/MessagesQuery.graphql.ts
+++ b/src/__generated__/MessagesQuery.graphql.ts
@@ -8,7 +8,8 @@ export type MessagesQueryVariables = {
 };
 export type MessagesQueryResponse = {
     readonly me: ({
-        readonly conversation: ({}) | null;
+        readonly conversation: ({
+        }) | null;
     }) | null;
 };
 

--- a/src/__generated__/MessagesQuery.graphql.ts
+++ b/src/__generated__/MessagesQuery.graphql.ts
@@ -8,8 +8,7 @@ export type MessagesQueryVariables = {
 };
 export type MessagesQueryResponse = {
     readonly me: ({
-        readonly conversation: ({
-        }) | null;
+        readonly conversation: ({}) | null;
     }) | null;
 };
 

--- a/src/__generated__/Messages_conversation.graphql.ts
+++ b/src/__generated__/Messages_conversation.graphql.ts
@@ -22,26 +22,26 @@ export type Messages_conversation = {
             readonly hasNextPage: boolean;
         };
         readonly edges: ReadonlyArray<({
-                readonly cursor: string;
-                readonly node: ({
-                    readonly __id: string;
-                    readonly impulse_id: string;
-                    readonly is_from_user: boolean | null;
-                    readonly body: string | null;
-                    readonly attachments: ReadonlyArray<({
-                            readonly id: string;
-                        }) | null> | null;
-                }) | null;
-            }) | null> | null;
-    }) | null;
-    readonly items: ReadonlyArray<({
-            readonly artwork: ({
-                readonly href?: string | null;
-            }) | null;
-            readonly show: ({
-                readonly href?: string | null;
+            readonly cursor: string;
+            readonly node: ({
+                readonly __id: string;
+                readonly impulse_id: string;
+                readonly is_from_user: boolean | null;
+                readonly body: string | null;
+                readonly attachments: ReadonlyArray<({
+                    readonly id: string;
+                }) | null> | null;
             }) | null;
         }) | null> | null;
+    }) | null;
+    readonly items: ReadonlyArray<({
+        readonly artwork: ({
+            readonly href?: string | null;
+        }) | null;
+        readonly show: ({
+            readonly href?: string | null;
+        }) | null;
+    }) | null> | null;
 };
 
 

--- a/src/__generated__/Messages_conversation.graphql.ts
+++ b/src/__generated__/Messages_conversation.graphql.ts
@@ -22,26 +22,26 @@ export type Messages_conversation = {
             readonly hasNextPage: boolean;
         };
         readonly edges: ReadonlyArray<({
-            readonly cursor: string;
-            readonly node: ({
-                readonly __id: string;
-                readonly impulse_id: string;
-                readonly is_from_user: boolean | null;
-                readonly body: string | null;
-                readonly attachments: ReadonlyArray<({
-                    readonly id: string;
-                }) | null> | null;
-            }) | null;
-        }) | null> | null;
+                readonly cursor: string;
+                readonly node: ({
+                    readonly __id: string;
+                    readonly impulse_id: string;
+                    readonly is_from_user: boolean | null;
+                    readonly body: string | null;
+                    readonly attachments: ReadonlyArray<({
+                            readonly id: string;
+                        }) | null> | null;
+                }) | null;
+            }) | null> | null;
     }) | null;
     readonly items: ReadonlyArray<({
-        readonly artwork: ({
-            readonly href?: string | null;
-        }) | null;
-        readonly show: ({
-            readonly href?: string | null;
-        }) | null;
-    }) | null> | null;
+            readonly artwork: ({
+                readonly href?: string | null;
+            }) | null;
+            readonly show: ({
+                readonly href?: string | null;
+            }) | null;
+        }) | null> | null;
 };
 
 

--- a/src/__generated__/Notification_notification.graphql.ts
+++ b/src/__generated__/Notification_notification.graphql.ts
@@ -5,10 +5,10 @@ export type Notification_notification = {
     readonly summary: string | null;
     readonly artists: string | null;
     readonly artworks: ReadonlyArray<({
-            readonly artists: ReadonlyArray<({
-                    readonly href: string | null;
-                }) | null> | null;
+        readonly artists: ReadonlyArray<({
+            readonly href: string | null;
         }) | null> | null;
+    }) | null> | null;
     readonly image: ({
         readonly resized: ({
             readonly url: string | null;

--- a/src/__generated__/Notification_notification.graphql.ts
+++ b/src/__generated__/Notification_notification.graphql.ts
@@ -5,10 +5,10 @@ export type Notification_notification = {
     readonly summary: string | null;
     readonly artists: string | null;
     readonly artworks: ReadonlyArray<({
-        readonly artists: ReadonlyArray<({
-            readonly href: string | null;
+            readonly artists: ReadonlyArray<({
+                    readonly href: string | null;
+                }) | null> | null;
         }) | null> | null;
-    }) | null> | null;
     readonly image: ({
         readonly resized: ({
             readonly url: string | null;

--- a/src/__generated__/QueryRenderersArtistQuery.graphql.ts
+++ b/src/__generated__/QueryRenderersArtistQuery.graphql.ts
@@ -6,8 +6,7 @@ export type QueryRenderersArtistQueryVariables = {
     readonly isPad: boolean;
 };
 export type QueryRenderersArtistQueryResponse = {
-    readonly artist: ({
-    }) | null;
+    readonly artist: ({}) | null;
 };
 
 

--- a/src/__generated__/QueryRenderersArtistQuery.graphql.ts
+++ b/src/__generated__/QueryRenderersArtistQuery.graphql.ts
@@ -6,7 +6,8 @@ export type QueryRenderersArtistQueryVariables = {
     readonly isPad: boolean;
 };
 export type QueryRenderersArtistQueryResponse = {
-    readonly artist: ({}) | null;
+    readonly artist: ({
+    }) | null;
 };
 
 

--- a/src/__generated__/QueryRenderersBidFlowQuery.graphql.ts
+++ b/src/__generated__/QueryRenderersBidFlowQuery.graphql.ts
@@ -7,11 +7,9 @@ export type QueryRenderersBidFlowQueryVariables = {
 };
 export type QueryRenderersBidFlowQueryResponse = {
     readonly artwork: ({
-        readonly sale_artwork: ({
-        }) | null;
+        readonly sale_artwork: ({}) | null;
     }) | null;
-    readonly me: ({
-    }) | null;
+    readonly me: ({}) | null;
 };
 
 

--- a/src/__generated__/QueryRenderersBidFlowQuery.graphql.ts
+++ b/src/__generated__/QueryRenderersBidFlowQuery.graphql.ts
@@ -7,9 +7,11 @@ export type QueryRenderersBidFlowQueryVariables = {
 };
 export type QueryRenderersBidFlowQueryResponse = {
     readonly artwork: ({
-        readonly sale_artwork: ({}) | null;
+        readonly sale_artwork: ({
+        }) | null;
     }) | null;
-    readonly me: ({}) | null;
+    readonly me: ({
+    }) | null;
 };
 
 

--- a/src/__generated__/QueryRenderersConversationQuery.graphql.ts
+++ b/src/__generated__/QueryRenderersConversationQuery.graphql.ts
@@ -5,7 +5,8 @@ export type QueryRenderersConversationQueryVariables = {
     readonly conversationID: string;
 };
 export type QueryRenderersConversationQueryResponse = {
-    readonly me: ({}) | null;
+    readonly me: ({
+    }) | null;
 };
 
 

--- a/src/__generated__/QueryRenderersConversationQuery.graphql.ts
+++ b/src/__generated__/QueryRenderersConversationQuery.graphql.ts
@@ -5,8 +5,7 @@ export type QueryRenderersConversationQueryVariables = {
     readonly conversationID: string;
 };
 export type QueryRenderersConversationQueryResponse = {
-    readonly me: ({
-    }) | null;
+    readonly me: ({}) | null;
 };
 
 

--- a/src/__generated__/QueryRenderersForYouQuery.graphql.ts
+++ b/src/__generated__/QueryRenderersForYouQuery.graphql.ts
@@ -1,9 +1,11 @@
 /* tslint:disable */
 
 import { ConcreteRequest } from "relay-runtime";
-export type QueryRenderersForYouQueryVariables = {};
+export type QueryRenderersForYouQueryVariables = {
+};
 export type QueryRenderersForYouQueryResponse = {
-    readonly forYou: ({}) | null;
+    readonly forYou: ({
+    }) | null;
 };
 
 

--- a/src/__generated__/QueryRenderersForYouQuery.graphql.ts
+++ b/src/__generated__/QueryRenderersForYouQuery.graphql.ts
@@ -1,11 +1,9 @@
 /* tslint:disable */
 
 import { ConcreteRequest } from "relay-runtime";
-export type QueryRenderersForYouQueryVariables = {
-};
+export type QueryRenderersForYouQueryVariables = {};
 export type QueryRenderersForYouQueryResponse = {
-    readonly forYou: ({
-    }) | null;
+    readonly forYou: ({}) | null;
 };
 
 

--- a/src/__generated__/QueryRenderersGeneQuery.graphql.ts
+++ b/src/__generated__/QueryRenderersGeneQuery.graphql.ts
@@ -7,7 +7,8 @@ export type QueryRenderersGeneQueryVariables = {
     readonly price_range?: string | null;
 };
 export type QueryRenderersGeneQueryResponse = {
-    readonly gene: ({}) | null;
+    readonly gene: ({
+    }) | null;
 };
 
 

--- a/src/__generated__/QueryRenderersGeneQuery.graphql.ts
+++ b/src/__generated__/QueryRenderersGeneQuery.graphql.ts
@@ -7,8 +7,7 @@ export type QueryRenderersGeneQueryVariables = {
     readonly price_range?: string | null;
 };
 export type QueryRenderersGeneQueryResponse = {
-    readonly gene: ({
-    }) | null;
+    readonly gene: ({}) | null;
 };
 
 

--- a/src/__generated__/QueryRenderersInboxQuery.graphql.ts
+++ b/src/__generated__/QueryRenderersInboxQuery.graphql.ts
@@ -1,11 +1,9 @@
 /* tslint:disable */
 
 import { ConcreteRequest } from "relay-runtime";
-export type QueryRenderersInboxQueryVariables = {
-};
+export type QueryRenderersInboxQueryVariables = {};
 export type QueryRenderersInboxQueryResponse = {
-    readonly me: ({
-    }) | null;
+    readonly me: ({}) | null;
 };
 
 

--- a/src/__generated__/QueryRenderersInboxQuery.graphql.ts
+++ b/src/__generated__/QueryRenderersInboxQuery.graphql.ts
@@ -1,9 +1,11 @@
 /* tslint:disable */
 
 import { ConcreteRequest } from "relay-runtime";
-export type QueryRenderersInboxQueryVariables = {};
+export type QueryRenderersInboxQueryVariables = {
+};
 export type QueryRenderersInboxQueryResponse = {
-    readonly me: ({}) | null;
+    readonly me: ({
+    }) | null;
 };
 
 

--- a/src/__generated__/QueryRenderersInquiryQuery.graphql.ts
+++ b/src/__generated__/QueryRenderersInquiryQuery.graphql.ts
@@ -5,8 +5,7 @@ export type QueryRenderersInquiryQueryVariables = {
     readonly artworkID: string;
 };
 export type QueryRenderersInquiryQueryResponse = {
-    readonly artwork: ({
-    }) | null;
+    readonly artwork: ({}) | null;
 };
 
 

--- a/src/__generated__/QueryRenderersInquiryQuery.graphql.ts
+++ b/src/__generated__/QueryRenderersInquiryQuery.graphql.ts
@@ -5,7 +5,8 @@ export type QueryRenderersInquiryQueryVariables = {
     readonly artworkID: string;
 };
 export type QueryRenderersInquiryQueryResponse = {
-    readonly artwork: ({}) | null;
+    readonly artwork: ({
+    }) | null;
 };
 
 

--- a/src/__generated__/QueryRenderersMyProfileQuery.graphql.ts
+++ b/src/__generated__/QueryRenderersMyProfileQuery.graphql.ts
@@ -1,9 +1,11 @@
 /* tslint:disable */
 
 import { ConcreteRequest } from "relay-runtime";
-export type QueryRenderersMyProfileQueryVariables = {};
+export type QueryRenderersMyProfileQueryVariables = {
+};
 export type QueryRenderersMyProfileQueryResponse = {
-    readonly me: ({}) | null;
+    readonly me: ({
+    }) | null;
 };
 
 

--- a/src/__generated__/QueryRenderersMyProfileQuery.graphql.ts
+++ b/src/__generated__/QueryRenderersMyProfileQuery.graphql.ts
@@ -1,11 +1,9 @@
 /* tslint:disable */
 
 import { ConcreteRequest } from "relay-runtime";
-export type QueryRenderersMyProfileQueryVariables = {
-};
+export type QueryRenderersMyProfileQueryVariables = {};
 export type QueryRenderersMyProfileQueryResponse = {
-    readonly me: ({
-    }) | null;
+    readonly me: ({}) | null;
 };
 
 

--- a/src/__generated__/QueryRenderersRegistrationFlowQuery.graphql.ts
+++ b/src/__generated__/QueryRenderersRegistrationFlowQuery.graphql.ts
@@ -8,8 +8,7 @@ export type QueryRenderersRegistrationFlowQueryResponse = {
     readonly sale: ({
         readonly name: string | null;
     }) | null;
-    readonly me: ({
-    }) | null;
+    readonly me: ({}) | null;
 };
 
 

--- a/src/__generated__/QueryRenderersRegistrationFlowQuery.graphql.ts
+++ b/src/__generated__/QueryRenderersRegistrationFlowQuery.graphql.ts
@@ -8,7 +8,8 @@ export type QueryRenderersRegistrationFlowQueryResponse = {
     readonly sale: ({
         readonly name: string | null;
     }) | null;
-    readonly me: ({}) | null;
+    readonly me: ({
+    }) | null;
 };
 
 

--- a/src/__generated__/QueryRenderersSaleQuery.graphql.ts
+++ b/src/__generated__/QueryRenderersSaleQuery.graphql.ts
@@ -5,7 +5,8 @@ export type QueryRenderersSaleQueryVariables = {
     readonly saleID: string;
 };
 export type QueryRenderersSaleQueryResponse = {
-    readonly sale: ({}) | null;
+    readonly sale: ({
+    }) | null;
 };
 
 

--- a/src/__generated__/QueryRenderersSaleQuery.graphql.ts
+++ b/src/__generated__/QueryRenderersSaleQuery.graphql.ts
@@ -5,8 +5,7 @@ export type QueryRenderersSaleQueryVariables = {
     readonly saleID: string;
 };
 export type QueryRenderersSaleQueryResponse = {
-    readonly sale: ({
-    }) | null;
+    readonly sale: ({}) | null;
 };
 
 

--- a/src/__generated__/QueryRenderersWorksForYouQuery.graphql.ts
+++ b/src/__generated__/QueryRenderersWorksForYouQuery.graphql.ts
@@ -5,7 +5,8 @@ export type QueryRenderersWorksForYouQueryVariables = {
     readonly selectedArtist: string;
 };
 export type QueryRenderersWorksForYouQueryResponse = {
-    readonly viewer: ({}) | null;
+    readonly viewer: ({
+    }) | null;
 };
 
 

--- a/src/__generated__/QueryRenderersWorksForYouQuery.graphql.ts
+++ b/src/__generated__/QueryRenderersWorksForYouQuery.graphql.ts
@@ -5,8 +5,7 @@ export type QueryRenderersWorksForYouQueryVariables = {
     readonly selectedArtist: string;
 };
 export type QueryRenderersWorksForYouQueryResponse = {
-    readonly viewer: ({
-    }) | null;
+    readonly viewer: ({}) | null;
 };
 
 

--- a/src/__generated__/RegistrationFlow_me.graphql.ts
+++ b/src/__generated__/RegistrationFlow_me.graphql.ts
@@ -1,7 +1,8 @@
 /* tslint:disable */
 
 import { ConcreteFragment } from "relay-runtime";
-export type RegistrationFlow_me = {};
+export type RegistrationFlow_me = {
+};
 
 
 

--- a/src/__generated__/RegistrationFlow_me.graphql.ts
+++ b/src/__generated__/RegistrationFlow_me.graphql.ts
@@ -1,8 +1,7 @@
 /* tslint:disable */
 
 import { ConcreteFragment } from "relay-runtime";
-export type RegistrationFlow_me = {
-};
+export type RegistrationFlow_me = {};
 
 
 

--- a/src/__generated__/RegistrationFlow_sale.graphql.ts
+++ b/src/__generated__/RegistrationFlow_sale.graphql.ts
@@ -1,7 +1,8 @@
 /* tslint:disable */
 
 import { ConcreteFragment } from "relay-runtime";
-export type RegistrationFlow_sale = {};
+export type RegistrationFlow_sale = {
+};
 
 
 

--- a/src/__generated__/RegistrationFlow_sale.graphql.ts
+++ b/src/__generated__/RegistrationFlow_sale.graphql.ts
@@ -1,8 +1,7 @@
 /* tslint:disable */
 
 import { ConcreteFragment } from "relay-runtime";
-export type RegistrationFlow_sale = {
-};
+export type RegistrationFlow_sale = {};
 
 
 

--- a/src/__generated__/RelatedArtists_artists.graphql.ts
+++ b/src/__generated__/RelatedArtists_artists.graphql.ts
@@ -2,8 +2,8 @@
 
 import { ConcreteFragment } from "relay-runtime";
 export type RelatedArtists_artists = ReadonlyArray<{
-        readonly __id: string;
-    }>;
+    readonly __id: string;
+}>;
 
 
 

--- a/src/__generated__/RelatedArtists_artists.graphql.ts
+++ b/src/__generated__/RelatedArtists_artists.graphql.ts
@@ -2,8 +2,8 @@
 
 import { ConcreteFragment } from "relay-runtime";
 export type RelatedArtists_artists = ReadonlyArray<{
-    readonly __id: string;
-}>;
+        readonly __id: string;
+    }>;
 
 
 

--- a/src/__generated__/SaleArtworksGridQuery.graphql.ts
+++ b/src/__generated__/SaleArtworksGridQuery.graphql.ts
@@ -7,8 +7,7 @@ export type SaleArtworksGridQueryVariables = {
     readonly cursor?: string | null;
 };
 export type SaleArtworksGridQueryResponse = {
-    readonly node: ({
-    }) | null;
+    readonly node: ({}) | null;
 };
 
 

--- a/src/__generated__/SaleArtworksGridQuery.graphql.ts
+++ b/src/__generated__/SaleArtworksGridQuery.graphql.ts
@@ -7,7 +7,8 @@ export type SaleArtworksGridQueryVariables = {
     readonly cursor?: string | null;
 };
 export type SaleArtworksGridQueryResponse = {
-    readonly node: ({}) | null;
+    readonly node: ({
+    }) | null;
 };
 
 

--- a/src/__generated__/SaleArtworksGrid_sale.graphql.ts
+++ b/src/__generated__/SaleArtworksGrid_sale.graphql.ts
@@ -10,16 +10,16 @@ export type SaleArtworksGrid_sale = {
             readonly endCursor: string | null;
         };
         readonly edges: ReadonlyArray<({
-                readonly node: ({
-                    readonly artwork: ({
-                        readonly id: string;
-                        readonly __id: string;
-                        readonly image: ({
-                            readonly aspect_ratio: number | null;
-                        }) | null;
+            readonly node: ({
+                readonly artwork: ({
+                    readonly id: string;
+                    readonly __id: string;
+                    readonly image: ({
+                        readonly aspect_ratio: number | null;
                     }) | null;
                 }) | null;
-            }) | null> | null;
+            }) | null;
+        }) | null> | null;
     }) | null;
 };
 

--- a/src/__generated__/SaleArtworksGrid_sale.graphql.ts
+++ b/src/__generated__/SaleArtworksGrid_sale.graphql.ts
@@ -10,16 +10,16 @@ export type SaleArtworksGrid_sale = {
             readonly endCursor: string | null;
         };
         readonly edges: ReadonlyArray<({
-            readonly node: ({
-                readonly artwork: ({
-                    readonly id: string;
-                    readonly __id: string;
-                    readonly image: ({
-                        readonly aspect_ratio: number | null;
+                readonly node: ({
+                    readonly artwork: ({
+                        readonly id: string;
+                        readonly __id: string;
+                        readonly image: ({
+                            readonly aspect_ratio: number | null;
+                        }) | null;
                     }) | null;
                 }) | null;
-            }) | null;
-        }) | null> | null;
+            }) | null> | null;
     }) | null;
 };
 

--- a/src/__generated__/SaleQuery.graphql.ts
+++ b/src/__generated__/SaleQuery.graphql.ts
@@ -5,7 +5,8 @@ export type SaleQueryVariables = {
     readonly saleID: string;
 };
 export type SaleQueryResponse = {
-    readonly sale: ({}) | null;
+    readonly sale: ({
+    }) | null;
 };
 
 

--- a/src/__generated__/SaleQuery.graphql.ts
+++ b/src/__generated__/SaleQuery.graphql.ts
@@ -5,8 +5,7 @@ export type SaleQueryVariables = {
     readonly saleID: string;
 };
 export type SaleQueryResponse = {
-    readonly sale: ({
-    }) | null;
+    readonly sale: ({}) | null;
 };
 
 

--- a/src/__generated__/SaleRefetchQuery.graphql.ts
+++ b/src/__generated__/SaleRefetchQuery.graphql.ts
@@ -5,7 +5,8 @@ export type SaleRefetchQueryVariables = {
     readonly saleID: string;
 };
 export type SaleRefetchQueryResponse = {
-    readonly sale: ({}) | null;
+    readonly sale: ({
+    }) | null;
 };
 
 

--- a/src/__generated__/SaleRefetchQuery.graphql.ts
+++ b/src/__generated__/SaleRefetchQuery.graphql.ts
@@ -5,8 +5,7 @@ export type SaleRefetchQueryVariables = {
     readonly saleID: string;
 };
 export type SaleRefetchQueryResponse = {
-    readonly sale: ({
-    }) | null;
+    readonly sale: ({}) | null;
 };
 
 

--- a/src/__generated__/SalesQuery.graphql.ts
+++ b/src/__generated__/SalesQuery.graphql.ts
@@ -1,9 +1,11 @@
 /* tslint:disable */
 
 import { ConcreteRequest } from "relay-runtime";
-export type SalesQueryVariables = {};
+export type SalesQueryVariables = {
+};
 export type SalesQueryResponse = {
-    readonly viewer: ({}) | null;
+    readonly viewer: ({
+    }) | null;
 };
 
 

--- a/src/__generated__/SalesQuery.graphql.ts
+++ b/src/__generated__/SalesQuery.graphql.ts
@@ -1,11 +1,9 @@
 /* tslint:disable */
 
 import { ConcreteRequest } from "relay-runtime";
-export type SalesQueryVariables = {
-};
+export type SalesQueryVariables = {};
 export type SalesQueryResponse = {
-    readonly viewer: ({
-    }) | null;
+    readonly viewer: ({}) | null;
 };
 
 

--- a/src/__generated__/SalesRendererQuery.graphql.ts
+++ b/src/__generated__/SalesRendererQuery.graphql.ts
@@ -1,9 +1,11 @@
 /* tslint:disable */
 
 import { ConcreteRequest } from "relay-runtime";
-export type SalesRendererQueryVariables = {};
+export type SalesRendererQueryVariables = {
+};
 export type SalesRendererQueryResponse = {
-    readonly viewer: ({}) | null;
+    readonly viewer: ({
+    }) | null;
 };
 
 

--- a/src/__generated__/SalesRendererQuery.graphql.ts
+++ b/src/__generated__/SalesRendererQuery.graphql.ts
@@ -1,11 +1,9 @@
 /* tslint:disable */
 
 import { ConcreteRequest } from "relay-runtime";
-export type SalesRendererQueryVariables = {
-};
+export type SalesRendererQueryVariables = {};
 export type SalesRendererQueryResponse = {
-    readonly viewer: ({
-    }) | null;
+    readonly viewer: ({}) | null;
 };
 
 

--- a/src/__generated__/Sales_viewer.graphql.ts
+++ b/src/__generated__/Sales_viewer.graphql.ts
@@ -3,9 +3,9 @@
 import { ConcreteFragment } from "relay-runtime";
 export type Sales_viewer = {
     readonly sales: ReadonlyArray<({
-        readonly href: string | null;
-        readonly live_start_at: string | null;
-    }) | null> | null;
+            readonly href: string | null;
+            readonly live_start_at: string | null;
+        }) | null> | null;
 };
 
 

--- a/src/__generated__/Sales_viewer.graphql.ts
+++ b/src/__generated__/Sales_viewer.graphql.ts
@@ -3,9 +3,9 @@
 import { ConcreteFragment } from "relay-runtime";
 export type Sales_viewer = {
     readonly sales: ReadonlyArray<({
-            readonly href: string | null;
-            readonly live_start_at: string | null;
-        }) | null> | null;
+        readonly href: string | null;
+        readonly live_start_at: string | null;
+    }) | null> | null;
 };
 
 

--- a/src/__generated__/SelectMaxBidRefetchQuery.graphql.ts
+++ b/src/__generated__/SelectMaxBidRefetchQuery.graphql.ts
@@ -5,8 +5,7 @@ export type SelectMaxBidRefetchQueryVariables = {
     readonly saleArtworkID: string;
 };
 export type SelectMaxBidRefetchQueryResponse = {
-    readonly sale_artwork: ({
-    }) | null;
+    readonly sale_artwork: ({}) | null;
 };
 
 

--- a/src/__generated__/SelectMaxBidRefetchQuery.graphql.ts
+++ b/src/__generated__/SelectMaxBidRefetchQuery.graphql.ts
@@ -5,7 +5,8 @@ export type SelectMaxBidRefetchQueryVariables = {
     readonly saleArtworkID: string;
 };
 export type SelectMaxBidRefetchQueryResponse = {
-    readonly sale_artwork: ({}) | null;
+    readonly sale_artwork: ({
+    }) | null;
 };
 
 

--- a/src/__generated__/SelectMaxBid_me.graphql.ts
+++ b/src/__generated__/SelectMaxBid_me.graphql.ts
@@ -1,8 +1,7 @@
 /* tslint:disable */
 
 import { ConcreteFragment } from "relay-runtime";
-export type SelectMaxBid_me = {
-};
+export type SelectMaxBid_me = {};
 
 
 

--- a/src/__generated__/SelectMaxBid_me.graphql.ts
+++ b/src/__generated__/SelectMaxBid_me.graphql.ts
@@ -1,7 +1,8 @@
 /* tslint:disable */
 
 import { ConcreteFragment } from "relay-runtime";
-export type SelectMaxBid_me = {};
+export type SelectMaxBid_me = {
+};
 
 
 

--- a/src/__generated__/SelectMaxBid_sale_artwork.graphql.ts
+++ b/src/__generated__/SelectMaxBid_sale_artwork.graphql.ts
@@ -3,9 +3,9 @@
 import { ConcreteFragment } from "relay-runtime";
 export type SelectMaxBid_sale_artwork = {
     readonly increments: ReadonlyArray<({
-            readonly display: string | null;
-            readonly cents: number | null;
-        }) | null> | null;
+        readonly display: string | null;
+        readonly cents: number | null;
+    }) | null> | null;
     readonly _id: string;
 };
 

--- a/src/__generated__/SelectMaxBid_sale_artwork.graphql.ts
+++ b/src/__generated__/SelectMaxBid_sale_artwork.graphql.ts
@@ -3,9 +3,9 @@
 import { ConcreteFragment } from "relay-runtime";
 export type SelectMaxBid_sale_artwork = {
     readonly increments: ReadonlyArray<({
-        readonly display: string | null;
-        readonly cents: number | null;
-    }) | null> | null;
+            readonly display: string | null;
+            readonly cents: number | null;
+        }) | null> | null;
     readonly _id: string;
 };
 

--- a/src/__generated__/Shows_artist.graphql.ts
+++ b/src/__generated__/Shows_artist.graphql.ts
@@ -2,10 +2,14 @@
 
 import { ConcreteFragment } from "relay-runtime";
 export type Shows_artist = {
-    readonly current_shows: ReadonlyArray<({}) | null> | null;
-    readonly upcoming_shows: ReadonlyArray<({}) | null> | null;
-    readonly past_small_shows?: ReadonlyArray<({}) | null> | null;
-    readonly past_large_shows?: ReadonlyArray<({}) | null> | null;
+    readonly current_shows: ReadonlyArray<({
+        }) | null> | null;
+    readonly upcoming_shows: ReadonlyArray<({
+        }) | null> | null;
+    readonly past_small_shows?: ReadonlyArray<({
+        }) | null> | null;
+    readonly past_large_shows?: ReadonlyArray<({
+        }) | null> | null;
 };
 
 

--- a/src/__generated__/Shows_artist.graphql.ts
+++ b/src/__generated__/Shows_artist.graphql.ts
@@ -2,14 +2,10 @@
 
 import { ConcreteFragment } from "relay-runtime";
 export type Shows_artist = {
-    readonly current_shows: ReadonlyArray<({
-        }) | null> | null;
-    readonly upcoming_shows: ReadonlyArray<({
-        }) | null> | null;
-    readonly past_small_shows?: ReadonlyArray<({
-        }) | null> | null;
-    readonly past_large_shows?: ReadonlyArray<({
-        }) | null> | null;
+    readonly current_shows: ReadonlyArray<({}) | null> | null;
+    readonly upcoming_shows: ReadonlyArray<({}) | null> | null;
+    readonly past_small_shows?: ReadonlyArray<({}) | null> | null;
+    readonly past_large_shows?: ReadonlyArray<({}) | null> | null;
 };
 
 

--- a/src/__generated__/SmallList_shows.graphql.ts
+++ b/src/__generated__/SmallList_shows.graphql.ts
@@ -1,8 +1,7 @@
 /* tslint:disable */
 
 import { ConcreteFragment } from "relay-runtime";
-export type SmallList_shows = ReadonlyArray<{
-    }>;
+export type SmallList_shows = ReadonlyArray<{}>;
 
 
 

--- a/src/__generated__/SmallList_shows.graphql.ts
+++ b/src/__generated__/SmallList_shows.graphql.ts
@@ -1,7 +1,8 @@
 /* tslint:disable */
 
 import { ConcreteFragment } from "relay-runtime";
-export type SmallList_shows = ReadonlyArray<{}>;
+export type SmallList_shows = ReadonlyArray<{
+    }>;
 
 
 

--- a/src/__generated__/VariableSizeShowsList_shows.graphql.ts
+++ b/src/__generated__/VariableSizeShowsList_shows.graphql.ts
@@ -2,8 +2,8 @@
 
 import { ConcreteFragment } from "relay-runtime";
 export type VariableSizeShowsList_shows = ReadonlyArray<{
-    readonly __id: string;
-}>;
+        readonly __id: string;
+    }>;
 
 
 

--- a/src/__generated__/VariableSizeShowsList_shows.graphql.ts
+++ b/src/__generated__/VariableSizeShowsList_shows.graphql.ts
@@ -2,8 +2,8 @@
 
 import { ConcreteFragment } from "relay-runtime";
 export type VariableSizeShowsList_shows = ReadonlyArray<{
-        readonly __id: string;
-    }>;
+    readonly __id: string;
+}>;
 
 
 

--- a/src/__generated__/WorksForYouQuery.graphql.ts
+++ b/src/__generated__/WorksForYouQuery.graphql.ts
@@ -6,8 +6,7 @@ export type WorksForYouQueryVariables = {
     readonly cursor?: string | null;
 };
 export type WorksForYouQueryResponse = {
-    readonly viewer: ({
-    }) | null;
+    readonly viewer: ({}) | null;
 };
 
 

--- a/src/__generated__/WorksForYouQuery.graphql.ts
+++ b/src/__generated__/WorksForYouQuery.graphql.ts
@@ -6,7 +6,8 @@ export type WorksForYouQueryVariables = {
     readonly cursor?: string | null;
 };
 export type WorksForYouQueryResponse = {
-    readonly viewer: ({}) | null;
+    readonly viewer: ({
+    }) | null;
 };
 
 

--- a/src/__generated__/WorksForYou_viewer.graphql.ts
+++ b/src/__generated__/WorksForYou_viewer.graphql.ts
@@ -10,10 +10,10 @@ export type WorksForYou_viewer = {
                     readonly endCursor: string | null;
                 };
                 readonly edges: ReadonlyArray<({
-                    readonly node: ({
-                        readonly __id: string;
-                    }) | null;
-                }) | null> | null;
+                        readonly node: ({
+                            readonly __id: string;
+                        }) | null;
+                    }) | null> | null;
             }) | null;
         }) | null;
     }) | null;
@@ -26,7 +26,8 @@ export type WorksForYou_viewer = {
                 readonly url: string | null;
             }) | null;
         }) | null;
-        readonly artworks: ReadonlyArray<({}) | null> | null;
+        readonly artworks: ReadonlyArray<({
+            }) | null> | null;
     }) | null;
 };
 

--- a/src/__generated__/WorksForYou_viewer.graphql.ts
+++ b/src/__generated__/WorksForYou_viewer.graphql.ts
@@ -10,10 +10,10 @@ export type WorksForYou_viewer = {
                     readonly endCursor: string | null;
                 };
                 readonly edges: ReadonlyArray<({
-                        readonly node: ({
-                            readonly __id: string;
-                        }) | null;
-                    }) | null> | null;
+                    readonly node: ({
+                        readonly __id: string;
+                    }) | null;
+                }) | null> | null;
             }) | null;
         }) | null;
     }) | null;
@@ -26,8 +26,7 @@ export type WorksForYou_viewer = {
                 readonly url: string | null;
             }) | null;
         }) | null;
-        readonly artworks: ReadonlyArray<({
-            }) | null> | null;
+        readonly artworks: ReadonlyArray<({}) | null> | null;
     }) | null;
 };
 

--- a/src/lib/Components/Inbox/Conversations/Messages.tsx
+++ b/src/lib/Components/Inbox/Conversations/Messages.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Dimensions, FlatList, RefreshControl } from "react-native"
+import { Dimensions, FlatList, RefreshControl, ScrollViewStyle } from "react-native"
 import { ConnectionData, createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 import styled from "styled-components/native"
 
@@ -131,7 +131,7 @@ export class Messages extends React.Component<Props, State> {
 
     const refreshControl = <RefreshControl refreshing={this.state.reloadingData} onRefresh={this.reload.bind(this)} />
 
-    const messagesStyles = isPad
+    const messagesStyles: Partial<ScrollViewStyle> = isPad
       ? {
           width: 708,
           alignSelf: "center",

--- a/src/lib/Scenes/Home/Components/Sales/Components/ZeroState/index.tsx
+++ b/src/lib/Scenes/Home/Components/Sales/Components/ZeroState/index.tsx
@@ -3,7 +3,7 @@ import { WebView, WebViewIOSLoadRequestEvent } from "react-native"
 
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 
-export class ZeroState extends React.Component<null> {
+export class ZeroState extends React.Component {
   shouldLoadRequest(e: WebViewIOSLoadRequestEvent) {
     if (e.navigationType === "click") {
       SwitchBoard.presentNavigationViewController(this, e.url)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "baseUrl": "src",
     "experimentalDecorators": true,
     "jsx": "react",
+    "keyofStringsOnly": true,
     "module": "es2015",
     "moduleResolution": "node",
     "noUnusedLocals": true,

--- a/tslint.json
+++ b/tslint.json
@@ -3,10 +3,9 @@
   "rules": {
     "arrow-parens": false,
     "interface-name": [true, "never-prefix"],
-    "max-classes-per-file": [false],
+    "max-classes-per-file": false,
     "member-access": [false, "check-accessor", "check-constructor"],
     "no-console": [true, ["error", ["warn", "error"]]],
-    "no-unused-variable": [true, { "ignore-pattern": "^_" }],
     "object-literal-sort-keys": false,
     "ordered-imports": true,
     "switch-default": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10868,9 +10868,13 @@ typescript-template-language-service-decorator@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/typescript-template-language-service-decorator/-/typescript-template-language-service-decorator-0.1.2.tgz#d64153b3417af4a7b0143a5e6d10a26ba034db83"
 
-typescript@^2.1.5, typescript@^2.5.3:
+typescript@^2.1.5:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.2.tgz#3c5b6fd7f6de0914269027f03c0946758f7673a4"
+
+typescript@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.3.tgz#4853b3e275ecdaa27f78fda46dc273a7eb7fc1c8"
 
 ua-parser-js@^0.7.9:
   version "0.7.17"

--- a/yarn.lock
+++ b/yarn.lock
@@ -567,10 +567,6 @@
   dependencies:
     moment ">=2.14.0"
 
-"@types/node@*":
-  version "8.5.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.5.1.tgz#4ec3020bcdfe2abffeef9ba3fbf26fca097514b5"
-
 "@types/query-string@^5.0.0":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@types/query-string/-/query-string-5.0.1.tgz#6cb41c724cb1644d56c2d1dae7c7b204e706b39e"
@@ -8038,11 +8034,9 @@ parse-passwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
 
-parse5@^3.0.1, parse5@^3.0.2:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
-  dependencies:
-    "@types/node" "*"
+parse5@5.1.0, parse5@^3.0.1, parse5@^3.0.2:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.0.tgz#c59341c9723f414c452975564c7c00a68d58acd2"
 
 parseurl@~1.3.2:
   version "1.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2943,6 +2943,10 @@ commander@2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.6.0.tgz#9df7e52fb2a0cb0fb89058ee80c3104225f37e1d"
 
+commander@^2.12.1:
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.18.0.tgz#2bf063ddee7c7891176981a2cc798e5754bc6970"
+
 commander@^2.12.2, commander@~2.13.0:
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
@@ -10788,35 +10792,40 @@ ts-jest@^22.0.2:
     source-map-support "^0.5.0"
     yargs "^11.0.0"
 
-tslib@^1.7.1, tslib@^1.8.0:
+tslib@^1.8.0:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.8.1.tgz#6946af2d1d651a7b1863b531d6e5afa41aa44eac"
+
+tslib@^1.8.1:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
 
 tslint-config-prettier@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/tslint-config-prettier/-/tslint-config-prettier-1.6.0.tgz#fec1ee8fb07e8f033c63fed6b135af997f31962a"
 
-tslint@^5.8.0:
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.8.0.tgz#1f49ad5b2e77c76c3af4ddcae552ae4e3612eb13"
+tslint@^5.11.0:
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.11.0.tgz#98f30c02eae3cde7006201e4c33cb08b48581eed"
   dependencies:
     babel-code-frame "^6.22.0"
     builtin-modules "^1.1.1"
-    chalk "^2.1.0"
-    commander "^2.9.0"
+    chalk "^2.3.0"
+    commander "^2.12.1"
     diff "^3.2.0"
     glob "^7.1.1"
+    js-yaml "^3.7.0"
     minimatch "^3.0.4"
     resolve "^1.3.2"
     semver "^5.3.0"
-    tslib "^1.7.1"
-    tsutils "^2.12.1"
-
-tsutils@^2.12.1:
-  version "2.13.1"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.13.1.tgz#d6d1cc0f7c04cf9fb3b28a292973cffb9cfbe09a"
-  dependencies:
     tslib "^1.8.0"
+    tsutils "^2.27.2"
+
+tsutils@^2.27.2:
+  version "2.29.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.29.0.tgz#32b488501467acbedd4b85498673a0812aca0b99"
+  dependencies:
+    tslib "^1.8.1"
 
 tty-browserify@0.0.0:
   version "0.0.0"


### PR DESCRIPTION
Upgrades Typescript and TSLint to latest, and followed a few work-arounds to get it green since we're a few versions behind in terms of `react-native` / `react`. 


