### PR TITLE
[Docs] Add troubleshooting.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Inside Emission you will find:
 * **State:** production
 * **Point People:** [@alloy](https://github.com/alloy), [@ashfurrow](https://github.com/ashfurrow)
 * **CI:** [![Build Status](https://travis-ci.org/artsy/emission.svg?branch=master)](https://travis-ci.org/artsy/emission)
+* **[Troubleshooting](https://github.com/artsy/emission/blob/master/docs/troubleshooting.md)**
 
 This is a core [Artsy Mobile](https://github.com/artsy/mobile) OSS project, along with [Energy](https://github.com/artsy/energy), [Eidolon](https://github.com/artsy/eidolon), [Eigen](https://github.com/artsy/eigen) and [Emergence](https://github.com/artsy/emergence).
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,23 @@
+# Troubleshooting
+
+### Working with local media assets
+
+When writing a component that refers to a local media asset
+
+```tsx
+<VideoPlayback source={require("./some-video.mp4")} />
+```
+
+note that
+
+1. React Native's compiler will see the require path and copy the file to `pods/Assets/path/to/location/` automatically; and
+2. `require` will return an opaque reference to the file location (an integer), not the fully-resolved path. To get the fully-resolved path `resolveAssetSource` must be used:
+
+```tsx
+import resolveAssetSource from "react-native/Libraries/Image/resolveAssetSource"
+
+const source = resolveAssetSource(this.props.source)
+console.log(source) // => { uri: "pods/Assets/.../some-video.mp4" }
+```
+
+See [Video.tsx](https://github.com/artsy/emission/tree/master/src/lib/Components/Video.tsx) for an example implementation and [here](https://facebook.github.io/react-native/docs/images#static-non-image-resources) for a list of supported file formats.


### PR DESCRIPTION
Adds a new `docs/troubleshooting.md` guide and includes a recently confusing issue around requiring media assets. 

#trivial