### PR TITLE
[BNMO Home] Hide consignments sash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - New artwork brick style - matt
 - Deployment improvements to hopefully automate everything again - orta
+- Silence consignments sash on home for BNMO - chris
 
 ### 1.6.0
 

--- a/src/lib/Containers/WorksForYou.tsx
+++ b/src/lib/Containers/WorksForYou.tsx
@@ -127,7 +127,7 @@ export class WorksForYou extends React.Component<Props, State> {
   render() {
     const hasNotifications = this.state.dataSource
 
-    // TODO: After /collect2 reaches 100% redirect in A/B remove
+    // FIXME: BNMO - Update with Echo setting and remove once BNMO has launched
     const showMarketingHeader = NativeModules.Emission.options.enableBuyNowMakeOffer
 
     /* If showing the empty state, the ScrollView should have a {flex: 1} style so it can expand to fit the screen.

--- a/src/lib/Containers/__tests__/WorksForYou-tests.tsx
+++ b/src/lib/Containers/__tests__/WorksForYou-tests.tsx
@@ -7,6 +7,7 @@ import { WorksForYou } from "../WorksForYou"
 
 beforeAll(() => {
   NativeModules.ARTemporaryAPIModule = { markNotificationsRead: jest.fn() }
+  // FIXME: BNMO - Update with Echo setting and remove once BNMO has launched
   NativeModules.Emission = { options: { enableBuyNowMakeOffer: true } }
   WorksForYou.prototype.componentDidUpdate = () => {
     return null

--- a/src/lib/Scenes/Home/__tests__/index-tests.tsx
+++ b/src/lib/Scenes/Home/__tests__/index-tests.tsx
@@ -1,9 +1,15 @@
 import { shallow } from "enzyme"
 import { Tab } from "lib/Components/TabBar"
 import React from "react"
+import { NativeModules } from "react-native"
 import Home from "../index"
 
 jest.mock("tipsi-stripe", () => ({ setOptions: jest.fn() }))
+
+beforeAll(() => {
+  // FIXME: BNMO - Update with Echo setting and remove once BNMO has launched
+  NativeModules.Emission = { options: { enableBuyNowMakeOffer: true } }
+})
 
 it("has the correct number of tabs", () => {
   const wrapper = shallow(<Home initialTab={0} isVisible={true} tracking={null} />)

--- a/src/lib/Scenes/Home/index.tsx
+++ b/src/lib/Scenes/Home/index.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { AppState, View } from "react-native"
+import { AppState, NativeModules, View } from "react-native"
 import ScrollableTabView from "react-native-scrollable-tab-view"
 import styled from "styled-components/native"
 
@@ -102,6 +102,9 @@ export default class Home extends React.Component<Props, State> {
   }
 
   render() {
+    // FIXME: BNMO - Update with Echo setting and remove once BNMO has launched
+    const showConsignmentsSash = !NativeModules.Emission.options.enableBuyNowMakeOffer
+
     return (
       <View style={{ flex: 1 }}>
         <ScrollableTabView
@@ -131,10 +134,12 @@ export default class Home extends React.Component<Props, State> {
           </Tab>
         </ScrollableTabView>
 
-        <DarkNavigationButton
-          title="Sell works from your collection through Artsy"
-          onPress={this.openLink.bind(this)}
-        />
+        {showConsignmentsSash && (
+          <DarkNavigationButton
+            title="Sell works from your collection through Artsy"
+            onPress={this.openLink.bind(this)}
+          />
+        )}
       </View>
     )
   }


### PR DESCRIPTION
**Addresses:** https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=57&modal=detail&selectedIssue=DISCO-327

Hide Home view `"Sell works from your collection through Artsy"` consigments sash if `enableBuyNowMakeOffer` lab feature is on.

**TODO**: Swap the lab feature out for an Echo feature flag. 

