### PR TITLE
Mention that Xcode is a prereq

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Don't know what Artsy is? Check out [this overview](https://github.com/artsy/met
 
 Want to know more about Emission? Read the [mobile](http://artsy.github.io/blog/categories/mobile/) blog posts, or [Emission's](http://artsy.github.io/blog/categories/emission/) / [React Native's](http://artsy.github.io/blog/categories/reactnative/) specifically. Also check out [the map to Emission](docs/map_to_emission.md) to oriented yourself to the codebase.
 
+### Prerequisites
+
+* Xcode
+
 ### Installation
 
 _Automated install_:


### PR DESCRIPTION
I got pretty far along in the setup process before realizing Xcode wasn't installed; it'd be good to catch that earlier, by mentioning it as a prerequisite.