### PR TITLE
Fixes crash from possible division by zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Updates cocoapods (1.5.3) - luc
 - Adds Mapbox + Location Component - luc
 - Adds Artwork grids with infinite scroll to Show View - ashley
+- Fixes crash in marketing banner - ash
 
 ### 1.7.1
 

--- a/Example/Emission.xcodeproj/project.pbxproj
+++ b/Example/Emission.xcodeproj/project.pbxproj
@@ -647,9 +647,12 @@
 			files = (
 			);
 			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-Emission/Pods-Emission-frameworks.sh",
+				"${PODS_ROOT}/../../node_modules/@mapbox/react-native-mapbox-gl/ios/Mapbox.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Mapbox.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "emission",
   "version": "1.7.2",
-  "native-code-version": 8,
+  "native-code-version": 9,
   "description": "Artsy React(Native) components.",
   "engines": {
     "node": "8.x.x",


### PR DESCRIPTION
I was looking at Eigen's Sentry logs and came across [this new crash from 4.3.2](https://sentry.io/artsynet/eigen/issues/748150611/?query=is:unresolved):

```
Application threw exception CALayerInvalidGeometry: CALayer position contains NaN: [nan 110]
```

(It's only happened to one user so far.)

I took a look at the code and it looks like in some edge cases, we might be dividing by zero to calculate the aspect ratio. I put in a check for `isnan` first, hopefully this will fix it.