### PR TITLE
Brings back the consignment banner to the home component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@
 
 ### Master
 
+#### User Facing
+
+- Makes the consignment banner show by default, and allows changing this via an echo flag - orta
+- Fixes crash in marketing banner - ash
+
+#### Not user facing
+
 - Adds Shows detail page header components - javamonn
 - Updates to relay-compiler and relay-runtime - ash
 - Adds tslint-plugin-relay lint rule (from Reaction) - ash
@@ -23,7 +30,6 @@
 - Updates cocoapods (1.5.3) - luc
 - Adds Mapbox + Location Component - luc
 - Adds Artwork grids with infinite scroll to Show View - ashley
-- Fixes crash in marketing banner - ash
 - Adds Relay DevTools, Update Node.js to 10.13.0 - javamonn
 - Adds artists list component to show detail view - javamonn
 

--- a/Example/Emission/ARLabOptions.m
+++ b/Example/Emission/ARLabOptions.m
@@ -12,12 +12,15 @@ static NSDictionary *options = nil;
     //
     // The keys in this hash are how you can access the value in Emission code:
     //
-    // import { NativeModules } from "react-native"
-    // const { Emission } = NativeModules
+    // import { options } from "lib/options"
     //
-    // if (Emission.options.example) {
+    // if (options.example) {
     //   [something]
-
+    //
+    //
+    // Then in your test files, you can use jest to mock "lib/options" with your own
+    // object.
+    //
     options = @{
        @"nothingYet": @"No feature flags available"
     };

--- a/docs/adding_a_lab_option.md
+++ b/docs/adding_a_lab_option.md
@@ -1,0 +1,36 @@
+# How to add a new lab option to Emission
+
+Let's say you want to add something which is defaulted to hidden. We'll call the variable `showMarketingBanner`.
+
+1. Start by going to [`src/lib/options.ts`](src/lib/options.ts) and extend the interface with your new option.
+2. Go to your JS code, and import `lib/options` and use `options.showMarketingBanner` to handle your logic
+
+OK, now to understand how this gets set, there are three ways:
+
+### Emission
+
+Inside the development environment app (the green icon, Emission) you expose the ability to toggle options via
+[`/Example/Emission/ARLabOptions.m`](/Example/Emission/ARLabOptions.m) and [`/Example/Emission/ARLabOptions.h`](/Example/Emission/ARLabOptions.h) - you use the Objective-C hash `options` (note: you prefix strings/bools with an `@`)
+
+Changing [`ARLabOptions.m`](/Example/Emission/ARLabOptions.m) to add a new option would look like:
+
+```diff
+    options = @{
+       @"nothingYet": @"No feature flags available"
++        @"showMarketingBanner": @"Show the new marketing banner in the Artist page"
+    };
+```
+
+You'll need to re-compile the iOS app to make this show up on your launch screen in the app.
+
+### Eigen
+
+Eigen has the same setup as above. In this case, they are in [`/Artsy/App/AROptions.m`](https://github.com/artsy/eigen/blob/master/Artsy/App/AROptions.m) and [`/Artsy/App/AROptions.h`](https://github.com/artsy/eigen/blob/master/Artsy/App/AROptions.h) - the files are a bit more complicated, but in the end there's still an `options` has that you can use to set your option in.
+
+This ^ makes the option available to be toggled by any admin, they can shake their phones to see the admin menu in Eigen.
+
+The additional way for you to make option changes is via [Artsy Echo](https://github.com/artsy/echo) - Echo has a concept [called Features](https://echo-web-production.herokuapp.com/accounts/1/features) which are boolean options for features. Any feature set here is synced across all devices (so be conservative about changes for people's bandwidth) and will be applied on the next launch of an app.
+
+An admin setting in the Eigen admin screen can override defaults that come in from echo.
+
+If you make echo changes, ideally you should update the local bundled copy of the echo settings by running `make update_echo` in Eigen.

--- a/src/lib/Containers/__tests__/index-tests.tsx
+++ b/src/lib/Containers/__tests__/index-tests.tsx
@@ -1,6 +1,7 @@
 import exportsFromIndex from "../"
 
 jest.mock("tipsi-stripe", () => ({ setOptions: jest.fn() }))
+jest.mock("lib/options", () => ({ options: {} }))
 
 it("should export all components", () => {
   expect(Object.keys(exportsFromIndex)).toEqual([

--- a/src/lib/Scenes/Home/__tests__/index-tests.tsx
+++ b/src/lib/Scenes/Home/__tests__/index-tests.tsx
@@ -1,11 +1,26 @@
+jest.mock("tipsi-stripe", () => ({ setOptions: jest.fn() }))
+jest.mock("lib/options", () => ({ options: {} }))
+import { options } from "lib/options"
+
 import { shallow } from "enzyme"
+import DarkNavigationButton from "lib/Components/Buttons/DarkNavigationButton"
 import { Tab } from "lib/Components/TabBar"
 import React from "react"
 import Home from "../index"
 
-jest.mock("tipsi-stripe", () => ({ setOptions: jest.fn() }))
-
 it("has the correct number of tabs", () => {
   const wrapper = shallow(<Home initialTab={0} isVisible={true} tracking={null} />)
   expect(wrapper.find(Tab)).toHaveLength(3)
+})
+
+it("defaults to showing the sash", () => {
+  options.hideConsignmentsSash = undefined
+  const wrapper = shallow(<Home initialTab={0} isVisible={true} tracking={null} />)
+  expect(wrapper.find(DarkNavigationButton)).toHaveLength(1)
+})
+
+it("can hide the sash by setting the global option hideConsignmentsSash", () => {
+  options.hideConsignmentsSash = true
+  const wrapper = shallow(<Home initialTab={0} isVisible={true} tracking={null} />)
+  expect(wrapper.find(DarkNavigationButton)).toHaveLength(0)
 })

--- a/src/lib/Scenes/Home/index.tsx
+++ b/src/lib/Scenes/Home/index.tsx
@@ -6,6 +6,7 @@ import styled from "styled-components/native"
 import { Schema, screenTrack } from "lib/utils/track"
 
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
+import { options } from "lib/options"
 import { Router } from "lib/utils/router"
 
 import WorksForYou from "lib/Containers/WorksForYou"
@@ -102,10 +103,9 @@ export default class Home extends React.Component<Props, State> {
   }
 
   render() {
-    // TODO: Get confirmation on whether we're completey removing this
-    // https://github.com/artsy/emission/pull/1203/files/9ed3eb23a08080601876b50bef4c04468312bb2c#r226737902
-    //
-    const showConsignmentsSash = false
+    // This option doesn't exist today, so it will be undefined, it can
+    // be added to Echo's set of features if we want to disable it.
+    const showConsignmentsSash = !options.hideConsignmentsSash
     return (
       <View style={{ flex: 1 }}>
         <ScrollableTabView

--- a/src/lib/options.ts
+++ b/src/lib/options.ts
@@ -1,0 +1,18 @@
+import { NativeModules } from "react-native"
+const { Emission } = NativeModules
+
+// These features are available in the JS runtime,
+// they can either come in as AROptions inside the Emission app, or Eigen
+// or as Echo features inside Eigen.
+
+// You can find out more in docs/adding_a_lab_option.md
+
+/**
+ * Options that get passed down from the native host application
+ */
+export interface AvailableOptions {
+  /** Hide the consignments flag from the home screen? */
+  hideConsignmentsSash: boolean
+}
+
+export const options: AvailableOptions = Emission.options


### PR DESCRIPTION
Brings back the consignments sash and lets it be something we can toggle via Echo if needed. In doing this I also added some docs on how the lab options work.


<img width="621" alt="screen shot 2018-11-07 at 11 17 29 am" src="https://user-images.githubusercontent.com/49038/48144354-baa60800-e27e-11e8-9324-cdad13b06f07.png">

This is for DISCO-460

#skip_new_tests