### PR TITLE
Tighten the native dependencies for Emission

### DIFF
--- a/Emission.podspec
+++ b/Emission.podspec
@@ -9,7 +9,6 @@ end
 emission_version = pkg_version.call
 emission_native_version = pkg_version.call('', 'native-code-version')
 react_native_version = pkg_version.call('node_modules/react-native')
-sentry_version = pkg_version.call('node_modules/react-native-sentry')
 
 podspec = Pod::Spec.new do |s|
   s.name           = 'Emission'
@@ -22,16 +21,19 @@ podspec = Pod::Spec.new do |s|
                        'Sarah Scott' => 'sarah.scott@artsy.net' }
   s.source         = { :git => 'https://github.com/artsy/emission.git', :tag => "v#{s.version}" }
   s.platform       = :ios, '8.0'
-  s.requires_arc   = true
   s.source_files   = 'Pod/Classes/**/*.{h,m}'
   s.preserve_paths = 'Pod/Classes/**/*.generated.objc'
   s.resources      = 'Pod/Assets/{Emission.js,assets}'
 
+  # Artsy UI dependencies
   s.dependency 'Artsy+UIColors'
   s.dependency 'Artsy+UIFonts', '>= 3.0.0'
   s.dependency 'Extraction', '>= 1.2.1'
 
-  # React
+  # To ensure a consistent image cache between app/lib
+  s.dependency 'SDWebImage', '>= 3.7.2', '< 4'
+
+  # React, and the subspecs we have to use
   s.dependency 'React/Core', react_native_version
   s.dependency 'React/CxxBridge', react_native_version
   s.dependency 'React/RCTAnimation', react_native_version
@@ -43,20 +45,26 @@ podspec = Pod::Spec.new do |s|
 
   # React's Dependencies
   s.dependency 'yoga', "#{react_native_version}.React"
-  podspecs = [
+  react_podspecs = [
     'node_modules/react-native/third-party-podspecs/DoubleConversion.podspec',
     'node_modules/react-native/third-party-podspecs/Folly.podspec',
-    'node_modules/react-native/third-party-podspecs/glog.podspec'
+    'node_modules/react-native/third-party-podspecs/glog.podspec',
   ]
+
+  # Native dependencies of Emission, which come from node_modules
+  dep_podspecs = [
+    'node_modules/tipsi-stripe/tipsi-stripe.podspec',
+    'node_modules/@mapbox/react-native-mapbox-gl/react-native-mapbox-gl.podspec',
+    'node_modules/react-native-sentry/SentryReactNative.podspec'
+  ]
+
+  # Ties the exact versions so host apps don't need to guess the version
+  # or have a potential mismatch
+  podspecs = react_podspecs + dep_podspecs
   podspecs.each do |podspec_path|
     spec = Pod::Specification.from_file podspec_path
     s.dependency spec.name, "#{spec.version}"
   end
-
-  s.dependency 'SDWebImage', '>= 3.7.2', '< 4'
-  # This needs to be locked down because we’re including this specific version’s JS in our bundle, so it needs to match
-  # with the SentryReactNative version that CocoaPods would pull into Eigen.
-  s.dependency 'SentryReactNative', sentry_version
 end
 
 # Attach the native version info into the podspec

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -19,6 +19,9 @@ yoga_path = File.join(react_path, 'ReactCommon/yoga')
 folly_spec_path = File.join(react_path, 'third-party-podspecs/Folly.podspec')
 glog_spec_path = File.join(react_path, 'third-party-podspecs/glog.podspec')
 double_conversion_spec_path = File.join(react_path, 'third-party-podspecs/DoubleConversion.podspec')
+
+
+# If you add a new dependency here, it should also go in the Podspec
 sentry_path = File.join(node_modules_path, 'react-native-sentry')
 tispi_stripe_spec_path = File.join(node_modules_path, 'tipsi-stripe/tipsi-stripe.podspec')
 mapbox_path = File.join(node_modules_path, '@mapbox/react-native-mapbox-gl')


### PR DESCRIPTION
Tightens up the dependencies in the Emission podspec to the exact versions of the JS that's emitted.