### PR TITLE
Adds extra checking around sale artwork messaging in artwork grids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Refactor More Shows section - luc
 - Styles fair header view - luc
 - Increases size of pin for LocationMap and zooms in slighlty - kieran
+- Adds extra checking around sale artwork messaging in artwork grids - ash
 
 ### 1.7.4
 

--- a/src/lib/Components/ArtworkGrids/Artwork.tsx
+++ b/src/lib/Components/ArtworkGrids/Artwork.tsx
@@ -136,12 +136,11 @@ class Artwork extends React.Component<Props, any> {
 
   saleMessageOrBidInfo() {
     const { artwork } = this.props
-    const { sale } = artwork
-    const inRunningAuction = sale && sale.is_auction && !sale.is_closed
+    const { sale, sale_artwork } = artwork
+    const inRunningAuction = sale && sale_artwork && sale.is_auction && !sale.is_closed
 
     if (inRunningAuction) {
-      const sa = artwork.sale_artwork
-      const currentBid = sa.current_bid
+      const currentBid = sale_artwork.current_bid
       return currentBid && currentBid.display
     }
 

--- a/src/lib/Components/ArtworkGrids/__tests__/Artwork-tests.tsx
+++ b/src/lib/Components/ArtworkGrids/__tests__/Artwork-tests.tsx
@@ -36,6 +36,12 @@ describe("in an open sale", () => {
     const artwork = renderer.create(<Artwork artwork={artworkProps(saleArtwork) as any} />).toJSON()
     expect(artwork).toMatchSnapshot()
   })
+
+  it("safely handles a missing sale_artwork", () => {
+    const props = artworkProps({}) // Passing in empty sale_artwork prop to trigger "sale is live" code in artworkProps()
+    props.sale_artwork = null
+    expect(() => renderer.create(<Artwork artwork={props as any} />).toJSON()).not.toThrowError()
+  })
 })
 
 describe("in a closed sale", () => {


### PR DESCRIPTION
I was looking through Eigen's Sentry and found [this crash](https://sentry.io/artsynet/eigen/issues/587358816/events/latest/). It's been around about 5 months and happens occasionally. There isn't a lot of detail in the crash report, but based on the breadcrumbs, users see this crash on the home screen. This PR adds some extra checking to the data that comes from Relay. Here's the situation:

> What if we have an artwork that has a sale, and that sale is an artwork, but the `sale_artwork` property on the `artwork` object is `null`?

I don't know under what circumstances that would happen, but based on the breadcrumbs this is the most likely source of the crash. The fix is to simply get `sale_artwork` from `artwork` and check it for `null` first. Thoughts?