### PR TITLE
Pass through partnerType to LocationMap on Fair

### DIFF
--- a/src/lib/Scenes/Fair/index.tsx
+++ b/src/lib/Scenes/Fair/index.tsx
@@ -25,6 +25,7 @@ export class Fair extends React.Component<Props> {
       data: {
         location: fair.location,
         partnerName: fair.organizer.profile.name,
+        partnerType: "Fair",
       },
     })
 


### PR DESCRIPTION
Fixes a crash triggered when accessing the Fair screen

#trivial