### PR TITLE
Update extensions.json to remove the old GraphQL extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,4 @@
 {
-  "recommendations": ["artsy.artsy-studio-extension-pack"]
+  "recommendations": ["artsy.artsy-studio-extension-pack"],
+  "unwantedRecommendations": ["prisma.vscode-graphql"]
 }


### PR DESCRIPTION
This should hopefully recommend to uninstall, or maybe not load it - I'm actually unsure.