### PR TITLE
Warn if "yarn install" is required

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -5,6 +5,12 @@ unless using_bundler
   exit(1)
 end
 
+unless Dir.exist? '../node_modules'
+  puts "\nYou will need to run:".red
+  puts "  yarn install\n\n"
+  exit(1)
+end
+
 source 'https://github.com/artsy/Specs.git'
 source 'https://github.com/CocoaPods/Specs.git'
 


### PR DESCRIPTION
This adds a warning for a step that may have been missed during a manual install (or an aborted auto install, as in my case).

Simply checks for existence of `node_modules` in the project root, and warns if it's missing.