### PR TITLE
Lists simulators in native CI runs #trivial

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,10 @@ jobs:
       BUNDLE_PATH: vendor/bundle
 
     steps:
+      - run:
+          name: List Simulators
+          command: xcrun simctl list
+
       - checkout
 
       - restore_cache:


### PR DESCRIPTION
[The docs](https://circle-macos-docs.s3.amazonaws.com/image-manifest/build-474/index.html) list iPhone 6 (10.3.1) as an installed simulator, but the build is [failing](https://circleci.com/gh/artsy/emission/171) with:

```
xcodebuild: error: Unable to find a destination matching the provided destination specifier:
		{ platform:iOS Simulator, OS:10.3.1, name:iPhone 6 }
```

First step is to list the installed simulators. 