### PR TITLE
Fix gemfile reference to cocoapods-check

### DIFF
--- a/Example/Gemfile
+++ b/Example/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 gem "cocoapods"
 
 # So we know if we need to run `pod install`
-gem 'cocoapods-check', git: 'https://github.com/ashfurrow/cocoapods-check.git', branch: 'ignore-dev-pods'
+gem 'cocoapods-check', git: 'https://github.com/square/cocoapods-check.git', branch: 'master'
 
 # To manage our secret keys
 gem "cocoapods-keys"

--- a/Example/Gemfile.lock
+++ b/Example/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
-  remote: https://github.com/ashfurrow/cocoapods-check.git
-  revision: ded2d0195a902e54917bd935e5a015db1d6ef799
-  branch: ignore-dev-pods
+  remote: https://github.com/square/cocoapods-check.git
+  revision: f19086dee299c27b52453e5a87b011900b7f8ae0
+  branch: master
   specs:
     cocoapods-check (1.0.2)
       cocoapods (~> 1.0)


### PR DESCRIPTION
Switches a flaky Gemfile reference to a better repo location now that @ashfurrow's PR has been merged. 

We'll want to clean this up further once Square cuts an actual new release of the gem.