### PR TITLE
Fixes pod install #trivial

### DIFF
--- a/Example/Emission.xcodeproj/project.pbxproj
+++ b/Example/Emission.xcodeproj/project.pbxproj
@@ -520,6 +520,7 @@
 					};
 					510DCB251CCA69EC0075E8CB = {
 						CreatedOnToolsVersion = 7.2.1;
+						LastSwiftMigration = 1010;
 						TestTargetID = 510DCB0D1CCA69EC0075E8CB;
 					};
 					510DCB301CCA69EC0075E8CB = {
@@ -612,7 +613,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-Emission/Pods-Emission-resources.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-Emission/Pods-Emission-resources.sh",
 				"${PODS_ROOT}/Artsy+UIFonts/Pod/Assets/AGaramondPro-Bold.otf",
 				"${PODS_ROOT}/Artsy+UIFonts/Pod/Assets/AGaramondPro-BoldItalic.otf",
 				"${PODS_ROOT}/Artsy+UIFonts/Pod/Assets/AGaramondPro-Italic.otf",
@@ -649,7 +650,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Emission/Pods-Emission-resources.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Emission/Pods-Emission-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		510E94FE1CCB87F100BDF098 /* Create Clang compilation DB */ = {
@@ -721,7 +722,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-Emission/Pods-Emission-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-Emission/Pods-Emission-frameworks.sh",
 				"${PODS_ROOT}/../../node_modules/@mapbox/react-native-mapbox-gl/ios/Mapbox.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -730,7 +731,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Emission/Pods-Emission-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Emission/Pods-Emission-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -875,8 +876,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 17DDC2B5E27740D462B9B1E4 /* Pods-EmissionTests.debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_MODULES = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
@@ -888,6 +889,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = net.artsy.EmissionTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.2;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Emission.app/Emission";
 			};
 			name = Debug;
@@ -896,13 +899,14 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E347387A62A41620FEED9427 /* Pods-EmissionTests.release.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = EmissionTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = net.artsy.EmissionTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.2;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Emission.app/Emission";
 			};
 			name = Release;
@@ -1128,14 +1132,16 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5D75FFB0E282ED7DB0B9141E /* Pods-EmissionTests.deploy.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_MODULES = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				INFOPLIST_FILE = EmissionTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = net.artsy.EmissionTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.2;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Emission.app/Emission";
 			};
 			name = Deploy;


### PR DESCRIPTION
@ashleyjelks was seeing the following error, which I managed to reproduce locally:

```
[!] Unable to determine Swift version for the following pods:

- `FBSnapshotTestCase` does not specify a Swift version and none of the targets (`EmissionTests`) integrating it have the `SWIFT_VERSION` attribute set. Please contact the author or set the `SWIFT_VERSION` attribute in at least one of the targets that integrate this pod.
```

The solution was to add a Swift file to the test target, then delete it (because Swift files can't be integrated into our Xcode project directly... yet). I also removed the `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES` which was left over from an earlier version of CocoaPods.