### PR TITLE
removes Fairs tab from Favorites view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - Fixes scroll in artworks grid - kieran
 - Check for saleInfoLine before rendering sales info on artwork - kieran
 - Adds analytics to all Show screens and views - luc
+- Removes Fairs tab from Global Saves and Follows view -ashley
 
 ### 1.8.2
 

--- a/src/lib/Components/ScrollableTabBar.tsx
+++ b/src/lib/Components/ScrollableTabBar.tsx
@@ -132,7 +132,7 @@ export default class ScrollableTabBar extends React.Component<ScrollableTabBarPr
         alwaysBounceVertical={false}
         showsHorizontalScrollIndicator={false}
         showsVerticalScrollIndicator={false}
-        contentContainerStyle={{ flexDirection: "row", justifyContent: "space-around" }}
+        contentContainerStyle={{ flexDirection: "row", justifyContent: "space-between", width: "100%" }}
         onContentSizeChange={width => (this.scrollViewWidth = width)}
         horizontal
       >

--- a/src/lib/Scenes/Favorites/index.tsx
+++ b/src/lib/Scenes/Favorites/index.tsx
@@ -37,12 +37,13 @@ const Title = styled.Text`
 `
 
 const isStaging = gravityURL.includes("staging")
+const isTabVisible = false
 
 const WorksTab = 0
 const ArtistsTab = 1
 const CategoriesTab = 2
-const FairsTab = 3
 const ShowsTab = 3
+const FairsTab = 4
 
 interface Props {
   tracking: any
@@ -74,9 +75,11 @@ class Favorites extends React.Component<Props, null> {
           <ScrollableTab tabLabel="Categories">
             <CategoriesRenderer render={renderWithLoadProgress(Categories)} />
           </ScrollableTab>
-          <ScrollableTab tabLabel="Fairs">
-            <FairsRenderer render={renderWithLoadProgress(Fairs)} />
-          </ScrollableTab>
+          {isTabVisible && ( // @TODO: hides Fairs tab for now. Revert after v1 of Local Discovery is launched.
+            <ScrollableTab tabLabel="Fairs">
+              <FairsRenderer render={renderWithLoadProgress(Fairs)} />
+            </ScrollableTab>
+          )}
           <ScrollableTab tabLabel="Shows">
             <ShowsRenderer render={renderWithLoadProgress(Shows)} />
           </ScrollableTab>
@@ -95,10 +98,10 @@ class Favorites extends React.Component<Props, null> {
       tabType = Schema.ActionNames.SavesAndFollowsArtists
     } else if (selectedTab.i === CategoriesTab) {
       tabType = Schema.ActionNames.SavesAndFollowsCategories
-    } else if (selectedTab.i === FairsTab) {
-      tabType = Schema.ActionNames.SavesAndFollowsFairs
     } else if (selectedTab.i === ShowsTab) {
       tabType = Schema.ActionNames.SavesAndFollowsShows
+    } else if (selectedTab.i === FairsTab) {
+      tabType = Schema.ActionNames.SavesAndFollowsFairs
     }
 
     this.props.tracking.trackEvent({


### PR DESCRIPTION
This PR removes the Fairs tab button from the Favorites scrolling tab. 


<img width="390" alt="screen shot 2019-02-19 at 3 51 59 pm" src="https://user-images.githubusercontent.com/10385964/53046612-7110b000-345e-11e9-943f-1404179e0cb7.png">


#skip_new_tests
