### PR TITLE
Change the positioning of the caret button to fit design specs

### DIFF
--- a/src/lib/Components/Buttons/CaretButton.tsx
+++ b/src/lib/Components/Buttons/CaretButton.tsx
@@ -15,7 +15,7 @@ export const CaretButton: React.SFC<Props> = ({ text, onPress }) => {
         <Sans size="3t" weight="medium">
           {text}
         </Sans>
-        <Box ml={0.5}>
+        <Box ml={0.5} style={{ marginTop: 1.5 }}>
           <ChevronIcon />
         </Box>
       </Flex>

--- a/src/lib/Components/Buttons/__tests__/CaretButton-tests.tsx
+++ b/src/lib/Components/Buttons/__tests__/CaretButton-tests.tsx
@@ -6,6 +6,7 @@ import { CaretButton } from "../CaretButton"
 describe("CaretButton", () => {
   it("renders properly", () => {
     const button = renderer.create(<CaretButton text="I am a caret button" />)
+    expect(JSON.stringify(button.toJSON())).toContain("I am a caret button")
     expect(button).toMatchSnapshot()
   })
 })

--- a/src/lib/Components/Buttons/__tests__/__snapshots__/CaretButton-tests.tsx.snap
+++ b/src/lib/Components/Buttons/__tests__/__snapshots__/CaretButton-tests.tsx.snap
@@ -49,7 +49,9 @@ exports[`CaretButton renders properly 1`] = `
         Object {
           "marginLeft": 0.5,
         },
-        undefined,
+        Object {
+          "marginTop": 1.5,
+        },
       ]
     }
   >

--- a/src/lib/Scenes/Fair/Components/__tests__/__snapshots__/ArtistsExhibitorsWorksLink-tests.tsx.snap
+++ b/src/lib/Scenes/Fair/Components/__tests__/__snapshots__/ArtistsExhibitorsWorksLink-tests.tsx.snap
@@ -76,7 +76,9 @@ exports[`ArtistsExhibitorsWorksLink Renders correctly 1`] = `
             Object {
               "marginLeft": 0.5,
             },
-            undefined,
+            Object {
+              "marginTop": 1.5,
+            },
           ]
         }
       >
@@ -310,7 +312,9 @@ exports[`ArtistsExhibitorsWorksLink Renders correctly 1`] = `
             Object {
               "marginLeft": 0.5,
             },
-            undefined,
+            Object {
+              "marginTop": 1.5,
+            },
           ]
         }
       >
@@ -544,7 +548,9 @@ exports[`ArtistsExhibitorsWorksLink Renders correctly 1`] = `
             Object {
               "marginLeft": 0.5,
             },
-            undefined,
+            Object {
+              "marginTop": 1.5,
+            },
           ]
         }
       >


### PR DESCRIPTION
Before -> After:

<img width="300" alt="screen shot 2019-02-22 at 10 37 02 am" src="https://user-images.githubusercontent.com/49038/53253859-32623c00-3690-11e9-96e5-47a92fb13f7b.png"><img width="300" alt="screen shot 2019-02-22 at 10 47 39 am" src="https://user-images.githubusercontent.com/49038/53253844-2aa29780-3690-11e9-9932-1583d698d073.png">

#trivial