### PR TITLE
Fixes rendering markdown in Fair/Show (but also everywhere else

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - Check for saleInfoLine before rendering sales info on artwork - kieran
 - Adds analytics to all Show screens and views - luc
 - Removes Fairs tab from Global Saves and Follows view -ashley
+- Fix rendering strong elements in markdown all over the app - orta
 - Fixes FairBooth routing - kieran
 - Fair exhibitors overview looks up to spec - orta
 

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "react-tracking": "^5.0.0",
     "relay-runtime": "https://github.com/alloy/relay/releases/download/v1.5.0-artsy.5/relay-runtime-1.5.0-artsy.5.tgz",
     "remove-markdown": "0.1.0",
-    "simple-markdown": "^0.4.0",
+    "simple-markdown": "^0.4.2",
     "styled-components": "3.2.2",
     "tipsi-stripe": "5.2.4"
   },

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/RegistrationResult-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/RegistrationResult-tests.tsx.snap
@@ -118,10 +118,14 @@ exports[`Registration result component renders registration complete properly 1`
           Thank you for registering. You’re now eligible
 to bid on works in this sale.
         </Text>
-        
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+        >
+          
 
-
-
+        </Text>
       </View>
     </View>
   </View>
@@ -308,10 +312,14 @@ exports[`Registration result component renders registration error properly 1`] =
           
 with any questions.
         </Text>
-        
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+        >
+          
 
-
-
+        </Text>
       </View>
     </View>
   </View>
@@ -499,10 +507,14 @@ Please contact
            for
 more information.
         </Text>
-        
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+        >
+          
 
-
-
+        </Text>
       </View>
     </View>
   </View>

--- a/src/lib/Components/Markdown.tsx
+++ b/src/lib/Components/Markdown.tsx
@@ -50,12 +50,14 @@ export const defaultRules = {
   },
 
   newline: {
+    ...SimpleMarkdown.defaultRules.newline,
     react: (_node, _output, state) => {
       return <Text key={state.key}>{"\n"}</Text>
     },
   },
 
   strong: {
+    ...SimpleMarkdown.defaultRules.strong,
     react: (node, output, state) => {
       return (
         <Sans size="3t" weight="medium" key={state.key}>
@@ -66,6 +68,7 @@ export const defaultRules = {
   },
 
   br: {
+    ...SimpleMarkdown.defaultRules.br,
     react: (_node, _output, state) => {
       return <Text key={state.key}>{"\n\n"}</Text>
     },

--- a/src/lib/Components/__tests__/Markdown-tests.tsx
+++ b/src/lib/Components/__tests__/Markdown-tests.tsx
@@ -92,3 +92,14 @@ describe("Markdown", () => {
     expect(markdown.root.findAllByType(Text)[0].props.testID).toBe("foobar")
   })
 })
+
+describe("defaultRules", () => {
+  Object.keys(defaultRules).forEach(key => {
+    if (key === "Array") {
+      return
+    }
+    it(`has a match rule for ${key}`, () => {
+      expect(defaultRules[key].match).toBeTruthy()
+    })
+  })
+})

--- a/src/lib/Components/__tests__/Markdown-tests.tsx
+++ b/src/lib/Components/__tests__/Markdown-tests.tsx
@@ -28,9 +28,9 @@ describe("Markdown", () => {
       </Theme>
     )
 
-    expect(markdown.root.findAllByType(Text).length).toEqual(2)
+    expect(markdown.root.findAllByType(Text).length).toEqual(4)
     expect(markdown.root.findAllByType(Text)[0].props.children[0]).toMatch("paragraph 1 has some text")
-    expect(markdown.root.findAllByType(Text)[1].props.children[0]).toMatch("paragraph 2 also has text")
+    expect(markdown.root.findAllByType(Text)[2].props.children[0]).toMatch("paragraph 2 also has text")
   })
 
   it("renders links as LinkText", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11071,9 +11071,10 @@ signedsource@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/signedsource/-/signedsource-1.0.0.tgz#1ddace4981798f93bd833973803d80d52e93ad6a"
 
-simple-markdown@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/simple-markdown/-/simple-markdown-0.4.0.tgz#86ec1344c7747a3ca120f5e4325be88cb4a67cc3"
+simple-markdown@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/simple-markdown/-/simple-markdown-0.4.2.tgz#98fd72bd4f8ced9705f3e72c4cb4a00261a5eca0"
+  integrity sha512-lysF/mIJ3Trv/QsxY5Q5XWupVLtyPH6AslxOxscWhUshQNAfHRd7ayuXHlXkXVnujHfIVa0okDw3ZGnzCroO7Q==
 
 simple-plist@^0.2.1:
   version "0.2.1"


### PR DESCRIPTION
This never worked, so now if anyone creates a new item in the markdown config a test will fail if they don't remember to do the `...default`.

Fixes LD-214
