### PR TITLE
Fix for the artwork count in a show

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Master
 
+- Fix for the count of artworks in a show - orta
+
 ### 1.8.4
 
 - Fair exhibitors overview looks up to spec - orta

--- a/src/lib/Components/Show/ShowArtworksPreview.tsx
+++ b/src/lib/Components/Show/ShowArtworksPreview.tsx
@@ -29,7 +29,7 @@ export class ShowArtworksPreview extends React.Component<Props> {
         {counts &&
           counts.artworks > artworks.length && (
             <Box mt={1}>
-              <CaretButton text={`View all ${artworks.length} works`} onPress={() => onViewAllArtworksPressed()} />
+              <CaretButton text={`View all ${counts.artworks} works`} onPress={() => onViewAllArtworksPressed()} />
             </Box>
           )}
       </>


### PR DESCRIPTION
Before: always 6
After:

<img width="683" alt="screen shot 2019-02-26 at 12 39 21 pm" src="https://user-images.githubusercontent.com/49038/53434008-a15ad000-39c3-11e9-9f0e-5138554cc28b.png">
