### PR TITLE
Fixes logo size to contain #trivial

### DIFF
--- a/src/lib/Scenes/Fair/Components/FairHeader/index.tsx
+++ b/src/lib/Scenes/Fair/Components/FairHeader/index.tsx
@@ -146,7 +146,7 @@ export class FairHeader extends React.Component<Props, State> {
           <Overlay />
           <Flex flexDirection="row" justifyContent="center" alignItems="center" px={2} height={imageHeight}>
             <Flex alignItems="center" flexDirection="column" flexGrow={1}>
-              {profile && <Logo source={{ uri: profile.icon.url }} />}
+              {profile && <Logo source={{ uri: profile.icon.url }} resizeMode="contain" />}
               <Sans size="3t" weight="medium" textAlign="center" color="white100">
                 {name}
               </Sans>


### PR DESCRIPTION
Before: 

<img src="https://user-images.githubusercontent.com/296775/53454230-82286680-39f4-11e9-80c3-18b4de360b8b.png" width="400" />

After: 

<img src="https://user-images.githubusercontent.com/296775/53454266-a2582580-39f4-11e9-8ced-5126c145a3ce.png" width="400" />
