### PR TITLE
Improvements to fair handling for map preview taps

### DIFF
--- a/src/lib/Components/LocationMap/index.tsx
+++ b/src/lib/Components/LocationMap/index.tsx
@@ -104,9 +104,17 @@ export class LocationMap extends React.Component<Props> {
     }
 
     const tappedOnMap = () => {
+      // Fairs only have a "summary", so we need to
+      // be quite conservative about what parts of the address we
+      // send to the different services
+      const firstLineAddress = address || summary
+      const suffix = postal_code && !firstLineAddress.includes(postal_code) ? `, ${postal_code}` : ""
+      const title = `${firstLineAddress}${suffix}`
+      const addressOrName = address || partnerName
+
       ActionSheetIOS.showActionSheetWithOptions(
         {
-          title: `${address}, ${postal_code}`,
+          title,
           options: ["Cancel", "Open in Apple Maps", "Open in City Mapper", "Open in Google Maps", "Copy Address"],
           cancelButtonIndex: 0,
         },
@@ -114,7 +122,7 @@ export class LocationMap extends React.Component<Props> {
           if (buttonIndex === 1) {
             // Apple Maps
             // https://developer.apple.com/library/archive/featuredarticles/iPhoneURLScheme_Reference/MapLinks/MapLinks.html
-            Linking.openURL(`http://maps.apple.com/?addr="${address}, ${postal_code}"&near=${lat},${lng}`)
+            Linking.openURL(`http://maps.apple.com/?addr="${addressOrName}${suffix}"&near=${lat},${lng}`)
           } else if (buttonIndex === 2) {
             // City Mapper
             // https://citymapper.com/tools/1053/launch-citymapper-for-directions
@@ -124,12 +132,10 @@ export class LocationMap extends React.Component<Props> {
           } else if (buttonIndex === 3) {
             // Google Maps
             // https://developers.google.com/maps/documentation/urls/guide
-            Linking.openURL(
-              `https://www.google.com/maps/dir/?api=1&map_action=map&destination=${partnerName}, ${address}`
-            )
+            Linking.openURL(`https://www.google.com/maps/dir/?api=1&map_action=map&destination=${lat}, ${lng}`)
           } else if (buttonIndex === 4) {
             // Copy to pasteboard
-            Clipboard.setString(`${address}, ${postal_code}`)
+            Clipboard.setString(title)
           }
         }
       )


### PR DESCRIPTION
- The title now will take into account fairs, and is always the same as the text copied. 
- Google maps now only gets lat/lng and under the hood that is shown as an address (on the site at least)
- Better handling of no postal code existing

<img width="621" alt="screen shot 2019-02-27 at 1 56 19 pm" src="https://user-images.githubusercontent.com/49038/53515218-79d53780-3a97-11e9-976e-767013b1e3f7.png">

#trivial