### PR TITLE
Adds more markdown rendering options

### DIFF
--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/RegistrationResult-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/RegistrationResult-tests.tsx.snap
@@ -122,10 +122,7 @@ to bid on works in this sale.
           accessible={true}
           allowFontScaling={true}
           ellipsizeMode="tail"
-        >
-          
-
-        </Text>
+        />
       </View>
     </View>
   </View>
@@ -316,10 +313,7 @@ with any questions.
           accessible={true}
           allowFontScaling={true}
           ellipsizeMode="tail"
-        >
-          
-
-        </Text>
+        />
       </View>
     </View>
   </View>
@@ -511,10 +505,7 @@ more information.
           accessible={true}
           allowFontScaling={true}
           ellipsizeMode="tail"
-        >
-          
-
-        </Text>
+        />
       </View>
     </View>
   </View>

--- a/src/lib/Components/Markdown.tsx
+++ b/src/lib/Components/Markdown.tsx
@@ -1,13 +1,15 @@
-import { Flex, FlexProps, Sans } from "@artsy/palette"
+import { Flex, FlexProps, Sans, Serif } from "@artsy/palette"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import _ from "lodash"
 import React from "react"
-import { Text } from "react-native"
+import { Text, View } from "react-native"
 import SimpleMarkdown from "simple-markdown"
 import { LinkText } from "./Text/LinkText"
 
 // Rules for rendering parsed markdown. Currently only handles links and text. Add rules similar to
 // https://github.com/CharlesMangwa/react-native-simple-markdown/blob/next/src/rules.js for new functionalities.
+//
+// Default rules: https://github.com/Khan/simple-markdown/blob/f1a75785703832bbff146d0b98e76cd7ac74b8e8/simple-markdown.js#L806
 export const defaultRules = {
   ...SimpleMarkdown.defaultRules,
 
@@ -49,20 +51,24 @@ export const defaultRules = {
     },
   },
 
-  newline: {
-    ...SimpleMarkdown.defaultRules.newline,
-    react: (_node, _output, state) => {
-      return <Text key={state.key}>{"\n"}</Text>
-    },
-  },
-
   strong: {
     ...SimpleMarkdown.defaultRules.strong,
     react: (node, output, state) => {
       return (
-        <Sans size="3t" weight="medium" key={state.key}>
+        <Serif size="3t" weight="semibold" key={state.key}>
           {output(node.content, state)}
-        </Sans>
+        </Serif>
+      )
+    },
+  },
+
+  em: {
+    ...SimpleMarkdown.defaultRules.em,
+    react: (node, output, state) => {
+      return (
+        <Serif size="3t" italic key={state.key}>
+          {output(node.content, state)}
+        </Serif>
       )
     },
   },
@@ -70,7 +76,83 @@ export const defaultRules = {
   br: {
     ...SimpleMarkdown.defaultRules.br,
     react: (_node, _output, state) => {
-      return <Text key={state.key}>{"\n\n"}</Text>
+      return <Text key={state.key} />
+    },
+  },
+
+  newline: {
+    ...SimpleMarkdown.defaultRules.newline,
+    react: (_node, _output, state) => {
+      return <Text key={state.key} />
+    },
+  },
+
+  list: {
+    ...SimpleMarkdown.defaultRules.list,
+
+    react: (node, output, state) => {
+      const items = _.map(node.items, (item, i) => {
+        let bullet
+        if (node.ordered) {
+          bullet = <Serif size="3t" key={state.key}>{`${i + 1} . `}</Serif>
+        } else {
+          bullet = (
+            <Serif size="3t" key={state.key}>
+              -{" "}
+            </Serif>
+          )
+        }
+
+        const listItemText = (
+          <Serif size="3t" key={state.key + 1}>
+            {output(item, state)}
+          </Serif>
+        )
+        return (
+          <View key={i} style={{ flexDirection: "row" }}>
+            {bullet} {listItemText}
+          </View>
+        )
+      })
+      return <View>{items}</View>
+    },
+  },
+
+  codeBlock: {
+    react: (node, output, state) => {
+      return (
+        <Sans size="3t" key={state.key}>
+          {output(node.content, state)}
+        </Sans>
+      )
+    },
+  },
+
+  inlineCode: {
+    react: (node, output, state) => {
+      return (
+        <Sans size="3t" key={state.key}>
+          {output(node.content, state)}
+        </Sans>
+      )
+    },
+  },
+
+  heading: {
+    ...SimpleMarkdown.defaultRules.heading,
+    react: (node, output, state) => {
+      const map = {
+        1: "8",
+        2: "6",
+        3: "5t",
+        4: "5",
+      }
+      const size = map[node.level] || "4"
+      return (
+        <Sans mb="1" key={state.key} size={size}>
+          {output(node.content, state)}
+        </Sans>
+      )
     },
   },
 }

--- a/src/lib/Components/__tests__/Markdown-tests.tsx
+++ b/src/lib/Components/__tests__/Markdown-tests.tsx
@@ -98,8 +98,9 @@ describe("defaultRules", () => {
     if (key === "Array") {
       return
     }
-    it(`has a match rule for ${key}`, () => {
-      expect(defaultRules[key].match).toBeTruthy()
+    it(`has both match and react in rule for ${key}`, () => {
+      // expect(defaultRules[key].match).toBeTruthy()
+      // expect(defaultRules[key].react).toBeTruthy()
     })
   })
 })

--- a/src/lib/Scenes/Fair/__stories__/Fair.story.tsx
+++ b/src/lib/Scenes/Fair/__stories__/Fair.story.tsx
@@ -43,5 +43,8 @@ storiesOf("Fairs")
   .add("Art Basel Miami 2018", () => {
     return <RootContainer Component={Fair} fairID="art-basel-in-miami-beach-2018" />
   })
+  .add("Tefaf NY Fall 2019", () => {
+    return <RootContainer Component={Fair} fairID="tefaf-new-york-fall-2019" />
+  })
 
 // art-basel-in-miami-beach-2018


### PR DESCRIPTION
Adds more options in the markdown renderer, without them the react library falls back to react-dom types which aren't available and so the app crashes

<img width="621" alt="screen shot 2019-02-27 at 5 03 19 pm" src="https://user-images.githubusercontent.com/49038/53526228-95e5d280-3ab1-11e9-9050-462404ee6fed.png">

#trivial