### PR TITLE
Fixes fair view crash on fairs with no profiles #trivial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 
 ### Master
 
+- Fixes fair view crash on fairs with no profiles - ash
+
+### 1.8.7
+
 - Fixed the fairs thumbnails for a city, and makes the fairs clickable - orta
 - Fixed fair links - ash
 - Fixed various other edge-case broken links - ash

--- a/src/lib/Scenes/Fair/Components/FairHeader/index.tsx
+++ b/src/lib/Scenes/Fair/Components/FairHeader/index.tsx
@@ -147,7 +147,7 @@ export class FairHeader extends React.Component<Props, State> {
     return (
       <>
         <Box style={{ height: imageHeight, width: screenWidth, position: "relative" }}>
-          <BackgroundImage imageURL={image.url} height={imageHeight} width={screenWidth} />
+          {image && <BackgroundImage imageURL={image.url} height={imageHeight} width={screenWidth} />}
           <Overlay />
           <Flex flexDirection="row" justifyContent="center" alignItems="center" px={2} height={imageHeight}>
             <Flex alignItems="center" flexDirection="column" flexGrow={1}>


### PR DESCRIPTION
For example: https://www.artsy.net/affordable-art-fair-battersea-spring-2019