### PR TITLE
Updates show routing for emission to not break if / is used before href

### DIFF
--- a/Example/Emission/AppDelegate.m
+++ b/Example/Emission/AppDelegate.m
@@ -336,7 +336,7 @@ randomBOOL(void)
     NSString *showID = [[route componentsSeparatedByString:@"/"] objectAtIndex:2];
     viewController = [[ARShowMoreInfoComponentViewController alloc] initWithShowID:showID];
   } else if (isShow) {
-    NSString *showID = [[route componentsSeparatedByString:@"/"] objectAtIndex:1];
+    NSString *showID = [[route componentsSeparatedByString:@"/"] lastObject];
     viewController = [[ARShowComponentViewController alloc] initWithShowID:showID];
   } else {
     viewController = [[UnroutedViewController alloc] initWithRoute:route];


### PR DESCRIPTION
- Show routing was broken in emission if `/` was used before `show` e.g. `/show/${id}`. This PR fixes this issue.