### PR TITLE
Fixes render failure with missing city coords.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Order name of Fair's artists based on user's favorite artists - ashkan
 - Adds styled city picker modal - ashley
 - Adds CityTab stying and passes CityName to AllEvents view - kieran
+- Fixes render failure with missing city coords - ash
 
 ### 1.8.10
 

--- a/src/lib/Scenes/Map/MapContainer.tsx
+++ b/src/lib/Scenes/Map/MapContainer.tsx
@@ -1,16 +1,17 @@
 import React, { Component } from "react"
+import { View } from "react-native"
 import { MapRenderer } from "./MapRenderer"
 import { Coordinates } from "./types"
 
 interface Props {
-  coordinates: Coordinates
+  coordinates?: Coordinates
   hideMapButtons: boolean
 }
 
-// TODO: Do we even need this component any more?
 export class MapContainer extends Component<Props> {
   render() {
     const { coordinates, hideMapButtons } = this.props
-    return <MapRenderer coords={coordinates} hideMapButtons={hideMapButtons} />
+    // TODO: If there are no coords, we should show something else instead.
+    return coordinates ? <MapRenderer coords={coordinates} hideMapButtons={hideMapButtons} /> : <View />
   }
 }


### PR DESCRIPTION
Follow-up to LD-295 / #1377. This is a workaround until LD–309 is addressed.

#skip_new_tests