### PR TITLE
Ensure the tab is consistent throughout Emission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Master
 
+- The Home tab bar is now consistent with the design system - orta
 - Order name of Fair's artists based on user's favorite artists - ashkan
 - Adds styled city picker modal - ashley
 - Adds CityTab stying and passes CityName to AllEvents view - kieran

--- a/src/lib/Components/TabBar.tsx
+++ b/src/lib/Components/TabBar.tsx
@@ -2,19 +2,31 @@ import React from "react"
 import { Animated, View } from "react-native"
 import styled from "styled-components/native"
 
+import { Sans } from "@artsy/palette"
 import colors from "lib/data/colors"
-import fonts from "lib/data/fonts"
 
+/**
+ * Nearly all props are given by the ScrollableTabView,
+ * these are prefixed with Auto:
+ */
 interface TabBarProps {
+  /** Auto: A list of strings for the buttons */
+  tabs: string[]
+  /** Auto:  A callback for usage in the tab buttons */
   goToPage?: () => null
+  /** Auto: The index of the currently active tab */
   activeTab?: number
-  tabs?: any[]
+  /** Auto: How much horiztonal space do you have */
   containerWidth?: number
+  /** Auto: Handled by ScrollableTabView */
   scrollValue?: Animated.AnimatedInterpolation
 }
+
 const Button = styled.TouchableWithoutFeedback`
   flex: 1;
 `
+
+const Underline = Animated.View
 
 const Tabs = styled.View`
   height: 50px;
@@ -35,18 +47,6 @@ interface TabProps {
   tabLabel: string
 }
 
-interface TabLabelProps {
-  active: boolean
-}
-
-const TabLabel: any = styled.Text`
-  font-family: ${fonts["avant-garde-regular"]};
-  font-size: 13px;
-  letter-spacing: 1.5;
-  text-align: center;
-  color: ${(props: TabLabelProps) => (props.active ? "black" : colors["gray-medium"])};
-`
-
 export const Tab: React.SFC<TabProps> = ({ children }) => (
   <View style={{ flex: 1, overflow: "hidden" }}>{children}</View>
 )
@@ -62,7 +62,15 @@ export default class TabBar extends React.Component<TabBarProps, null> {
         onPress={() => onPressHandler(page)}
       >
         <TabButton>
-          <TabLabel active={isTabActive}>{name.toUpperCase()}</TabLabel>
+          <Sans
+            numberOfLines={1}
+            ellipsizeMode="tail"
+            weight="medium"
+            size="3"
+            color={isTabActive ? "black" : colors["gray-medium"]}
+          >
+            {name}
+          </Sans>
         </TabButton>
       </Button>
     )
@@ -83,7 +91,7 @@ export default class TabBar extends React.Component<TabBarProps, null> {
           const isTabActive = this.props.activeTab === page
           return this.renderTab(name, page, isTabActive, this.props.goToPage)
         })}
-        <Animated.View
+        <Underline
           style={[
             {
               position: "absolute",

--- a/src/lib/Components/__stories__/TabBar.story.tsx
+++ b/src/lib/Components/__stories__/TabBar.story.tsx
@@ -1,0 +1,53 @@
+import { storiesOf } from "@storybook/react-native"
+import React from "react"
+import { ScrollView, View } from "react-native"
+import ScrollableTabView from "react-native-scrollable-tab-view"
+import TabBar, { Tab } from "../TabBar"
+
+storiesOf("App Style/Tab Bar")
+  .addDecorator(story => <View style={{ marginTop: 60, marginLeft: 20, marginRight: 20 }}>{story()}</View>)
+  .add("Fixed sized tabs and Centered", () => {
+    return (
+      <ScrollView>
+        <View style={{ height: 200 }}>
+          <ScrollableTabView renderTabBar={props => <TabBar tabAlignment="left" {...props} />}>
+            <Tab tabLabel=" Artists">
+              <View style={{ backgroundColor: "red", height: 200 }} />
+            </Tab>
+            <Tab tabLabel=" For you">
+              <View style={{ backgroundColor: "green", height: 200 }} />
+            </Tab>
+            <Tab tabLabel=" Auctions">
+              <View style={{ backgroundColor: "blue", height: 200 }} />
+            </Tab>
+          </ScrollableTabView>
+        </View>
+
+        <View style={{ height: 200 }}>
+          <ScrollableTabView initialPage={2} renderTabBar={props => <TabBar {...props} />}>
+            <Tab tabLabel="One">
+              <View style={{ backgroundColor: "red", height: 200 }} />
+            </Tab>
+            <Tab tabLabel="Two">
+              <View style={{ backgroundColor: "green", height: 200 }} />
+            </Tab>
+            <Tab tabLabel="Three">
+              <View style={{ backgroundColor: "blue", height: 200 }} />
+            </Tab>
+            <Tab tabLabel="Four">
+              <View style={{ backgroundColor: "yellow", height: 200 }} />
+            </Tab>
+            <Tab tabLabel="Five">
+              <View style={{ backgroundColor: "orange", height: 200 }} />
+            </Tab>
+            <Tab tabLabel="Six">
+              <View style={{ backgroundColor: "purple", height: 200 }} />
+            </Tab>
+            <Tab tabLabel="Seven">
+              <View style={{ backgroundColor: "silver", height: 200 }} />
+            </Tab>
+          </ScrollableTabView>
+        </View>
+      </ScrollView>
+    )
+  })

--- a/src/lib/Scenes/City/City.tsx
+++ b/src/lib/Scenes/City/City.tsx
@@ -6,7 +6,7 @@ import styled from "styled-components/native"
 import { BucketKey, BucketResults } from "../Map/Bucket"
 import { FiltersBar } from "../Map/Components/FiltersBar"
 import { EventEmitter } from "../Map/EventEmitter"
-import { Tab } from "../Map/types"
+import { MapTab as Tab } from "../Map/types"
 import { AllEvents } from "./Components/AllEvents"
 import { CityTab } from "./Components/CityTab"
 

--- a/src/lib/Scenes/Home/Components/__tests__/__snapshots__/TabBar-tests.tsx.snap
+++ b/src/lib/Scenes/Home/Components/__tests__/__snapshots__/TabBar-tests.tsx.snap
@@ -41,23 +41,27 @@ exports[`renders correctly 1`] = `
   >
     <Text
       accessible={true}
-      active={false}
       allowFontScaling={true}
+      className="sc-bdVaJa bDWFJH"
+      color="#cccccc"
       ellipsizeMode="tail"
+      fontFamily="Unica77LL-Medium"
+      fontSize="14px"
+      lineHeight="24px"
+      numberOfLines={1}
       style={
         Array [
           Object {
             "color": "#cccccc",
-            "fontFamily": "AvantGardeGothicITC",
-            "fontSize": 13,
-            "letterSpacing": 1.5,
-            "textAlign": "center",
+            "fontFamily": "Unica77LL-Medium",
+            "fontSize": 14,
+            "lineHeight": 24,
           },
           undefined,
         ]
       }
     >
-      PAGE 1
+      Page 1
     </Text>
   </View>
   <View
@@ -86,23 +90,27 @@ exports[`renders correctly 1`] = `
   >
     <Text
       accessible={true}
-      active={false}
       allowFontScaling={true}
+      className="sc-bdVaJa bDWFJH"
+      color="#cccccc"
       ellipsizeMode="tail"
+      fontFamily="Unica77LL-Medium"
+      fontSize="14px"
+      lineHeight="24px"
+      numberOfLines={1}
       style={
         Array [
           Object {
             "color": "#cccccc",
-            "fontFamily": "AvantGardeGothicITC",
-            "fontSize": 13,
-            "letterSpacing": 1.5,
-            "textAlign": "center",
+            "fontFamily": "Unica77LL-Medium",
+            "fontSize": 14,
+            "lineHeight": 24,
           },
           undefined,
         ]
       }
     >
-      PAGE 2
+      Page 2
     </Text>
   </View>
   <View
@@ -131,23 +139,27 @@ exports[`renders correctly 1`] = `
   >
     <Text
       accessible={true}
-      active={false}
       allowFontScaling={true}
+      className="sc-bdVaJa bDWFJH"
+      color="#cccccc"
       ellipsizeMode="tail"
+      fontFamily="Unica77LL-Medium"
+      fontSize="14px"
+      lineHeight="24px"
+      numberOfLines={1}
       style={
         Array [
           Object {
             "color": "#cccccc",
-            "fontFamily": "AvantGardeGothicITC",
-            "fontSize": 13,
-            "letterSpacing": 1.5,
-            "textAlign": "center",
+            "fontFamily": "Unica77LL-Medium",
+            "fontSize": 14,
+            "lineHeight": 24,
           },
           undefined,
         ]
       }
     >
-      PAGE 3
+      Page 3
     </Text>
   </View>
   <View

--- a/src/lib/Scenes/Home/index.tsx
+++ b/src/lib/Scenes/Home/index.tsx
@@ -127,7 +127,7 @@ export default class Home extends React.Component<Props, State> {
               selectedArtist={this.props.selectedArtist}
             />
           </Tab>
-          <Tab tabLabel=" For You">
+          <Tab tabLabel=" For you">
             <ForYouRenderer render={renderWithLoadProgress(ForYou)} />
           </Tab>
           <Tab tabLabel=" Auctions">

--- a/src/lib/Scenes/Map/Bucket.ts
+++ b/src/lib/Scenes/Map/Bucket.ts
@@ -1,7 +1,7 @@
 import { GlobalMap_viewer } from "__generated__/GlobalMap_viewer.graphql"
 import { filter } from "lodash"
 import moment from "moment"
-import { Tab } from "./types"
+import { MapTab } from "./types"
 
 export type BucketKey = "saved" | "fairs" | "galleries" | "museums" | "closing" | "opening"
 export type BucketResults = { [key in BucketKey]: any[] }
@@ -9,7 +9,7 @@ export type BucketResults = { [key in BucketKey]: any[] }
 export const bucketCityResults = (viewer: GlobalMap_viewer): BucketResults => {
   const saved = filter(viewer.city.shows.edges, e => e.node.is_followed === true)
   const oneWeekFromNow = moment(new Date()).add(1, "week")
-  const fairs = (viewer.city.fairs.edges as unknown) as Tab[]
+  const fairs = (viewer.city.fairs.edges as unknown) as MapTab[]
   const galleries = filter(viewer.city.shows.edges, e => e.node.partner.type === "Gallery")
   const museums = filter(viewer.city.shows.edges, e => e.node.partner.type === "Institution")
   const opening = filter(viewer.city.shows.edges, e => {

--- a/src/lib/Scenes/Map/Components/FiltersBar.tsx
+++ b/src/lib/Scenes/Map/Components/FiltersBar.tsx
@@ -2,12 +2,12 @@ import { color, Sans } from "@artsy/palette"
 import React from "react"
 import { Animated, Dimensions, LayoutRectangle, ScrollView, View } from "react-native"
 import styled from "styled-components/native"
-import { Tab } from "../types"
+import { MapTab } from "../types"
 
 export interface FiltersBarProps {
   goToPage?: (number) => void
   activeTab?: number
-  tabs?: Tab[]
+  tabs?: MapTab[]
   containerWidth?: number
   scrollValue?: Animated.AnimatedInterpolation
 }
@@ -50,7 +50,7 @@ export class FiltersBar extends React.Component<FiltersBarProps, FiltersBarState
     activeTab: this.props.activeTab || 0,
   }
 
-  renderTab(tab: Tab, page: number, isTabActive: boolean, onPressHandler: (page: number) => void) {
+  renderTab(tab: MapTab, page: number, isTabActive: boolean, onPressHandler: (page: number) => void) {
     return (
       <Button
         key={tab.id}

--- a/src/lib/Scenes/Map/GlobalMap.tsx
+++ b/src/lib/Scenes/Map/GlobalMap.tsx
@@ -14,7 +14,7 @@ import { CitySwitcherButton } from "./Components/CitySwitcherButton"
 import { ShowCard } from "./Components/ShowCard"
 import { UserPositionButton } from "./Components/UserPositionButton"
 import { EventEmitter } from "./EventEmitter"
-import { Show, Tab } from "./types"
+import { MapTab, Show } from "./types"
 
 const Emission = NativeModules.Emission || {}
 
@@ -72,7 +72,7 @@ export class GlobalMap extends React.Component<Props, State> {
   clusterEngine: Supercluster
   moveButtons: Animated.Value
 
-  filters: Tab[] = [
+  filters: MapTab[] = [
     { id: "all", text: "All" },
     { id: "saved", text: "Saved" },
     { id: "fairs", text: "Fairs" },

--- a/src/lib/Scenes/Map/__stories__/Map.story.tsx
+++ b/src/lib/Scenes/Map/__stories__/Map.story.tsx
@@ -1,0 +1,10 @@
+import { storiesOf } from "@storybook/react-native"
+import React from "react"
+import { MapRenderer } from ".."
+
+storiesOf("Map/Relay")
+  .add("New York", () => <MapRenderer hideMapButtons coords={{ lat: 40.71, lng: -74.01 }} />)
+  .add("Hong Kong", () => <MapRenderer hideMapButtons coords={{ lat: 22.4, lng: 114.11 }} />)
+  .add("London", () => <MapRenderer hideMapButtons coords={{ lat: 51.51, lng: -0.13 }} />)
+  .add("Los Angeles", () => <MapRenderer hideMapButtons coords={{ lat: 34.05, lng: -118.24 }} />)
+  .add("Berlin", () => <MapRenderer hideMapButtons coords={{ lat: 52.52, lng: 13.4 }} />)

--- a/src/lib/Scenes/Map/types.ts
+++ b/src/lib/Scenes/Map/types.ts
@@ -10,7 +10,7 @@ export interface City {
   epicenter: Coordinates
 }
 
-export interface Tab {
+export interface MapTab {
   id: string
   text: string
 }

--- a/storybook/storyLoader.js
+++ b/storybook/storyLoader.js
@@ -34,6 +34,7 @@ function loadStories() {
   require('../src/lib/Components/__stories__/DottedLine.story.tsx');
   require('../src/lib/Components/__stories__/Markdown.story.tsx');
   require('../src/lib/Components/__stories__/Modal.story.tsx');
+  require('../src/lib/Components/__stories__/TabBar.story.tsx');
   require('../src/lib/Components/__stories__/Video.story.tsx');
   require('../src/lib/Containers/__stories__/Artist.story.tsx');
   require('../src/lib/Containers/__stories__/Gene.story.tsx');
@@ -43,6 +44,7 @@ function loadStories() {
   require('../src/lib/Scenes/Favorites/__stories__/Favorites.story.tsx');
   require('../src/lib/Scenes/Home/Components/Sales/Components/__stories__/LotsByFollowedArtists.story.tsx');
   require('../src/lib/Scenes/Home/__stories__/Home.story.tsx');
+  require('../src/lib/Scenes/Map/__stories__/Map.story.tsx');
   require('../src/lib/Scenes/Settings/__stories__/Settings.story.tsx');
   require('../src/lib/Scenes/Show/__stories__/Show.story.tsx');
   
@@ -78,6 +80,7 @@ const stories = [
   '../src/lib/Components/__stories__/DottedLine.story.tsx',
   '../src/lib/Components/__stories__/Markdown.story.tsx',
   '../src/lib/Components/__stories__/Modal.story.tsx',
+  '../src/lib/Components/__stories__/TabBar.story.tsx',
   '../src/lib/Components/__stories__/Video.story.tsx',
   '../src/lib/Containers/__stories__/Artist.story.tsx',
   '../src/lib/Containers/__stories__/Gene.story.tsx',
@@ -87,6 +90,7 @@ const stories = [
   '../src/lib/Scenes/Favorites/__stories__/Favorites.story.tsx',
   '../src/lib/Scenes/Home/Components/Sales/Components/__stories__/LotsByFollowedArtists.story.tsx',
   '../src/lib/Scenes/Home/__stories__/Home.story.tsx',
+  '../src/lib/Scenes/Map/__stories__/Map.story.tsx',
   '../src/lib/Scenes/Settings/__stories__/Settings.story.tsx',
   '../src/lib/Scenes/Show/__stories__/Show.story.tsx',
   


### PR DESCRIPTION
This brings the main Home tab inline with the design in palette making the two consistent

<img width="657" alt="screen shot 2019-03-04 at 3 10 03 pm" src="https://user-images.githubusercontent.com/49038/53759995-a02c1600-3e8f-11e9-9be0-1fc2d916cafd.png">

I looked at turning these both into a single component, but the version in Home and the component in the City are pretty far away in implementation, so I'm bailing on that for now. 

#skip_new_tests