### PR TITLE
Fix a few warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Master
 
+- Fixes warning about missing viewer prop - ash
+
 ### 1.8.14
 
 - Adds order artists in a show based on user's favorite - ashkan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Master
 
 - Fixes warning about missing viewer prop - ash
+- Fixes warning about duplicate keys in list - ash
 
 ### 1.8.14
 

--- a/src/lib/Scenes/City/Components/EventSection/index.tsx
+++ b/src/lib/Scenes/City/Components/EventSection/index.tsx
@@ -19,7 +19,7 @@ export class EventSection extends React.Component<Props> {
     return data.map((event, i) => {
       if (i < 2) {
         return (
-          <Box key={event.id}>
+          <Box key={event.node.id}>
             <Event event={event} />
           </Box>
         )

--- a/src/lib/Scenes/Map/MapRenderer.tsx
+++ b/src/lib/Scenes/Map/MapRenderer.tsx
@@ -34,7 +34,9 @@ export const MapRenderer: React.SFC<{
       render={({ props: mapProps }) => {
         // TODO: Handle error, see LD-318.
         if (mapProps || props.initialCoordinates) {
-          return <GlobalMap {...mapProps} {...props} />
+          // viewer={null} is to handle the case where we want to render the map with initialCoordinates but the Relay
+          // response hasn't arrived yet. Relay requires us to pass an explicit null if the missing data is intentional.
+          return <GlobalMap viewer={null} {...mapProps} {...props} />
         }
         return <View style={{ backgroundColor: colors["gray-light"] }} />
       }}


### PR DESCRIPTION
This PR fixes two warnings I was seeing in dev builds: missing `viewer` prop for `GlobalMap` and duplicate keys in the `EventSection` component. 

#skip_new_tests