### PR TITLE
Sync city coordinates with Metaphysics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Master
 
+- Update city coordinates (to fix Los Angeles bug) - anandaroop
 - Fixes warning about missing viewer prop - ash
 - Fixes warning about duplicate keys in list - ash
 - Adds zero state to CityTab - kieran

--- a/src/lib/Scenes/City/cities.ts
+++ b/src/lib/Scenes/City/cities.ts
@@ -3,24 +3,24 @@ export const cityList = [
     name: "New York",
     slug: "new-york-ny-usa",
     epicenter: {
-      lat: 40.7128,
-      lng: -74.006,
+      lat: 40.71,
+      lng: -74.01,
     },
   },
   {
     name: "Los Angeles",
     slug: "los-angeles-ca-usa",
     epicenter: {
-      lat: 34.0522,
-      lng: 118.2437,
+      lat: 34.05,
+      lng: -118.24,
     },
   },
   {
     name: "London",
     slug: "london-united-kingdom",
     epicenter: {
-      lat: 51.5074,
-      lng: 0.1278,
+      lat: 51.51,
+      lng: -0.13,
     },
   },
   {
@@ -28,23 +28,23 @@ export const cityList = [
     slug: "berlin-germany",
     epicenter: {
       lat: 52.52,
-      lng: 13.405,
+      lng: 13.4,
     },
   },
   {
     name: "Paris",
     slug: "paris-france",
     epicenter: {
-      lat: 48.8566,
-      lng: 2.3522,
+      lat: 48.86,
+      lng: 2.35,
     },
   },
   {
     name: "Hong Kong",
     slug: "hong-kong-hong-kong",
     epicenter: {
-      lat: 22.3964,
-      lng: 114.1095,
+      lat: 22.3,
+      lng: 114.2,
     },
   },
 ]


### PR DESCRIPTION
This is a one-off change to bring Emission's city data inline with [Metaphysics' version](https://github.com/artsy/metaphysics/blob/master/src/schema/city/city_data.json) of the same.

A further enhancement would be to consolidate this source of truth via the build process, an item which is ticketed elsewhere.

#skip_new_tests