### PR TITLE
Narrow iphone fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Adds Save button functionality to button in All tab - kieran
 - Fixes top buttons re-appearing behind city picker - ash
 - Fixes map not re-centering on new city when changed - ash
+- Handles text spillover bug on narrow iphone screens in Saved Shows view - ashley
 
 ### 1.8.14
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -254,7 +254,7 @@ SPEC CHECKSUMS:
   Artsy-UIButtons: 3c396f0fad352a7b0332100e0ffcb0ca577e0082
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: ebb6747c5b66026ad4f97b789c3ceac6f18e57a6
-  Emission: e929d97dc2ec6feb37a4c7c2c133dc160e17d4ea
+  Emission: fb538b061b497b38af3fcd334377457b2da5188e
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   Extraction: 642a73b8ccc7806e9a7daf95ebb4c14c374829f1
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a

--- a/src/lib/Components/Lists/ShowItemRow.tsx
+++ b/src/lib/Components/Lists/ShowItemRow.tsx
@@ -9,7 +9,7 @@ import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { hrefForPartialShow } from "lib/utils/router"
 import { Schema, Track, track as _track } from "lib/utils/track"
 import React from "react"
-import { TouchableWithoutFeedback } from "react-native"
+import { Dimensions, TouchableWithoutFeedback } from "react-native"
 import { commitMutation, createFragmentContainer, graphql, RelayProp } from "react-relay"
 import styled from "styled-components/native"
 
@@ -104,6 +104,8 @@ export class ShowItemRow extends React.Component<Props, State> {
   render() {
     const { show } = this.props
     const imageURL = show.cover_image && show.cover_image.url
+    const { width } = Dimensions.get("window")
+    const isScreenNarrow = width <= 320
 
     return (
       <TouchableWithoutFeedback onPress={this.handleTap.bind(this)}>
@@ -119,7 +121,7 @@ export class ShowItemRow extends React.Component<Props, State> {
               ) : (
                 <OpaqueImageView width={58} height={58} imageURL={imageURL} />
               )}
-              <Flex flexDirection="column" flexGrow="1" width="197">
+              <Flex flexDirection="column" flexGrow="1" width={isScreenNarrow ? width / 7 : 197}>
                 {show.partner &&
                   show.partner.name && (
                     <Sans size="3t" color="black" weight="medium" numberOfLines={1} ml={15}>
@@ -141,7 +143,7 @@ export class ShowItemRow extends React.Component<Props, State> {
                   )}
               </Flex>
             </Flex>
-            <Box width="50">
+            <Box width={isScreenNarrow ? width / 8 : 50} ml={isScreenNarrow ? 10 : 0}>
               <Flex alignItems="flex-start" justifyContent="flex-end" flexDirection="row">
                 <InvertedButton
                   inProgress={this.state.isFollowedSaving}

--- a/src/lib/Components/Lists/ShowItemRow.tsx
+++ b/src/lib/Components/Lists/ShowItemRow.tsx
@@ -9,7 +9,7 @@ import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { hrefForPartialShow } from "lib/utils/router"
 import { Schema, Track, track as _track } from "lib/utils/track"
 import React from "react"
-import { Dimensions, TouchableWithoutFeedback } from "react-native"
+import { TouchableWithoutFeedback } from "react-native"
 import { commitMutation, createFragmentContainer, graphql, RelayProp } from "react-relay"
 import styled from "styled-components/native"
 
@@ -104,56 +104,50 @@ export class ShowItemRow extends React.Component<Props, State> {
   render() {
     const { show } = this.props
     const imageURL = show.cover_image && show.cover_image.url
-    const { width } = Dimensions.get("window")
-    const isScreenNarrow = width <= 320
 
     return (
       <TouchableWithoutFeedback onPress={this.handleTap.bind(this)}>
         <Box py={2}>
-          <Flex flexDirection="row" flexGrow="1">
-            <Flex flexGrow="1" flexDirection="row" alignItems="center">
-              {!imageURL ? (
-                <DefaultImageContainer>
-                  <Box p={2}>
-                    <Pin color={color("white100")} pinHeight={30} pinWidth={30} />
-                  </Box>
-                </DefaultImageContainer>
-              ) : (
-                <OpaqueImageView width={58} height={58} imageURL={imageURL} />
-              )}
-              <Flex flexDirection="column" flexGrow="1" width={isScreenNarrow ? width / 7 : 197}>
-                {show.partner &&
-                  show.partner.name && (
-                    <Sans size="3t" color="black" weight="medium" numberOfLines={1} ml={15}>
-                      {show.partner.name}
-                    </Sans>
-                  )}
-                {show.name && (
-                  <TightendSerif size="3t" color={color("black60")} ml={15} numberOfLines={1}>
-                    {show.name}
-                  </TightendSerif>
+          <Flex flexDirection="row">
+            {!imageURL ? (
+              <DefaultImageContainer>
+                <Box p={2}>
+                  <Pin color={color("white100")} pinHeight={30} pinWidth={30} />
+                </Box>
+              </DefaultImageContainer>
+            ) : (
+              <OpaqueImageView width={58} height={58} imageURL={imageURL} />
+            )}
+            <Flex flexDirection="column" flexGrow={1} width={180}>
+              {show.partner &&
+                show.partner.name && (
+                  <Sans size="3t" color="black" weight="medium" numberOfLines={1} ml={15}>
+                    {show.partner.name}
+                  </Sans>
                 )}
-                {show.status &&
-                  show.exhibition_period && (
-                    <Sans size="3t" color={color("black60")} ml={15}>
-                      {show.status.includes("closed")
-                        ? show.status.charAt(0).toUpperCase() + show.status.slice(1)
-                        : show.exhibition_period}
-                    </Sans>
-                  )}
-              </Flex>
+              {show.name && (
+                <TightendSerif size="3t" color={color("black60")} ml={15} numberOfLines={1}>
+                  {show.name}
+                </TightendSerif>
+              )}
+              {show.status &&
+                show.exhibition_period && (
+                  <Sans size="3t" color={color("black60")} ml={15}>
+                    {show.status.includes("closed")
+                      ? show.status.charAt(0).toUpperCase() + show.status.slice(1)
+                      : show.exhibition_period}
+                  </Sans>
+                )}
             </Flex>
-            <Box width={isScreenNarrow ? width / 8 : 50} ml={isScreenNarrow ? 10 : 0}>
-              <Flex alignItems="flex-start" justifyContent="flex-end" flexDirection="row">
-                <InvertedButton
-                  inProgress={this.state.isFollowedSaving}
-                  text={show.is_followed ? "Saved" : "Save"}
-                  selected={show.is_followed}
-                  onPress={() => this.handleSave()}
-                  noBackground={true}
-                />
-              </Flex>
-            </Box>
+            <Flex flexDirection="row">
+              <InvertedButton
+                inProgress={this.state.isFollowedSaving}
+                text={show.is_followed ? "Saved" : "Save"}
+                selected={show.is_followed}
+                onPress={() => this.handleSave()}
+                noBackground={true}
+              />
+            </Flex>
           </Flex>
         </Box>
       </TouchableWithoutFeedback>


### PR DESCRIPTION
This PR handles narrow iphone screens so the Saved Shows text does not get truncated off the screen on smaller iphone devices. PR involved a refactor to the Flexbox code that contained the Saved Shows contents. 
<img width="403" alt="screen shot 2019-03-07 at 5 09 33 pm" src="https://user-images.githubusercontent.com/10385964/54041354-82172c00-4195-11e9-98b7-dbae948bd603.png">
<img width="434" alt="screen shot 2019-03-07 at 5 10 48 pm" src="https://user-images.githubusercontent.com/10385964/54041355-82172c00-4195-11e9-9ad6-9df866f3d292.png">






#skip_new_tests 