### PR TITLE
Adds more metadata to the Podspec

### DIFF
--- a/Emission.podspec
+++ b/Emission.podspec
@@ -1,4 +1,5 @@
 require 'json'
+require 'date'
 
 root = ENV["EMISSION_ROOT"] || __dir__
 pkg_version = lambda do |dir_from_root = '', version = 'version'|
@@ -16,9 +17,7 @@ podspec = Pod::Spec.new do |s|
   s.summary        = 'React Native Components used by Eigen.'
   s.homepage       = 'https://github.com/artsy/emission'
   s.license        = 'MIT'
-  s.author         = { 'Eloy Durán' => 'eloy@artsy.net',
-                       'Maxim Cramer' => 'maxim@artsy.net',
-                       'Sarah Scott' => 'sarah.scott@artsy.net' }
+  s.author         = { 'Artsy Mobile' => 'mobile@artsy.net' }
   s.source         = { :git => 'https://github.com/artsy/emission.git', :tag => "v#{s.version}" }
   s.platform       = :ios, '8.0'
   s.source_files   = 'Pod/Classes/**/*.{h,m}'
@@ -30,6 +29,7 @@ podspec = Pod::Spec.new do |s|
   s.dependency 'Artsy+UIFonts', '>= 3.0.0'
   s.dependency 'Extraction', '>= 1.2.1'
 
+  # Used in City Guides
   s.dependency 'Pulley'
 
   # To ensure a consistent image cache between app/lib
@@ -72,6 +72,11 @@ podspec = Pod::Spec.new do |s|
   end
 end
 
-# Attach the native version info into the podspec
+# Attach the useful metadata to the podspec, which can be used in admin tools
 podspec.attributes_hash['native_version'] = emission_native_version
+podspec.attributes_hash['release_date'] = DateTime.now.strftime("%h %d, %Y")
+podspec.attributes_hash['sha'] = `git rev-parse HEAD`.strip
+podspec.attributes_hash['react_native_version'] = react_native_version
+podspec.attributes_hash['app_registry'] = File.read("./src/lib/AppRegistry.tsx").scan(/AppRegistry.registerComponent\(\"(.*)\"/).flatten
+
 podspec


### PR DESCRIPTION
This JSON can be picked up in Eigen, and used to provide better visibility into the Emission integration in Eigen.

```
~/d/p/a/i/emission  $ pod ipc spec Emission.podspec
{
  "name": "Emission",
  "version": "1.8.14",
  "summary": "React Native Components used by Eigen.",
  "homepage": "https://github.com/artsy/emission",
  "license": "MIT",
  "authors": {
    "Artsy Mobile": "mobile@artsy.net"
  },
  "source": {
    "git": "https://github.com/artsy/emission.git",
    "tag": "v1.8.14"
  },
  "platforms": {
    "ios": "8.0"
  },
  "source_files": "Pod/Classes/**/*.{h,m}",
  "preserve_paths": "Pod/Classes/**/*.generated.objc",
  "resources": "Pod/Assets/{Emission.js,assets}",
  "dependencies": {
    "Artsy+UIColors": [

    ],
    "Artsy+UIFonts": [
      ">= 3.0.0"
    ],
    "Extraction": [
      ">= 1.2.1"
    ],
    "Pulley": [

    ],
    "SDWebImage": [
      ">= 3.7.2",
      "< 4"
    ],
    "React/Core": [
      "0.54.4"
    ],
    "React/CxxBridge": [
      "0.54.4"
    ],
    "React/RCTAnimation": [
      "0.54.4"
    ],
    "React/RCTCameraRoll": [
      "0.54.4"
    ],
    "React/RCTImage": [
      "0.54.4"
    ],
    "React/RCTLinkingIOS": [
      "0.54.4"
    ],
    "React/RCTNetwork": [
      "0.54.4"
    ],
    "React/RCTText": [
      "0.54.4"
    ],
    "React/RCTGeolocation": [
      "0.54.4"
    ],
    "React/RCTActionSheet": [
      "0.54.4"
    ],
    "yoga": [
      "0.54.4.React"
    ],
    "DoubleConversion": [
      "1.1.5"
    ],
    "Folly": [
      "2016.09.26.00"
    ],
    "glog": [
      "0.3.4"
    ],
    "tipsi-stripe": [
      "5.2.4"
    ],
    "react-native-mapbox-gl": [
      "6.1.3"
    ],
    "SentryReactNative": [
      "0.30.3"
    ],
    "RNSVG": [
      "9.0.4"
    ]
  },
  "native_version": 23,
  "release_date": "Mar 10, 2019",
  "sha": "5cf2fbf95d81826d5fd746784b9c29af16d7156b",
  "react_native_version": "0.54.4",
  "app_registry": [
    "Consignments",
    "Artist",
    "Home",
    "Gene",
    "WorksForYou",
    "MyProfile",
    "MySellingProfile",
    "MyProfileEdit",
    "Inbox",
    "Conversation",
    "Inquiry",
    "Favorites",
    "BidFlow",
    "Fair",
    "FairMoreInfo",
    "FairBooth",
    "FairArtists",
    "FairArtworks",
    "FairExhibitors",
    "FairBMWArtActivation",
    "Show",
    "ShowArtists",
    "ShowArtworks",
    "ShowMoreInfo",
    "Map",
    "City",
    "CityPicker",
    "CityFairList",
    "CitySectionList"
  ]
}
```