### PR TITLE
Don't allow the map to rotate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Master
 
+- Don't allow the map to rotate - orta
+
 - Only shows open, or upcoming fairs in the fairs tab - orta
 - Support filtering the map based on the selected tab - orta
 - Shows fairs on the map - orta

--- a/Pod/Classes/ViewControllers/ARMapContainerViewController.m
+++ b/Pod/Classes/ViewControllers/ARMapContainerViewController.m
@@ -276,4 +276,14 @@ Since this controller already has to do the above logic, having it handle the Ci
     [manager stopUpdatingLocation];
 }
 
+- (BOOL)shouldAutorotate;
+{
+    return UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad;
+}
+
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations;
+{
+    return self.shouldAutorotate ? UIInterfaceOrientationMaskAll : UIInterfaceOrientationMaskPortrait;
+}
+
 @end


### PR DESCRIPTION
Now it won't accidentally rotate when you show someone else the map

#native_no_changes