### PR TITLE
Move set state to callback

### DIFF
--- a/src/lib/Scenes/City/CityPicker.tsx
+++ b/src/lib/Scenes/City/CityPicker.tsx
@@ -32,11 +32,14 @@ export class CityPicker extends Component<Props, State> {
     }
   }
 
-  selectCity(city: string, index: number) {
-    this.setState({ selectedCity: city })
-    // TODO: setState is asynchronous. Why are we doing this twice?
-    NativeModules.ARNotificationsManager.postNotificationName("ARLocalDiscoveryUserSelectedCity", { cityIndex: index })
+  clearSelectedCityState() {
+    console.log("TCL: CityPicker -> clearSelectedCityState -> clearSelectedCityState")
     this.setState({ selectedCity: null })
+  }
+
+  selectCity(city: string, index: number) {
+    this.setState({ selectedCity: city }, this.clearSelectedCityState)
+    NativeModules.ARNotificationsManager.postNotificationName("ARLocalDiscoveryUserSelectedCity", { cityIndex: index })
   }
 
   handleLogo(screenHeight) {

--- a/src/lib/Scenes/City/CityPicker.tsx
+++ b/src/lib/Scenes/City/CityPicker.tsx
@@ -33,7 +33,6 @@ export class CityPicker extends Component<Props, State> {
   }
 
   clearSelectedCityState() {
-    console.log("TCL: CityPicker -> clearSelectedCityState -> clearSelectedCityState")
     this.setState({ selectedCity: null })
   }
 

--- a/src/lib/Scenes/City/Components/SavedEventSection/index.tsx
+++ b/src/lib/Scenes/City/Components/SavedEventSection/index.tsx
@@ -43,7 +43,7 @@ export class SavedEventSection extends Component<any> {
               No saved events
             </Sans>
             <Sans size="3t" color="black60">
-              Save a show or fair to find it later
+              Save a show to find it later
             </Sans>
           </Flex>
         </Flex>

--- a/src/lib/Scenes/Map/GlobalMap.tsx
+++ b/src/lib/Scenes/Map/GlobalMap.tsx
@@ -361,12 +361,10 @@ export class GlobalMap extends React.Component<Props, State> {
 
   renderSelectedPin() {
     const { activeShows } = this.state
-    console.log("TCL: renderSelectedPin -> activeShows", activeShows)
     const isCluster = activeShows.length > 1
     const isSingleShow = activeShows.length === 1
 
     if (isCluster) {
-      console.log("TCL: renderSelectedPin -> isCluster", isCluster)
       const { nearestFeature } = this.state
       const activeClusterLat = get(nearestFeature, "geometry.coordinates[0]")
       const activeClusterLng = get(nearestFeature, "geometry.coordinates[1]")
@@ -397,7 +395,6 @@ export class GlobalMap extends React.Component<Props, State> {
       )
     }
     if (isSingleShow) {
-      console.log("TCL: renderSelectedPin -> isSingleShow", isSingleShow)
       const lat = get(activeShows, "[0].location.coordinates.lat")
       const lng = get(activeShows, "[0].location.coordinates.lng")
       const showId = get(activeShows, "[0].id")


### PR DESCRIPTION
About this PR:

To handle showing and removing the checkmark icon from a city name on the City, we save a selectedCities field to state.  

This state is updated twice when a user interacts with the modal: once to show the icon on the selected city, and then again after the touch event to clear the icon and remove the modal. 

Since this.setState is an asynchronous function, I am passing the second call to it as a callback to be called after the first call completes. 


#trivial 