### PR TITLE
Revert remove save shows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Adds saved shows page - Kieran
 - Make pre-heated GraphQL cache work for people that upgrade the app - alloy
 - Make content size of event list known upfront to prevent scroller from jumping - alloy
+- Fixes bug where saved button was removed from all Show Item rows + removes Save button only from Show card - ashley
 
 ### 1.8.14 - 1.8.19
 

--- a/src/lib/Components/Lists/ShowItemRow.tsx
+++ b/src/lib/Components/Lists/ShowItemRow.tsx
@@ -1,6 +1,7 @@
 import { Box, color, Flex, Sans, Serif, space } from "@artsy/palette"
 import { ShowItemRow_show } from "__generated__/ShowItemRow_show.graphql"
 import { ShowItemRowMutation } from "__generated__/ShowItemRowMutation.graphql"
+import InvertedButton from "lib/Components/Buttons/InvertedButton"
 import OpaqueImageView from "lib/Components/OpaqueImageView"
 import colors from "lib/data/colors"
 import { Pin } from "lib/Icons/Pin"
@@ -18,6 +19,7 @@ interface Props {
   noPadding?: boolean
   onSaveStarted?: () => void
   onSaveEnded?: () => void
+  shouldHideSaveButton?: boolean
 }
 
 interface State {
@@ -111,7 +113,7 @@ export class ShowItemRow extends React.Component<Props, State> {
   }
 
   render() {
-    const { noPadding, show } = this.props
+    const { noPadding, show, shouldHideSaveButton } = this.props
     const imageURL = show.cover_image && show.cover_image.url
 
     return (
@@ -146,6 +148,17 @@ export class ShowItemRow extends React.Component<Props, State> {
                   </Sans>
                 )}
             </Flex>
+            {!shouldHideSaveButton && (
+              <Flex flexDirection="row">
+                <InvertedButton
+                  inProgress={this.state.isFollowedSaving}
+                  text={show.is_followed ? "Saved" : "Save"}
+                  selected={show.is_followed}
+                  onPress={() => this.handleSave()}
+                  noBackground={true}
+                />
+              </Flex>
+            )}
           </Flex>
         </Box>
       </TouchableWithoutFeedback>

--- a/src/lib/Scenes/Map/Components/ShowCard.tsx
+++ b/src/lib/Scenes/Map/Components/ShowCard.tsx
@@ -80,6 +80,7 @@ export class ShowCard extends Component<ShowCardProps, ShowCardState> {
               onSaveStarted={this.props.onSaveStarted}
               onSaveEnded={this.props.onSaveEnded}
               noPadding
+              shouldHideSaveButton={true}
             />
           ) : (
             <TabFairItemRow item={item} noPadding />


### PR DESCRIPTION
This PR reverts a change where the Saved button was removed from all instances of the Show Item Row component.

Now the button is only removed from this component on the Show Card in the Global Map view.


![Kapture 2019-03-13 at 13 36 56](https://user-images.githubusercontent.com/10385964/54301356-2b469380-4595-11e9-806b-6f6bbc7fe8ac.gif)
