### PR TITLE
Fixes drawer UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Master
 
+- Fixes drawer behaviour - ash
+
 ### 1.8.22
 
 


### PR DESCRIPTION
This fixes the drawer interaction, hopefully once and for all:

![2019-03-13 20-56-03 2019-03-13 20_57_17](https://user-images.githubusercontent.com/498212/54324108-9a8ea880-45d2-11e9-9f44-76f0808664b4.gif)

The was broken by our switch to `ScrollableTabView` and #1476. The solution is complicated. But basically, the new tab view implementation has _a bunch_ of vertical scroll views (the old one replace the contents each time). This means that our `ARLocalDiscoveryCityGotScrollView` notification can't look for a reliable vertical scroll view (since the one it finds might be offscreen later). It also allows vertical bouncing, which is the behaviour we're seeing on the current beta. 

The solution is to find the city content scroll view, then walk up the hierarchy to find its containing `UIScrollView`. This is the horizontally-scrolling (vertically-bouncing) `ScrollableTabView`. We could just disable scrolling, but remember that we need to disable all the vertical scroll views inside it, too, which is a mess. So I just *disable all user interaction* under the tab bar while the drawer isn't open. Tab buttons will still work. This is a UX change I want to flag for you @l2succes. But I think this is the best way. 

Fixes [LD-437](https://artsyproduct.atlassian.net/browse/LD-437). #native_no_changes.