### PR TITLE
Fix fair hours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 -->
 
 ### Master
+- Fix using wrong field for fair hours - ashkan
 
 ### 1.8.22
 

--- a/src/lib/Scenes/Fair/Screens/FairDetail.tsx
+++ b/src/lib/Scenes/Fair/Screens/FairDetail.tsx
@@ -150,14 +150,13 @@ export class FairDetail extends React.Component<Props, State> {
   }
 
   renderItem = ({ item: { data, type, showIndex } }) => {
-    const { openingHours } = data
     switch (type) {
       case "location":
         return <LocationMap partnerType="Fair" {...data} />
       case "hours":
         return (
           <>
-            <HoursCollapsible openingHours={openingHours} onToggle={() => this.handleHoursToggled()} />
+            <HoursCollapsible openingHours={{ text: data }} onToggle={() => this.handleHoursToggled()} />
             <Separator mt={2} />
           </>
         )


### PR DESCRIPTION
Fix using `openingHours` on `Fair`, while `fair` has `Location` which can have `openingHours`, looks like we are using `hours` field of a fair which is a markdown text.

This was caused by #1478 