### PR TITLE
Tappable items in when pulley is semi-closed

### DIFF
--- a/Pod/Classes/ViewControllers/ARMapContainerViewController.m
+++ b/Pod/Classes/ViewControllers/ARMapContainerViewController.m
@@ -53,6 +53,22 @@ FindCityScrollView(UIView *view)
     return nil;
 }
 
+/// Goes through all the children of a view and makes sure they can or can't scroll
+static void
+RecurseThroughScrollViewsSettingScrollEnabled(UIView *view, BOOL scrollEnabled)
+{
+    for (UIView *subview in view.subviews) {
+        if ([subview isKindOfClass:UIScrollView.class]) {
+            UIScrollView *scrollView = (UIScrollView *)subview;
+            scrollView.scrollEnabled = scrollEnabled;
+        }
+    }
+    for (UIView *subview in view.subviews) {
+        RecurseThroughScrollViewsSettingScrollEnabled(subview, scrollEnabled);
+    }
+}
+
+
 /// Finds the closest parent in the view hiearchy that's a scroll view.
 static UIScrollView *
 FindParentScrollView(UIView *view)
@@ -122,7 +138,7 @@ Since this controller already has to do the above logic, having it handle the Ci
             if (!wself.scrollableTabView) {
                 UIScrollView *foundScrollView = FindCityScrollView(wself.cityVC.view);
                 self.scrollableTabView = FindParentScrollView(foundScrollView);
-                self.scrollableTabView.userInteractionEnabled = NO;
+                RecurseThroughScrollViewsSettingScrollEnabled(wself.scrollableTabView.superview, NO);
             }
     }];
 
@@ -321,7 +337,8 @@ Since this controller already has to do the above logic, having it handle the Ci
 
     BOOL isDrawerOpen = [drawer.drawerPosition isEqualToPosition:PulleyPosition.open];
     [self.cityVC setProperty:@(isDrawerOpen) forKey:@"isDrawerOpen"];
-    self.scrollableTabView.userInteractionEnabled = isDrawerOpen;
+        RecurseThroughScrollViewsSettingScrollEnabled(self.scrollableTabView.superview, isDrawerOpen);
+
     if (!isDrawerOpen) {
         UIScrollView *cityScrollView = FindCityScrollView(self.cityVC.view);
         [cityScrollView setContentOffset:CGPointZero animated:YES];

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -196,7 +196,7 @@ if (fs.existsSync("test-results.json")) {
 // Raise when native code changes are made, but the package.json does not
 // have a bump for the native code version
 //
-const hasNativeCodeChanges = modified.find(p => p.includes("Pod/Classes"))
+const hasNativeCodeChanges = modified.find(p => p.includes("Pod/Classes") && p.includes(".h"))
 const hasPackageJSONChanges = modified.find(p => p === "package.json")
 if (hasNativeCodeChanges && !hasPackageJSONChanges && !acceptedNoNativeChanges) {
   fail(


### PR DESCRIPTION
Old behavior: When we had the drawer closed (or half closed) you could see things like shows and fairs in the drawer, but couldn't click on them.

This caught both people I tested the app on, (and myself) which we figured was a bug. So I asked owen and he also figured we should make it interactable but not scrollable. 

New behavior: manually sets all of the scroll enableds down the view tree instead of having a hard stop pretty high up the tree.

![Screen Recording 2019-03-14 13_22_43](https://user-images.githubusercontent.com/49038/54377789-44664780-465c-11e9-8f5a-15a6bfc2048c.gif)

- Also makes the native check for danger only be affected by header changes, this shouldn't get a warning.