### PR TITLE
Fixes zoom outs when switching cities and fix cluster crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 ### Master
 
 - Fix using wrong field for fair hours - ashkan
-
+- Fixes zoom outs when switching cities and fix cluster crash - luc
 - Fixes drawer behaviour - ash
 
 ### 1.8.22

--- a/src/lib/Scenes/Map/Components/ShowCard.tsx
+++ b/src/lib/Scenes/Map/Components/ShowCard.tsx
@@ -58,7 +58,11 @@ export class ShowCard extends Component<ShowCardProps, ShowCardState> {
     const equal = isEqual(previousIds, currentIds)
 
     if (!this.state.isSaving && !equal && this.list) {
-      setTimeout(() => this.list.scrollToOffset({ offset: 0, animated: true }), 500)
+      setTimeout(() => {
+        if (this.list) {
+          this.list.scrollToOffset({ offset: 0, animated: true })
+        }
+      }, 500)
     }
   }
 

--- a/src/lib/Scenes/Map/GlobalMap.tsx
+++ b/src/lib/Scenes/Map/GlobalMap.tsx
@@ -115,7 +115,7 @@ interface State {
 
 export const ArtsyMapStyleURL = "mapbox://styles/artsyit/cjrb59mjb2tsq2tqxl17pfoak"
 
-const DefaultZoomLevel = 13
+const DefaultZoomLevel = 12
 
 const ButtonAnimation = {
   yDelta: -200,
@@ -233,8 +233,6 @@ export class GlobalMap extends React.Component<Props, State> {
 
   handleFilterChange = activeIndex => {
     this.setState({ activeIndex, activePin: null, activeShows: [] }, () => this.emitFilteredBucketResults())
-    // Reset zoom level
-    this.map.zoomTo(DefaultZoomLevel)
   }
 
   componentDidMount() {
@@ -256,7 +254,7 @@ export class GlobalMap extends React.Component<Props, State> {
 
     if (citySlug && citySlug !== nextProps.citySlug) {
       // Reset zoom level after switching cities
-      setTimeout(() => this.map.zoomTo(DefaultZoomLevel), 500)
+      setTimeout(() => this.map.zoomTo(10, 100), 500)
     }
 
     if (nextProps.viewer) {

--- a/src/lib/Scenes/Map/GlobalMap.tsx
+++ b/src/lib/Scenes/Map/GlobalMap.tsx
@@ -256,7 +256,7 @@ export class GlobalMap extends React.Component<Props, State> {
 
     if (citySlug && citySlug !== nextProps.citySlug) {
       // Reset zoom level after switching cities
-      setTimeout(() => this.map.zoomTo(DefaultZoomLevel, 200), 500)
+      setTimeout(() => this.map.zoomTo(DefaultZoomLevel), 500)
     }
 
     if (nextProps.viewer) {


### PR DESCRIPTION
Fixes the following crash: https://sentry.io/organizations/artsynet/issues/933653125/
Related: https://artsyproduct.atlassian.net/browse/LD-407

We were getting inconsistent zoom outs as the user was switching cities because of a race condition.

Two different zoom levels were being applied
1. when a user switches filters
2. when a user switches cities via the picker

Here we remove the filter switch zoom out as it was causing issues as they were being applied almost at the same time when switching cities. Also speeds up the zoom out animation a bit.

A better long term fix will be to set bounds to contain all pins on the map to make sure there's always something visible on the map.

#trivial