### PR TITLE
Fixes missing "view all shows" link in sponsored content sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fixes C compiler error - ash
 - Removes gallery context from fair page - ash
 - Only shows shows with images in all bricks - kieran
+- Fixes missing "view all shows" link in sponsored content sections - ash&ashley
 
 ### 1.8.23
 

--- a/src/lib/Scenes/City/Components/BMWEventSection/index.tsx
+++ b/src/lib/Scenes/City/Components/BMWEventSection/index.tsx
@@ -94,9 +94,7 @@ export class BMWEventSection extends React.Component<Props> {
         {this.renderEvents()}
         {totalCount > 2 && (
           <Box px={2} mb={2}>
-            <Sans weight="medium" size="3">
-              <CaretButton onPress={() => this.viewAllBmwShows()} text={`View all ${totalCount} shows`} />
-            </Sans>
+            <CaretButton onPress={() => this.viewAllBmwShows()} text={`View all ${totalCount} shows`} />
           </Box>
         )}
       </>


### PR DESCRIPTION
We reproduced this in the simulator by setting the `dev` query string param to `false`: 

https://github.com/artsy/emission/blob/d053d5335fe9b335759b6bb9d9f11e605b1b8e74/Example/Emission/AppSetup.m#L76

The `CaretButton` was wrapped  in a `Sans` component, but it actually contains a `Sans` component, so that double-`Sans` was causing no text to display.

Fixes [LD-418](https://artsyproduct.atlassian.net/browse/LD-418).