### PR TITLE
Fix fair [Objct object] for hours issue #trivial

### DIFF
--- a/src/lib/Scenes/Fair/Screens/FairDetail.tsx
+++ b/src/lib/Scenes/Fair/Screens/FairDetail.tsx
@@ -84,13 +84,10 @@ export class FairDetail extends React.Component<Props, State> {
         type: "bmw-art-activation",
       })
     }
-
     if (fair.hours) {
       sections.push({
         type: "hours",
-        data: {
-          hours: fair.hours,
-        },
+        data: fair.hours,
       })
     }
 


### PR DESCRIPTION
# Problem
The data being pushed to section had `{ hours: 'text' }` while component was assuming it's getting only `text` 



![image](https://user-images.githubusercontent.com/1230819/54395735-134f3c80-4687-11e9-9489-473ba5d8cd83.png)
