### PR TITLE
Update pods during release

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -255,7 +255,7 @@ SPEC CHECKSUMS:
   Artsy-UIButtons: 3c396f0fad352a7b0332100e0ffcb0ca577e0082
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: ebb6747c5b66026ad4f97b789c3ceac6f18e57a6
-  Emission: 4e0291bfc565eb528808afc7c1cd7a31cdff3e90
+  Emission: d05cb9dfddd4b5128437efdb3afdecb5b9afc7c6
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   Extraction: 642a73b8ccc7806e9a7daf95ebb4c14c374829f1
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -58,6 +58,7 @@ sh("npm --version")
 
 console.log(chalk.green("=> Creating release bundle."))
 sh("npm run bundle")
+sh("cd Example && bundle pod install && cd ..")
 sh('git add . && git commit -m "[Pod] Update release artefacts."', true)
 
 console.log(chalk.green("=> Creating version bump commit and tag."))


### PR DESCRIPTION
Ensure a `pod install` after a release doesn’t lead to new changes to the lock file.