### PR TITLE
Updates drawer sub-scrollview enabled state when tabs change 📱

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Master
 
 - Deploy script syncs local data with Metaphysics - ash
+- Updates drawer sub-scrollview enabled state when tabs change - ash
 
 ### 1.8.25
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -255,7 +255,7 @@ SPEC CHECKSUMS:
   Artsy-UIButtons: 3c396f0fad352a7b0332100e0ffcb0ca577e0082
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: ebb6747c5b66026ad4f97b789c3ceac6f18e57a6
-  Emission: d05cb9dfddd4b5128437efdb3afdecb5b9afc7c6
+  Emission: dab2244aef749271800bab8f746de03ac58b94cf
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   Extraction: 642a73b8ccc7806e9a7daf95ebb4c14c374829f1
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a

--- a/Pod/Classes/ViewControllers/ARMapContainerViewController.m
+++ b/Pod/Classes/ViewControllers/ARMapContainerViewController.m
@@ -135,11 +135,12 @@ Since this controller already has to do the above logic, having it handle the Ci
         wself.initialDataIsLoaded = YES;
     }];
     [[NSNotificationCenter defaultCenter] addObserverForName:@"ARLocalDiscoveryCityGotScrollView" object:nil queue:nil usingBlock:^(NSNotification * _Nonnull note) {
-            if (!wself.scrollableTabView) {
-                UIScrollView *foundScrollView = FindCityScrollView(wself.cityVC.view);
-                self.scrollableTabView = FindParentScrollView(foundScrollView);
-                RecurseThroughScrollViewsSettingScrollEnabled(wself.scrollableTabView.superview, NO);
-            }
+        if (!wself.scrollableTabView) {
+            UIScrollView *foundScrollView = FindCityScrollView(wself.cityVC.view);
+            self.scrollableTabView = FindParentScrollView(foundScrollView);
+        }
+        BOOL isDrawerOpen = [self.bottomSheetVC.drawerPosition isEqualToPosition:PulleyPosition.open];
+        RecurseThroughScrollViewsSettingScrollEnabled(wself.scrollableTabView.superview, isDrawerOpen);
     }];
 
 

--- a/src/lib/Scenes/City/City.tsx
+++ b/src/lib/Scenes/City/City.tsx
@@ -105,6 +105,7 @@ export class CityView extends Component<Props, State> {
   setSelectedTab(selectedTab) {
     this.setState({ selectedTab: selectedTab.i })
     EventEmitter.dispatch("filters:change", selectedTab.i)
+    NativeModules.ARNotificationsManager.postNotificationName("ARLocalDiscoveryCityGotScrollView", {})
   }
 
   @track((__, _, args) => {


### PR DESCRIPTION
The problem was occurring when we the tabs changed and a new scroll view was added to the view hierarchy. I tested this on device to make sure it worked. 