### PR TITLE
Fewer city render passes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - Deploy script syncs local data with Metaphysics - ash
 - Updates drawer sub-scrollview enabled state when tabs change - ash
+- Get rid of unneeded City render pass and potential further deep renders by unstable inline function props - alloy
 
 ### 1.8.25
 

--- a/src/lib/Scenes/City/City.tsx
+++ b/src/lib/Scenes/City/City.tsx
@@ -29,7 +29,6 @@ interface State {
   relay: RelayProp
   cityName: string
   citySlug: string
-  selectedTab: number
   sponsoredContent: { introText: string; artGuideUrl: string }
   relayErrorState?: RelayErrorState
 }
@@ -47,7 +46,6 @@ export class CityView extends Component<Props, State> {
     filter: cityTabs[0],
     relay: null,
     cityName: "",
-    selectedTab: AllCityMetaTab,
     citySlug: "",
     sponsoredContent: null,
     relayErrorState: null,
@@ -104,7 +102,6 @@ export class CityView extends Component<Props, State> {
   }
 
   setSelectedTab(selectedTab) {
-    this.setState({ selectedTab: selectedTab.i })
     EventEmitter.dispatch("filters:change", selectedTab.i)
     NativeModules.ARNotificationsManager.postNotificationName("ARLocalDiscoveryCityGotScrollView", {})
   }
@@ -164,7 +161,7 @@ export class CityView extends Component<Props, State> {
           ) : (
             <ScrollableTabView
               initialPage={this.props.initialTab || AllCityMetaTab}
-              onChangeTab={selectedTab => this.setSelectedTab(selectedTab)}
+              onChangeTab={this.setSelectedTab}
               prerenderingSiblingsNumber={2}
               renderTabBar={props => (
                 <View>

--- a/src/lib/Scenes/City/City.tsx
+++ b/src/lib/Scenes/City/City.tsx
@@ -144,6 +144,23 @@ export class CityView extends Component<Props, State> {
     }
   }
 
+  renderTabBar(props) {
+    return (
+      <View>
+        <TabBar {...props} spaceEvenly={false} />
+      </View>
+    )
+  }
+
+  // TODO: Is it correct that we have these two similar ones?
+  onScrollableTabViewLayout = layout => {
+    this.scrollViewVerticalStart = layout.nativeEvent.layout.y
+  }
+  onScrollViewLayout = layout => {
+    this.scrollViewVerticalStart = layout.nativeEvent.layout.y
+    NativeModules.ARNotificationsManager.postNotificationName("ARLocalDiscoveryCityGotScrollView", {})
+  }
+
   render() {
     const { buckets, cityName, citySlug, relayErrorState } = this.state
     const { verticalMargin } = this.props
@@ -163,19 +180,12 @@ export class CityView extends Component<Props, State> {
               initialPage={this.props.initialTab || AllCityMetaTab}
               onChangeTab={this.setSelectedTab}
               prerenderingSiblingsNumber={2}
-              renderTabBar={props => (
-                <View>
-                  <TabBar {...props} spaceEvenly={false} />
-                </View>
-              )}
-              onLayout={layout => (this.scrollViewVerticalStart = layout.nativeEvent.layout.y)}
+              renderTabBar={this.renderTabBar}
+              onLayout={this.onScrollableTabViewLayout}
               // These are the ScrollView props for inside the scrollable tab view
               contentProps={{
                 contentInset: { bottom: bottomInset },
-                onLayout: layout => {
-                  this.scrollViewVerticalStart = layout.nativeEvent.layout.y
-                  NativeModules.ARNotificationsManager.postNotificationName("ARLocalDiscoveryCityGotScrollView", {})
-                },
+                onLayout: this.onScrollViewLayout,
               }}
             >
               <ScrollableTab tabLabel="All" key="all">

--- a/src/lib/Scenes/Map/GlobalMap.tsx
+++ b/src/lib/Scenes/Map/GlobalMap.tsx
@@ -501,6 +501,69 @@ export class GlobalMap extends React.Component<Props, State> {
     )
   }
 
+  onRegionIsChanging = async () => {
+    const zoom = Math.floor(await this.map.getZoom())
+
+    if (!this.currentZoom) {
+      this.currentZoom = zoom
+    }
+
+    if (this.currentZoom !== zoom) {
+      this.setState({
+        activePin: null,
+      })
+    }
+  }
+
+  onRegionDidChange = (location: MapGeoFeature) => {
+    this.setState({
+      trackUserLocation: false,
+      currentLocation: GlobalMap.lngLatArrayToLocation(location.geometry && location.geometry.coordinates),
+    })
+  }
+
+  onUserLocationUpdate = (location: OSCoordsUpdate) => {
+    this.setState({
+      userLocation: location.coords && GlobalMap.longCoordsToLocation(location.coords),
+      currentLocation: location.coords && GlobalMap.longCoordsToLocation(location.coords),
+      trackUserLocation: true,
+    })
+  }
+
+  onDidFinishRenderingMapFully = () => {
+    NativeModules.ARNotificationsManager.postNotificationName("ARLocalDiscoveryMapHasRendered", {})
+    this.setState({ mapLoaded: true })
+  }
+
+  onPressMap = () => {
+    if (!this.state.isSavingShow) {
+      this.setState({
+        activeShows: [],
+        activePin: null,
+      })
+    }
+  }
+
+  onPressCitySwitcherButton = () => {
+    this.setState({
+      activeShows: [],
+      activePin: null,
+    })
+  }
+
+  onPressUserPositionButton = () => {
+    const { lat, lng } = this.state.userLocation
+    this.map.moveTo([lng, lat], 500)
+  }
+
+  onPressPinShapeLayer = e => this.handleFeaturePress(e.nativeEvent)
+
+  storeMapRef = (c: any) => {
+    if (c) {
+      this.map = c.root
+    }
+  }
+
   render() {
     const city = get(this.props, "viewer.city")
     const { relayErrorState } = this.props
@@ -519,47 +582,6 @@ export class GlobalMap extends React.Component<Props, State> {
       compassEnabled: false,
     }
 
-    const mapInteractions = {
-      onRegionIsChanging: async () => {
-        const zoom = Math.floor(await this.map.getZoom())
-
-        if (!this.currentZoom) {
-          this.currentZoom = zoom
-        }
-
-        if (this.currentZoom !== zoom) {
-          this.setState({
-            activePin: null,
-          })
-        }
-      },
-      onRegionDidChange: (location: MapGeoFeature) => {
-        this.setState({
-          trackUserLocation: false,
-          currentLocation: GlobalMap.lngLatArrayToLocation(location.geometry && location.geometry.coordinates),
-        })
-      },
-      onUserLocationUpdate: (location: OSCoordsUpdate) => {
-        this.setState({
-          userLocation: location.coords && GlobalMap.longCoordsToLocation(location.coords),
-          currentLocation: location.coords && GlobalMap.longCoordsToLocation(location.coords),
-          trackUserLocation: true,
-        })
-      },
-      onDidFinishRenderingMapFully: () => {
-        NativeModules.ARNotificationsManager.postNotificationName("ARLocalDiscoveryMapHasRendered", {})
-        this.setState({ mapLoaded: true })
-      },
-      onPress: () => {
-        if (!this.state.isSavingShow) {
-          this.setState({
-            activeShows: [],
-            activePin: null,
-          })
-        }
-      },
-    }
-
     return (
       <Flex mb={0.5} flexDirection="column" style={{ backgroundColor: colors["gray-light"] }}>
         <LoadingScreen
@@ -574,21 +596,13 @@ export class GlobalMap extends React.Component<Props, State> {
                 sponsoredContentUrl={this.props.viewer && this.props.viewer.city.sponsoredContent.artGuideUrl}
                 city={city}
                 isLoading={!city && !(relayErrorState && !relayErrorState.isRetrying)}
-                onPress={() => {
-                  this.setState({
-                    activeShows: [],
-                    activePin: null,
-                  })
-                }}
+                onPress={this.onPressCitySwitcherButton}
               />
               {this.state.userLocation && (
                 <Box style={{ marginLeft: "auto" }}>
                   <UserPositionButton
                     highlight={this.state.userLocation === this.state.currentLocation}
-                    onPress={() => {
-                      const { lat, lng } = this.state.userLocation
-                      this.map.moveTo([lng, lat], 500)
-                    }}
+                    onPress={this.onPressUserPositionButton}
                   />
                 </Box>
               )}
@@ -608,20 +622,17 @@ export class GlobalMap extends React.Component<Props, State> {
             <AnimatedView style={{ flex: 1, opacity }}>
               <Map
                 {...mapProps}
-                {...mapInteractions}
-                ref={(c: any) => {
-                  if (c) {
-                    this.map = c.root
-                  }
-                }}
+                onRegionIsChanging={this.onRegionIsChanging}
+                onRegionDidChange={this.onRegionDidChange}
+                onUserLocationUpdate={this.onUserLocationUpdate}
+                onDidFinishRenderingMapFully={this.onDidFinishRenderingMapFully}
+                onPress={this.onPressMap}
+                ref={this.storeMapRef}
               >
                 {city && (
                   <>
                     {this.featureCollection && (
-                      <PinsShapeLayer
-                        featureCollection={this.featureCollection}
-                        onPress={e => this.handleFeaturePress(e.nativeEvent)}
-                      />
+                      <PinsShapeLayer featureCollection={this.featureCollection} onPress={this.onPressPinShapeLayer} />
                     )}
                     <ShowCardContainer>{this.renderShowCard()}</ShowCardContainer>
                     {mapLoaded && activeShows && activePin && this.renderSelectedPin()}


### PR DESCRIPTION
Will comment inline about reduced city render pass. Otherwise this PR replaces inline function props to be stable, just on the odd chance that we're re-rendering trees more than necessary as these functions will never be the same across render passes.