### PR TITLE
Sets up the creds for webcredential sharing

### DIFF
--- a/Example/Emission.xcodeproj/project.pbxproj
+++ b/Example/Emission.xcodeproj/project.pbxproj
@@ -524,6 +524,9 @@
 							com.apple.Keychain = {
 								enabled = 1;
 							};
+							com.apple.SafariKeychain = {
+								enabled = 1;
+							};
 						};
 					};
 					510DCB251CCA69EC0075E8CB = {

--- a/Example/Emission/Emission.entitlements
+++ b/Example/Emission/Emission.entitlements
@@ -2,6 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>webcredentials:artsy.net</string>
+		<string>webcredentials:www.artsy.net</string>
+		<string>webcredentials:staging.artsy.net</string>
+		<string>webcredentials:m.artsy.net</string>
+	</array>
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(AppIdentifierPrefix)net.artsy.Emission</string>


### PR DESCRIPTION
Sibling to https://github.com/artsy/artsy-eigen-web-association/pull/25

Doesn't actually do the work though, just makes it feasible once ^ is deployed.