### PR TITLE
Copy update in BMW section title

### DIFF
--- a/src/lib/Scenes/City/Components/AllEvents.tsx
+++ b/src/lib/Scenes/City/Components/AllEvents.tsx
@@ -174,7 +174,7 @@ export class AllEvents extends React.Component<Props, State> {
       case "bmw":
         return (
           <BMWEventSection
-            title="BMW Art Guide"
+            title="BMW Art Guide by Independent Collectors"
             sponsoredContent={sponsoredContent}
             citySlug={citySlug}
             relay={this.props.relay}

--- a/src/lib/Scenes/City/Components/BMWEventSection/index.tsx
+++ b/src/lib/Scenes/City/Components/BMWEventSection/index.tsx
@@ -67,11 +67,13 @@ export class BMWEventSection extends React.Component<Props> {
         artGuideUrl,
         shows: { totalCount },
       },
+      title,
     } = this.props
+
     return (
       <>
         <Box my={2} px={2}>
-          <Serif size="8">{this.props.title}</Serif>
+          <Serif size="8">{title}</Serif>
         </Box>
         <Box mb={2} px={2}>
           <Sans weight="medium" size="3">


### PR DESCRIPTION
This PR changes the title of the BMW Section on the City show card.

[Links to LD-494:](https://artsyproduct.atlassian.net/browse/LD-494)


<img width="349" alt="Screen Shot 2019-03-18 at 2 42 07 PM" src="https://user-images.githubusercontent.com/10385964/54555459-2dda2c00-498d-11e9-8734-2c831ec690d5.png">


#trivial 