### PR TITLE
Fixes LD saving events inconsistencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Adds a hitslop to the save button for shows - orta
 - Updates copy in Global Saves and Follows Shows tab - ashley
 - Adds message if fair is not active and hides fair details - kieran
+- Fixes LD saving events inconsistencies - ash
 
 ### 1.8.26
 

--- a/src/lib/relay/QueryRenderers.tsx
+++ b/src/lib/relay/QueryRenderers.tsx
@@ -53,8 +53,7 @@ import { QueryRenderersShowMoreInfoQuery } from "__generated__/QueryRenderersSho
 import { QueryRenderersShowQuery } from "__generated__/QueryRenderersShowQuery.graphql"
 import { QueryRenderersWorksForYouQuery } from "__generated__/QueryRenderersWorksForYouQuery.graphql"
 import { BucketKey } from "lib/Scenes/Map/bucketCityResults"
-import createEnvironment, { defaultEnvironment } from "./createEnvironment"
-const environment = createEnvironment()
+import { defaultEnvironment as environment } from "./createEnvironment"
 
 export type RenderCallback = QueryRendererProps["render"]
 
@@ -369,7 +368,7 @@ interface ShowRendererProps extends RendererProps {
 export const ShowRenderer: React.SFC<ShowRendererProps> = ({ render, showID }) => {
   return (
     <QueryRenderer<QueryRenderersShowQuery>
-      environment={defaultEnvironment}
+      environment={environment}
       query={graphql`
         query QueryRenderersShowQuery($showID: String!) {
           show(id: $showID) {

--- a/src/lib/relay/createEnvironment.ts
+++ b/src/lib/relay/createEnvironment.ts
@@ -8,6 +8,8 @@ import { metaphysicsExtensionsLoggerMiddleware } from "./middlewares/metaphysics
 
 const Emission = NativeModules.Emission || {}
 
+/// WARNING: Creates a whole new, separate Relay environment. Useful for testing and in Storybooks.
+/// Use `defaultEnvironment` for production code.
 export default function createEnvironment() {
   const network = new RelayNetworkLayer([
     cacheMiddleware(),


### PR DESCRIPTION
This is a follow-up from #1502. 

The query renderers in `QueryRenderers.tsx` all use the same environment, but it is not the `defaultEnvironment`:

https://github.com/artsy/emission/blob/150ed9f7eefbf3494fcd81e11c5fccce7f5d5cf6/src/lib/relay/QueryRenderers.tsx#L57

But that environment is different from the environment used in our map component: 

https://github.com/artsy/emission/blob/150ed9f7eefbf3494fcd81e11c5fccce7f5d5cf6/src/lib/Scenes/Map/MapRenderer.tsx#L25

Leading to [LD-488](https://artsyproduct.atlassian.net/browse/LD-488). 

There seem to be only two production Relay environments left, and this PR will unite them into one. I've added a comment to the `createEnvironment.ts` file for now, and have added tooling discussion to prevent this in the future to our list of Front-End iOS Practice items.