### PR TITLE
narrows show detail column by 15 px to fit saved button in view

### DIFF
--- a/src/lib/Components/Lists/ShowItemRow.tsx
+++ b/src/lib/Components/Lists/ShowItemRow.tsx
@@ -148,7 +148,7 @@ export class ShowItemRow extends React.Component<Props, State> {
             ) : (
               <OpaqueImageView width={58} height={58} imageURL={imageURL} />
             )}
-            <Flex flexDirection="column" flexGrow={1} width={180} mr={10}>
+            <Flex flexDirection="column" flexGrow={1} width={165} mr={10}>
               {show.partner &&
                 show.partner.name && (
                   <Sans size="3t" color="black" weight="medium" numberOfLines={1} ml={15}>


### PR DESCRIPTION
This PR narrows the middle column in the Favorites show by 15px so that the Saved button isn't clipped by smaller devices.

[Links to an issue reported in LD=481](https://artsyproduct.atlassian.net/browse/LD-481) 


<img width="360" alt="Screen Shot 2019-03-18 at 5 44 42 PM" src="https://user-images.githubusercontent.com/10385964/54567309-b961b600-49a9-11e9-9bff-06ae7fbe4b32.png">
<img width="358" alt="Screen Shot 2019-03-18 at 5 47 54 PM" src="https://user-images.githubusercontent.com/10385964/54567310-b961b600-49a9-11e9-9375-6a135e0a0c0e.png">

#trivial 
