### PR TITLE
Relay no longer caches GraphQL responses which contain errors field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Updates copy in Global Saves and Follows Shows tab - ashley
 - Adds message if fair is not active and hides fair details - kieran
 - Fixes LD saving events inconsistencies - ash
+- Relay no longer caches GraphQL responses which contain `errors` field - ash
 
 ### 1.8.26
 


### PR DESCRIPTION
This PR changes the caching middleware on Emission to no longer store GraphQL responses that contain `errors` in the on-device cache. I have tested this locally against metaphysics.

Fixes [LD-502](https://artsyproduct.atlassian.net/browse/LD-502).