### PR TITLE
Configure a maxZoom for map component

### DIFF
--- a/src/lib/Scenes/Map/GlobalMap.tsx
+++ b/src/lib/Scenes/Map/GlobalMap.tsx
@@ -115,7 +115,9 @@ interface State {
 
 export const ArtsyMapStyleURL = "mapbox://styles/artsyit/cjrb59mjb2tsq2tqxl17pfoak"
 
-const DefaultZoomLevel = 12
+const DefaultZoomLevel = 11
+const MinZoomLevel = 9
+const MaxZoomLevel = 17.5
 
 const ButtonAnimation = {
   yDelta: -200,
@@ -210,6 +212,8 @@ export class GlobalMap extends React.Component<Props, State> {
 
     this.clusterEngine = new Supercluster({
       radius: 50,
+      minZoom: Math.floor(MinZoomLevel),
+      maxZoom: Math.floor(MaxZoomLevel),
     })
 
     this.updateShowIdMap()
@@ -233,7 +237,7 @@ export class GlobalMap extends React.Component<Props, State> {
 
     if (citySlug && citySlug !== nextProps.citySlug) {
       // Reset zoom level after switching cities
-      setTimeout(() => this.map.zoomTo(10, 100), 500)
+      setTimeout(() => this.map.zoomTo(DefaultZoomLevel, 100), 500)
     }
 
     if (nextProps.viewer) {
@@ -576,7 +580,8 @@ export class GlobalMap extends React.Component<Props, State> {
       userTrackingMode: Mapbox.UserTrackingModes.Follow,
       centerCoordinate: [centerLng, centerLat],
       zoomLevel: DefaultZoomLevel,
-      minZoomLevel: 10,
+      minZoomLevel: MinZoomLevel,
+      maxZoomLevel: MaxZoomLevel,
       logoEnabled: !!city,
       attributionEnabled: false,
       compassEnabled: false,


### PR DESCRIPTION
Implements: https://artsyproduct.atlassian.net/browse/LD-489

Workaround/fix for: https://artsyproduct.atlassian.net/browse/LD-438

(Update: Note that Jun and I have also adjusted min zoom and default zoom in this PR as well.)

This adds a maxZoom to the map. Before this you could zoom in so far that you were looking at nothing but a pin and a vast gray featureless expanse (see LD-489). Now you will be limited at a max zoom of 17.5, which basically ensures that you will see some street grid.

(This also appears to have a side effect of fixing LD-438.)

![maxzoom](https://user-images.githubusercontent.com/140521/54635878-91cb2600-4a5b-11e9-8ce3-3da7beca9e07.gif)

#trivial