### PR TITLE
Remove conditional sizing

### DIFF
--- a/src/lib/Components/Lists/ShowItemRow.tsx
+++ b/src/lib/Components/Lists/ShowItemRow.tsx
@@ -138,52 +138,50 @@ export class ShowItemRow extends React.Component<Props, State> {
 
     return (
       <TouchableWithoutFeedback onPress={() => (!this.isTapped ? this.handleTap(show.id, show._id) : null)}>
-        <Box py={2}>
-          <Flex flexDirection="row">
-            {!imageURL ? (
-              <DefaultImageContainer p={15}>
-                <Pin color={color("white100")} pinHeight={30} pinWidth={30} />
-              </DefaultImageContainer>
-            ) : (
-              <OpaqueImageView width={58} height={58} imageURL={imageURL} />
-            )}
-            <Flex flexDirection="column" flexGrow={1} width={165} mr={10}>
-              {show.partner &&
-                show.partner.name && (
-                  <Sans size="3t" color="black" weight="medium" numberOfLines={1} ml={15}>
-                    {show.partner.name}
-                  </Sans>
-                )}
-              {show.name && (
-                <TightendSerif size="3t" color={color("black60")} ml={15} numberOfLines={1}>
-                  {show.name}
-                </TightendSerif>
+        <Flex flexDirection="row">
+          {!imageURL ? (
+            <DefaultImageContainer p={15}>
+              <Pin color={color("white100")} pinHeight={30} pinWidth={30} />
+            </DefaultImageContainer>
+          ) : (
+            <OpaqueImageView width={58} height={58} imageURL={imageURL} />
+          )}
+          <Flex flexDirection="column" flexGrow={1} width={165} mr={10}>
+            {show.partner &&
+              show.partner.name && (
+                <Sans size="3t" color="black" weight="medium" numberOfLines={1} ml={15}>
+                  {show.partner.name}
+                </Sans>
               )}
-              {show.status &&
-                show.exhibition_period && (
-                  <Sans size="3t" color={color("black60")} ml={15}>
-                    {show.status.includes("closed")
-                      ? show.status.charAt(0).toUpperCase() + show.status.slice(1)
-                      : show.exhibition_period}
-                  </Sans>
-                )}
-            </Flex>
-            {!shouldHideSaveButton && (
-              <Flex flexDirection="row">
-                <Box width={50} height={20}>
-                  <InvertedButton
-                    inProgress={this.state.isFollowedSaving}
-                    text={show.is_followed ? "Saved" : "Save"}
-                    selected={show.is_followed}
-                    onPress={() => this.handleSave()}
-                    noBackground={true}
-                    hitSlop={{ top: 10, bottom: 10, left: 0, right: 0 }}
-                  />
-                </Box>
-              </Flex>
+            {show.name && (
+              <TightendSerif size="3t" color={color("black60")} ml={15} numberOfLines={1}>
+                {show.name}
+              </TightendSerif>
             )}
+            {show.status &&
+              show.exhibition_period && (
+                <Sans size="3t" color={color("black60")} ml={15}>
+                  {show.status.includes("closed")
+                    ? show.status.charAt(0).toUpperCase() + show.status.slice(1)
+                    : show.exhibition_period}
+                </Sans>
+              )}
           </Flex>
-        </Box>
+          {!shouldHideSaveButton && (
+            <Flex flexDirection="row">
+              <Box width={50} height={20}>
+                <InvertedButton
+                  inProgress={this.state.isFollowedSaving}
+                  text={show.is_followed ? "Saved" : "Save"}
+                  selected={show.is_followed}
+                  onPress={() => this.handleSave()}
+                  noBackground={true}
+                  hitSlop={{ top: 10, bottom: 10, left: 0, right: 0 }}
+                />
+              </Box>
+            </Flex>
+          )}
+        </Flex>
       </TouchableWithoutFeedback>
     )
   }

--- a/src/lib/Components/Lists/ShowItemRow.tsx
+++ b/src/lib/Components/Lists/ShowItemRow.tsx
@@ -17,7 +17,6 @@ import styled from "styled-components/native"
 interface Props {
   show: ShowItemRow_show
   relay?: RelayProp
-  noPadding?: boolean
   onSaveStarted?: () => void
   onSaveEnded?: () => void
   shouldHideSaveButton?: boolean
@@ -131,7 +130,7 @@ export class ShowItemRow extends React.Component<Props, State> {
   }
 
   render() {
-    const { noPadding, show, shouldHideSaveButton } = this.props
+    const { show, shouldHideSaveButton } = this.props
     const mainCoverImageURL = show.cover_image && show.cover_image.url
     const galleryProfileIcon = show.isStubShow && get(show, "partner.profile.image.url")
 
@@ -139,7 +138,7 @@ export class ShowItemRow extends React.Component<Props, State> {
 
     return (
       <TouchableWithoutFeedback onPress={() => (!this.isTapped ? this.handleTap(show.id, show._id) : null)}>
-        <Box py={noPadding ? 0 : 2}>
+        <Box py={2}>
           <Flex flexDirection="row">
             {!imageURL ? (
               <DefaultImageContainer p={15}>

--- a/src/lib/Scenes/City/CityFairList.tsx
+++ b/src/lib/Scenes/City/CityFairList.tsx
@@ -46,7 +46,11 @@ class CityFairList extends React.Component<Props, State> {
   }
 
   renderItem = item => {
-    return <TabFairItemRow item={item.node} />
+    return (
+      <Box py={2}>
+        <TabFairItemRow item={item.node} />
+      </Box>
+    )
   }
 
   render() {

--- a/src/lib/Scenes/City/Components/EventList.tsx
+++ b/src/lib/Scenes/City/Components/EventList.tsx
@@ -33,7 +33,15 @@ export class EventList extends React.Component<Props> {
     const { type } = this.props
     return (
       <Box height={ROW_HEIGHT}>
-        {type === "fairs" ? <TabFairItemRow item={item} /> : <ShowItemRow show={item} relay={this.props.relay} />}
+        {type === "fairs" ? (
+          <Box py={2}>
+            <TabFairItemRow item={item} />
+          </Box>
+        ) : (
+          <Box py={2}>
+            <ShowItemRow show={item} relay={this.props.relay} />
+          </Box>
+        )}
       </Box>
     )
   }

--- a/src/lib/Scenes/City/Components/TabFairItemRow/index.tsx
+++ b/src/lib/Scenes/City/Components/TabFairItemRow/index.tsx
@@ -8,7 +8,6 @@ import styled from "styled-components/native"
 
 export interface Props {
   item: Fair
-  noPadding?: boolean
 }
 
 export class TabFairItemRow extends React.Component<Props> {
@@ -17,11 +16,11 @@ export class TabFairItemRow extends React.Component<Props> {
   }
 
   render() {
-    const { item, noPadding } = this.props
+    const { item } = this.props
     const boxWidth = Dimensions.get("window").width - 62 - space(4) - space(1)
     const fairImage = item.image ? item.image.url : null
     return (
-      <Box py={noPadding ? 0 : 2}>
+      <Box py={2}>
         <TouchableWithoutFeedback onPress={() => this.handleTap(item)}>
           <Flex flexWrap="nowrap" flexDirection="row" alignItems="center" mr={10}>
             <RoundedImageWrapper>

--- a/src/lib/Scenes/City/Components/TabFairItemRow/index.tsx
+++ b/src/lib/Scenes/City/Components/TabFairItemRow/index.tsx
@@ -20,35 +20,33 @@ export class TabFairItemRow extends React.Component<Props> {
     const boxWidth = Dimensions.get("window").width - 62 - space(4) - space(1)
     const fairImage = item.image ? item.image.url : null
     return (
-      <Box py={2}>
-        <TouchableWithoutFeedback onPress={() => this.handleTap(item)}>
-          <Flex flexWrap="nowrap" flexDirection="row" alignItems="center" mr={10}>
-            <RoundedImageWrapper>
-              <OpaqueImageView height={58} width={58} imageURL={fairImage} />
-            </RoundedImageWrapper>
-            <Box width={boxWidth} pl={1}>
-              {item.name && (
-                <Sans weight="medium" size="3t" numberOfLines={1} ellipsizeMode="tail">
-                  {item.name}
-                </Sans>
-              )}
-              {item.counts &&
-                item.counts.partners && (
-                  <Sans size="3t" color="black60" numberOfLines={1} ellipsizeMode="tail">
-                    {item.counts.partners > 1
-                      ? `${item.counts.partners} Exhibitors`
-                      : `${item.counts.partners} Exhibitor`}
-                  </Sans>
-                )}
-              {item.exhibition_period && (
+      <TouchableWithoutFeedback onPress={() => this.handleTap(item)}>
+        <Flex flexWrap="nowrap" flexDirection="row" alignItems="center" mr={10}>
+          <RoundedImageWrapper>
+            <OpaqueImageView height={58} width={58} imageURL={fairImage} />
+          </RoundedImageWrapper>
+          <Box width={boxWidth} pl={1}>
+            {item.name && (
+              <Sans weight="medium" size="3t" numberOfLines={1} ellipsizeMode="tail">
+                {item.name}
+              </Sans>
+            )}
+            {item.counts &&
+              item.counts.partners && (
                 <Sans size="3t" color="black60" numberOfLines={1} ellipsizeMode="tail">
-                  {item.exhibition_period}
+                  {item.counts.partners > 1
+                    ? `${item.counts.partners} Exhibitors`
+                    : `${item.counts.partners} Exhibitor`}
                 </Sans>
               )}
-            </Box>
-          </Flex>
-        </TouchableWithoutFeedback>
-      </Box>
+            {item.exhibition_period && (
+              <Sans size="3t" color="black60" numberOfLines={1} ellipsizeMode="tail">
+                {item.exhibition_period}
+              </Sans>
+            )}
+          </Box>
+        </Flex>
+      </TouchableWithoutFeedback>
     )
   }
 }

--- a/src/lib/Scenes/Favorites/Components/Shows/index.tsx
+++ b/src/lib/Scenes/Favorites/Components/Shows/index.tsx
@@ -57,7 +57,11 @@ export class Shows extends Component<Props, State> {
           <FlatList
             data={shows}
             keyExtractor={item => item.__id}
-            renderItem={item => <ShowItemRow show={item.item} />}
+            renderItem={item => (
+              <Box py={2}>
+                <ShowItemRow show={item.item} />
+              </Box>
+            )}
             onEndReached={this.loadMore}
             onEndReachedThreshold={0.2}
             ItemSeparatorComponent={() => <Separator />}

--- a/src/lib/Scenes/Map/Components/ShowCard.tsx
+++ b/src/lib/Scenes/Map/Components/ShowCard.tsx
@@ -78,16 +78,19 @@ export class ShowCard extends Component<ShowCardProps, ShowCardState> {
       <Background ml={1} p={1} style={shadowDetails} {...props}>
         <TouchableOpacity onPress={this.handleTap.bind(this, item)}>
           {item.type === "Show" ? (
-            <ShowItemRow
-              show={item}
-              relay={this.props.relay}
-              onSaveStarted={this.props.onSaveStarted}
-              onSaveEnded={this.props.onSaveEnded}
-              noPadding
-              shouldHideSaveButton={true}
-            />
+            <Box py={-2}>
+              <ShowItemRow
+                show={item}
+                relay={this.props.relay}
+                onSaveStarted={this.props.onSaveStarted}
+                onSaveEnded={this.props.onSaveEnded}
+                shouldHideSaveButton={true}
+              />
+            </Box>
           ) : (
-            <TabFairItemRow item={item} noPadding />
+            <Box py={-2}>
+              <TabFairItemRow item={item} />
+            </Box>
           )}
         </TouchableOpacity>
       </Background>

--- a/src/lib/Scenes/Map/Components/ShowCard.tsx
+++ b/src/lib/Scenes/Map/Components/ShowCard.tsx
@@ -78,19 +78,15 @@ export class ShowCard extends Component<ShowCardProps, ShowCardState> {
       <Background ml={1} p={1} style={shadowDetails} {...props}>
         <TouchableOpacity onPress={this.handleTap.bind(this, item)}>
           {item.type === "Show" ? (
-            <Box py={-2}>
-              <ShowItemRow
-                show={item}
-                relay={this.props.relay}
-                onSaveStarted={this.props.onSaveStarted}
-                onSaveEnded={this.props.onSaveEnded}
-                shouldHideSaveButton={true}
-              />
-            </Box>
+            <ShowItemRow
+              show={item}
+              relay={this.props.relay}
+              onSaveStarted={this.props.onSaveStarted}
+              onSaveEnded={this.props.onSaveEnded}
+              shouldHideSaveButton={true}
+            />
           ) : (
-            <Box py={-2}>
-              <TabFairItemRow item={item} />
-            </Box>
+            <TabFairItemRow item={item} />
           )}
         </TouchableOpacity>
       </Background>


### PR DESCRIPTION
This PR moves control of margin and padding around Show and Fair List Items to its parent container rather than keeping them on the Show and Fair List Item components themselves.


It also obviates the need to add hacky props like `addMargin` and `noMargin` to the Show and Fair List Item components.

#trivial 

