### PR TITLE
Reset zoom, pitch and heading  upon city switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Updates dayThresholds for opening/closing shows to be 14/7 respectively - kieran
 - User location button hides when user is outside of currently selected city - ash
 - Adds "Ongoing" to shows running 2+ years beyond the present - ashley
+- Reset zoom, heading and pitch upon city change - roop
 
 ### 1.8.26
 

--- a/src/lib/Scenes/Map/GlobalMap.tsx
+++ b/src/lib/Scenes/Map/GlobalMap.tsx
@@ -109,6 +109,7 @@ export const ArtsyMapStyleURL = "mapbox://styles/artsyit/cjrb59mjb2tsq2tqxl17pfo
 const DefaultZoomLevel = 11
 const MinZoomLevel = 9
 const MaxZoomLevel = 17.5
+const DefaultCameraMode = 1 // https://github.com/nitaliano/react-native-mapbox-gl/blob/master/ios/RCTMGL/CameraMode.m
 
 const ButtonAnimation = {
   yDelta: -200,
@@ -206,6 +207,16 @@ export class GlobalMap extends React.Component<Props, State> {
     this.setState({ activeIndex, activePin: null, activeShows: [] })
   }
 
+  resetZoomAndCamera = () => {
+    this.map.setCamera({
+      mode: DefaultCameraMode,
+      zoom: DefaultZoomLevel,
+      pitch: 0,
+      heading: 0,
+      duration: 1000,
+    })
+  }
+
   componentDidMount() {
     EventEmitter.subscribe("filters:change", this.handleFilterChange)
   }
@@ -232,8 +243,7 @@ export class GlobalMap extends React.Component<Props, State> {
     const { citySlug, relayErrorState } = this.props
 
     if (citySlug && citySlug !== nextProps.citySlug) {
-      // Reset zoom level after switching cities
-      setTimeout(() => this.map.zoomTo(DefaultZoomLevel, 100), 500)
+      setTimeout(this.resetZoomAndCamera, 500)
     }
 
     if (nextProps.viewer) {


### PR DESCRIPTION
Iteration on https://artsyproduct.atlassian.net/browse/LD-407

When interacting with the map, it's possible to get into a permutation of custom **zoom**, **heading** (rotating away from north), and **pitch** (tilting away from camera-pointing down)

For example, facing down Canal St towards the Manhattan Bridge.

<img width="344" alt="canal" src="https://user-images.githubusercontent.com/140521/54659585-d8933d00-4aa8-11e9-9863-4106eeacf28a.png">

Currently when we switch to another city, we reset the zoom, but leave the heading and pitch unchanged, which leads to an unexpected initial experience:

<img width="344" alt="lon" src="https://user-images.githubusercontent.com/140521/54659796-c49c0b00-4aa9-11e9-966c-9787c9f8499c.png">

We can instead reset all three — zoom, pitch and heading in order to restore a neutral initial vantage point into the new city.

Furthermore, by taking advantage of an easing animation with a generous duration, we can also mitigate the perceived delays associated with the initial fetch of a new city's data.

Putting that all together looks something like this: 

<img width="344" alt="anim" src="https://user-images.githubusercontent.com/140521/54659976-ada9e880-4aaa-11e9-9d4a-ac1d758f07aa.gif">

Duration is currently set to 2 seconds, but that's up for grabs of course.

I would love to see this bit of finish added to v1.1 _**IF**_ it is reasonable to do so with solid Q/A. But if not, I don't want to rush things. Wondering what the best way to test this is outside of the beta. I looked into side-loading onto my own device but hit all kinds of walls with that. Would love some help if there's time tomorrow.