### PR TITLE
[Map] Do not reset safeAreaInsets back to 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Master
 
+- Do no reset safeAreaInsets back to 0 - luc
+
 ### 1.9.0
 
 - Add cover images to stub shows in full list - luc

--- a/Pod/Classes/ViewControllers/ARMapContainerViewController.m
+++ b/Pod/Classes/ViewControllers/ARMapContainerViewController.m
@@ -36,7 +36,7 @@ NSString * const __nonnull SelectedCityNameKey = @"SelectedCityName";
 
 @property (nonatomic, assign) BOOL initialDataIsLoaded;
 @property (nonatomic, assign) BOOL attributionViewsConstraintsAdded;
-
+@property (nonatomic, assign) BOOL mapViewSafeAreaInsetsSet;
 
 @end
 
@@ -340,10 +340,23 @@ Since this controller already has to do the above logic, having it handle the Ci
 
 - (void)updateSafeAreaInsets
 {
+    if (self.mapViewSafeAreaInsetsSet) {
+        return;
+    }
+    
     UIEdgeInsets safeAreaInsets = UIEdgeInsetsZero;
     if (@available(iOS 11.0, *)) {
         safeAreaInsets = self.view.safeAreaInsets;
+    
+        // Once we receive the correct top inset value it gets resetted to 0 after the VC gets hidden
+        // So let's not reset it afterwards
+        if (self.view.safeAreaInsets.top > 0) {
+            self.mapViewSafeAreaInsetsSet = YES;
+        }
+    } else {
+        self.mapViewSafeAreaInsetsSet = YES;
     }
+    
     [self.mapVC setProperty:@{ @"top": @(safeAreaInsets.top),
                                @"bottom": @(safeAreaInsets.bottom),
                                @"left": @(safeAreaInsets.left),

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "emission",
   "version": "1.9.0",
-  "native-code-version": 28,
+  "native-code-version": 29,
   "description": "Artsy React(Native) components.",
   "engines": {
     "node": "10.x",


### PR DESCRIPTION
If the user leaves the Map view and comes back, two things happen:
- our top button flash top positions 
- cards get hidden by the drawer

This PR fixes this behavior

<img src="https://user-images.githubusercontent.com/296775/54718005-eb048980-4b2f-11e9-9713-7425bb2488f5.png" width="400" />