### PR TITLE
LD-521 - Adds opening reception header to stub shows #trivial

### DIFF
--- a/src/lib/Scenes/Show/Screens/MoreInfo.tsx
+++ b/src/lib/Scenes/Show/Screens/MoreInfo.tsx
@@ -119,7 +119,16 @@ export class MoreInfo extends React.Component<Props, State> {
       case "pressReleaseUrl":
         return <CaretButton onPress={() => this.openPressReleaseLink()} text="View press release" />
       case "receptionText":
-        return <Sans size="3t">{data}</Sans>
+        return (
+          <>
+            <Box mb={2}>
+              <Sans size="3t" weight="medium">
+                Opening reception
+              </Sans>
+            </Box>
+            <Sans size="3t">{data}</Sans>
+          </>
+        )
       case "event":
         return <ShowEventSection {...data} />
       case "pressRelease":


### PR DESCRIPTION
- https://artsyproduct.atlassian.net/browse/LD-521

#trivial

## Before

![Screen Shot 2019-03-21 at 11 33 06 AM](https://user-images.githubusercontent.com/21182806/54764287-decf0980-4bcd-11e9-91a4-c3d5d4633a58.png)

## After

![Screen Shot 2019-03-21 at 11 36 42 AM](https://user-images.githubusercontent.com/21182806/54764320-e9899e80-4bcd-11e9-9c55-e712393bfaf0.png)

