### PR TITLE
Fixes City not re-rendering after a MP request is successfully retried

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Master
 
+- Fixes City not re-rendering after a MP request is successfully retried - ash
+
 ### 1.9.2
 
 - Fixes scrollable tab bar on global saves & follows - ash & ashley

--- a/src/lib/Scenes/Map/GlobalMap.tsx
+++ b/src/lib/Scenes/Map/GlobalMap.tsx
@@ -246,7 +246,9 @@ export class GlobalMap extends React.Component<Props, State> {
       setTimeout(this.resetZoomAndCamera, 500)
     }
 
+    // If there is a new city, emity it and update our map.
     if (nextProps.viewer) {
+      // TODO: This is currently really inefficient.
       const bucketResults = bucketCityResults(nextProps.viewer)
 
       this.setState({ bucketResults }, () => {
@@ -254,8 +256,10 @@ export class GlobalMap extends React.Component<Props, State> {
         this.updateShowIdMap()
         this.updateClusterMap()
       })
-    } else if (relayErrorState) {
-      EventEmitter.dispatch("map:error", { relayErrorState })
+    }
+    // If the relayErrorState changes, emit a new event.
+    if (!!relayErrorState !== !!nextProps.relayErrorState) {
+      EventEmitter.dispatch("map:error", { relayErrorState: nextProps.relayErrorState })
     }
 
     if (nextProps.hideMapButtons !== this.props.hideMapButtons) {


### PR DESCRIPTION
Fixes [LD-533](https://artsyproduct.atlassian.net/browse/LD-533).

The problem was that we were only ever sending the error (and never sending once the error was completed). I added a check where we only send if the values are different, and I want to take a look at using a similar approach with calculating+emitting bucket results (marked by a TODO right now).

This also needs a test, hoping to pair with @kierangillen on the `EventEmitter` mocking stuff tomorrow morning. 