### PR TITLE
Removes second sort on brick shows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Master
 
+- Fixes Closing Soon and Opening Soon order - kieran
+
 ### 1.9.2
 
 - Fixes scrollable tab bar on global saves & follows - ash & ashley

--- a/src/lib/Scenes/City/Components/EventSection/index.tsx
+++ b/src/lib/Scenes/City/Components/EventSection/index.tsx
@@ -23,8 +23,7 @@ export class EventSection extends React.Component<Props> {
     const { data } = this.props
     let finalShowsForPreviewBricks
     const eligibleForBrick = data.filter(s => !s.isStubShow && !!s.cover_image && !!s.cover_image.url)
-    const sortedByStartDesc = [...eligibleForBrick].sort((a, b) => ((a.start_at as any) > b.start_at) as any).reverse()
-    finalShowsForPreviewBricks = sortedByStartDesc.slice(0, 2)
+    finalShowsForPreviewBricks = eligibleForBrick.slice(0, 2)
 
     if (!!finalShowsForPreviewBricks) {
       return finalShowsForPreviewBricks.map(event => {


### PR DESCRIPTION
- The `opening soon` and `closing soon` sections in the `All` tab had a second unnecessary sort which was distorting the order, this fixes this issue by removing it.

<img width="402" alt="Screen Shot 2019-03-28 at 1 34 47 PM" src="https://user-images.githubusercontent.com/21182806/55179642-45b86980-515e-11e9-9601-e43245fd19d6.png">
