### PR TITLE
Fixes button overflow on smaller devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Master
 
+- Fixes overflowing Save button on small screen devices - ashley
+
 ### 1.9.4
 
 ### 1.9.3

--- a/src/lib/Scenes/City/Components/Event/index.tsx
+++ b/src/lib/Scenes/City/Components/Event/index.tsx
@@ -156,7 +156,7 @@ export class Event extends React.Component<Props, State> {
                 </Sans>
               )}
             </TextContainer>
-            <Box width={102} height={34}>
+            <Flex maxWidth={102} height={34} flexBasis="29%" flexDirection="row" flexGrow={1}>
               <InvertedButton
                 grayBorder={true}
                 text={is_followed ? "Saved" : "Save"}
@@ -164,7 +164,7 @@ export class Event extends React.Component<Props, State> {
                 selected={is_followed}
                 inProgress={isFollowedSaving}
               />
-            </Box>
+            </Flex>
           </Flex>
         </Box>
       </TouchableWithoutFeedback>


### PR DESCRIPTION
This PR fixes the UI bug causing the Save button on smaller screen iPhones to extend beyond their containers.

<img width="1425" alt="Screen Shot 2019-04-02 at 12 53 54 PM" src="https://user-images.githubusercontent.com/10385964/55421265-dd46ff00-5546-11e9-8b58-bde8d0f2ec64.png">


[Links to LD-546](https://artsyproduct.atlassian.net/browse/LD-546)

[Here's a good post to explain my rationale for implementing the fix this way](https://gedd.ski/post/the-difference-between-width-and-flex-basis/)