### PR TITLE
[metaphysics] Pass local timezone to MP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Master
 
+- Inlcude local timezone in each MP request so MP can decide to render datetimes in the user’s local time - alloy
 - Fixes overflowing Save button on small screen devices - ashley
 
 ### 1.9.4

--- a/Pod/Classes/Core/ARCocoaConstantsModule.m
+++ b/Pod/Classes/Core/ARCocoaConstantsModule.m
@@ -15,6 +15,7 @@ RCT_EXPORT_MODULE();
 {
     return @{
         @"UIApplicationOpenSettingsURLString": UIApplicationOpenSettingsURLString,
+        @"LocalTimeZone": [[NSTimeZone localTimeZone] name],
     };
 }
 

--- a/src/lib/relay/createEnvironment.ts
+++ b/src/lib/relay/createEnvironment.ts
@@ -7,6 +7,7 @@ import { cacheMiddleware } from "./middlewares/cacheMiddleware"
 import { metaphysicsExtensionsLoggerMiddleware } from "./middlewares/metaphysicsMiddleware"
 
 const Emission = NativeModules.Emission || {}
+const Constants = NativeModules.ARCocoaConstantsModule || {}
 
 /// WARNING: Creates a whole new, separate Relay environment. Useful for testing and in Storybooks.
 /// Use `defaultEnvironment` for production code.
@@ -20,6 +21,7 @@ export default function createEnvironment() {
         "User-Agent": Emission.userAgent,
         "X-USER-ID": Emission.userID,
         "X-ACCESS-TOKEN": Emission.authenticationToken,
+        "X-TIMEZONE": Constants.LocalTimeZone,
       },
     }),
     loggerMiddleware(),


### PR DESCRIPTION
So MP can use that as the default timezone for datetimes that should be rendered in the user’s local time (for instance the start time of a live auction).

Most importantly, this will allow us to fix _some_ issues outside of an app release, in the future.

This mimics Reaction https://github.com/artsy/reaction/blob/0aba9cc92bc99464bf1e4209301bd78eba7f39be/src/Artsy/Relay/createRelaySSREnvironment.ts#L70