### PR TITLE
[Refactor] Update deprecated Relay `graphql` assignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fixes overflowing Save button on small screen devices - ashley
 - Moves fair open hours display to metaphysics - kieran
 - Upgrade to React Native 0.59.2 - orta/alloy
+- Refactors deprecated Relay `graphql` calls - chris
 
 ### 1.9.4
 

--- a/scripts/update-graphql-fragments.js
+++ b/scripts/update-graphql-fragments.js
@@ -1,0 +1,73 @@
+"use strict"
+
+/**
+ * Updates `graphql` tags used throughout Relay code to assign result to an object
+ * key vs implicitly assigning. Implicit assignment has  ow been deprecated.
+ *
+ * See: https://mobile.twitter.com/kassens/status/1116018336192548865
+ *
+ * To be used with jscodeshift: https://github.com/facebook/jscodeshift
+ */
+
+export const parser = "tsx"
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift
+
+  if (!file.source.includes("graphql`")) {
+    return
+  }
+
+  const source = j(file.source)
+    .find(j.TaggedTemplateExpression, {
+      tag: { type: "Identifier", name: "graphql" },
+    })
+    .filter(path => getAssignedObjectPropertyName(path) == null)
+    .filter(path => path.parentPath.node.type !== "ExpressionStatement")
+    .forEach(path => {
+      const text = path.node.quasi.quasis[0].value.raw
+      const fragmentNameMatch = text.replace(/#.*/g, "").match(/fragment (\w+)/)
+      if (!fragmentNameMatch) {
+        return
+      }
+      const fragmentName = fragmentNameMatch[1]
+
+      const [, propName] = getFragmentNameParts(fragmentName)
+
+      j(path).replaceWith(
+        j.objectExpression([
+          j.objectProperty(j.identifier(propName), path.node),
+        ])
+      )
+    })
+    .toSource()
+
+  return source
+}
+
+function getAssignedObjectPropertyName(path) {
+  var property = path
+  while (property) {
+    if (property.node.type === "Property" && property.node.key.name) {
+      return property.node.key.name
+    }
+    property = property.parentPath
+  }
+}
+
+function getFragmentNameParts(fragmentName) {
+  const match = fragmentName.match(
+    /^([a-zA-Z][a-zA-Z0-9]*)(?:_([a-zA-Z][_a-zA-Z0-9]*))?$/
+  )
+  if (!match) {
+    throw new Error(
+      "BabelPluginGraphQL: Fragments should be named " +
+        "`ModuleName_fragmentName`, got `" +
+        fragmentName +
+        "`."
+    )
+  }
+  const module = match[1]
+  const propName = match[2] || "@nocommit"
+  return [module, propName]
+}

--- a/src/lib/Components/Artist/About.tsx
+++ b/src/lib/Components/Artist/About.tsx
@@ -73,9 +73,8 @@ const styles = StyleSheet.create({
   },
 })
 
-export default createFragmentContainer(
-  About,
-  graphql`
+export default createFragmentContainer(About, {
+  artist: graphql`
     fragment About_artist on Artist {
       has_metadata
       is_display_auction_link
@@ -88,5 +87,5 @@ export default createFragmentContainer(
         ...Articles_articles
       }
     }
-  `
-)
+  `,
+})

--- a/src/lib/Components/Artist/Articles/Article.tsx
+++ b/src/lib/Components/Artist/Articles/Article.tsx
@@ -74,9 +74,8 @@ const styles = StyleSheet.create<Styles>({
   },
 })
 
-export default createFragmentContainer(
-  Article,
-  graphql`
+export default createFragmentContainer(Article, {
+  article: graphql`
     fragment Article_article on Article {
       thumbnail_title
       href
@@ -87,5 +86,5 @@ export default createFragmentContainer(
         url(version: "large")
       }
     }
-  `
-)
+  `,
+})

--- a/src/lib/Components/Artist/Articles/index.tsx
+++ b/src/lib/Components/Artist/Articles/index.tsx
@@ -43,12 +43,11 @@ const styles = StyleSheet.create({
   },
 })
 
-export default createFragmentContainer(
-  Articles,
-  graphql`
+export default createFragmentContainer(Articles, {
+  articles: graphql`
     fragment Articles_articles on Article @relay(plural: true) {
       __id
       ...Article_article
     }
-  `
-)
+  `,
+})

--- a/src/lib/Components/Artist/Artworks/index.tsx
+++ b/src/lib/Components/Artist/Artworks/index.tsx
@@ -116,9 +116,8 @@ const styles = StyleSheet.create({
   },
 })
 
-export default createFragmentContainer(
-  Artworks,
-  graphql`
+export default createFragmentContainer(Artworks, {
+  artist: graphql`
     fragment Artworks_artist on Artist {
       counts {
         artworks
@@ -127,5 +126,5 @@ export default createFragmentContainer(
       ...ArtistForSaleArtworksGrid_artist
       ...ArtistNotForSaleArtworksGrid_artist
     }
-  `
-)
+  `,
+})

--- a/src/lib/Components/Artist/Biography.tsx
+++ b/src/lib/Components/Artist/Biography.tsx
@@ -62,12 +62,11 @@ const styles = StyleSheet.create({
   },
 })
 
-export default createFragmentContainer(
-  Biography,
-  graphql`
+export default createFragmentContainer(Biography, {
+  artist: graphql`
     fragment Biography_artist on Artist {
       bio
       blurb
     }
-  `
-)
+  `,
+})

--- a/src/lib/Components/Artist/Header.tsx
+++ b/src/lib/Components/Artist/Header.tsx
@@ -186,9 +186,8 @@ const styles = StyleSheet.create<Styles>({
   },
 })
 
-export default createFragmentContainer(
-  Header,
-  graphql`
+export default createFragmentContainer(Header, {
+  artist: graphql`
     fragment Header_artist on Artist {
       _id
       id
@@ -199,5 +198,5 @@ export default createFragmentContainer(
         follows
       }
     }
-  `
-)
+  `,
+})

--- a/src/lib/Components/Artist/Shows/ArtistShow.tsx
+++ b/src/lib/Components/Artist/Shows/ArtistShow.tsx
@@ -42,9 +42,8 @@ class Show extends React.Component<Props> {
   }
 }
 
-export default createFragmentContainer(
-  Show,
-  graphql`
+export default createFragmentContainer(Show, {
+  show: graphql`
     fragment ArtistShow_show on PartnerShow {
       id
       href
@@ -54,5 +53,5 @@ export default createFragmentContainer(
       }
       ...Metadata_show
     }
-  `
-)
+  `,
+})

--- a/src/lib/Components/Artist/Shows/Metadata.tsx
+++ b/src/lib/Components/Artist/Shows/Metadata.tsx
@@ -76,9 +76,8 @@ const styles = StyleSheet.create<Styles>({
   },
 })
 
-export default createFragmentContainer(
-  Metadata,
-  graphql`
+export default createFragmentContainer(Metadata, {
+  show: graphql`
     fragment Metadata_show on PartnerShow {
       kind
       name
@@ -92,5 +91,5 @@ export default createFragmentContainer(
         city
       }
     }
-  `
-)
+  `,
+})

--- a/src/lib/Components/Artist/Shows/SmallList.tsx
+++ b/src/lib/Components/Artist/Shows/SmallList.tsx
@@ -69,11 +69,10 @@ const showStyles = StyleSheet.create({
   image: ViewStyle
 }
 
-export default createFragmentContainer(
-  SmallList,
-  graphql`
+export default createFragmentContainer(SmallList, {
+  shows: graphql`
     fragment SmallList_shows on PartnerShow @relay(plural: true) {
       ...ArtistShow_show
     }
-  `
-)
+  `,
+})

--- a/src/lib/Components/Artist/Shows/VariableSizeShowsList.tsx
+++ b/src/lib/Components/Artist/Shows/VariableSizeShowsList.tsx
@@ -90,12 +90,11 @@ const styles = StyleSheet.create<Styles>({
   },
 })
 
-export default createFragmentContainer(
-  ShowsList,
-  graphql`
+export default createFragmentContainer(ShowsList, {
+  shows: graphql`
     fragment VariableSizeShowsList_shows on PartnerShow @relay(plural: true) {
       __id
       ...ArtistShow_show
     }
-  `
-)
+  `,
+})

--- a/src/lib/Components/Artist/Shows/index.tsx
+++ b/src/lib/Components/Artist/Shows/index.tsx
@@ -76,9 +76,8 @@ const styles = StyleSheet.create<Styles>({
   },
 })
 
-export default createFragmentContainer(
-  Shows,
-  graphql`
+export default createFragmentContainer(Shows, {
+  artist: graphql`
     fragment Shows_artist on Artist {
       current_shows: partner_shows(status: "running") {
         ...VariableSizeShowsList_shows
@@ -93,5 +92,5 @@ export default createFragmentContainer(
         ...VariableSizeShowsList_shows
       }
     }
-  `
-)
+  `,
+})

--- a/src/lib/Components/ArtistListItem.tsx
+++ b/src/lib/Components/ArtistListItem.tsx
@@ -193,9 +193,8 @@ export class ArtistListItem extends React.Component<Props, State> {
   }
 }
 
-export const ArtistListItemContainer = createFragmentContainer(
-  ArtistListItem,
-  graphql`
+export const ArtistListItemContainer = createFragmentContainer(ArtistListItem, {
+  artist: graphql`
     fragment ArtistListItem_artist on Artist {
       __id
       _id
@@ -209,5 +208,5 @@ export const ArtistListItemContainer = createFragmentContainer(
         url
       }
     }
-  `
-)
+  `,
+})

--- a/src/lib/Components/ArtworkGrids/Artwork.tsx
+++ b/src/lib/Components/ArtworkGrids/Artwork.tsx
@@ -192,9 +192,8 @@ const styles = StyleSheet.create({
   },
 })
 
-export default createFragmentContainer(
-  Artwork,
-  graphql`
+export default createFragmentContainer(Artwork, {
+  artwork: graphql`
     fragment Artwork_artwork on Artwork {
       title
       date
@@ -235,5 +234,5 @@ export default createFragmentContainer(
       }
       href
     }
-  `
-)
+  `,
+})

--- a/src/lib/Components/ArtworkGrids/GenericGrid.tsx
+++ b/src/lib/Components/ArtworkGrids/GenericGrid.tsx
@@ -172,9 +172,8 @@ const styles = StyleSheet.create<Styles>({
   },
 })
 
-const GenericGrid = createFragmentContainer(
-  GenericArtworksGrid,
-  graphql`
+const GenericGrid = createFragmentContainer(GenericArtworksGrid, {
+  artworks: graphql`
     fragment GenericGrid_artworks on Artwork @relay(plural: true) {
       __id
       id
@@ -183,7 +182,7 @@ const GenericGrid = createFragmentContainer(
       }
       ...Artwork_artwork
     }
-  `
-)
+  `,
+})
 
 export default GenericGrid

--- a/src/lib/Components/Bidding/Screens/BidResult.tsx
+++ b/src/lib/Components/Bidding/Screens/BidResult.tsx
@@ -114,9 +114,8 @@ export class BidResult extends React.Component<BidResultProps> {
   }
 }
 
-export const BidResultScreen = createFragmentContainer(
-  BidResult,
-  graphql`
+export const BidResultScreen = createFragmentContainer(BidResult, {
+  sale_artwork: graphql`
     fragment BidResult_sale_artwork on SaleArtwork {
       minimum_next_bid {
         amount
@@ -129,5 +128,5 @@ export const BidResultScreen = createFragmentContainer(
         id
       }
     }
-  `
-)
+  `,
+})

--- a/src/lib/Components/FilteredInfiniteScrollGrid/FilteredInfiniteScrollGrid.tsx
+++ b/src/lib/Components/FilteredInfiniteScrollGrid/FilteredInfiniteScrollGrid.tsx
@@ -111,12 +111,11 @@ function eventProps(actionName: Schema.ActionNames) {
   })
 }
 
-export const FilteredInfiniteScrollGridContainer = createFragmentContainer(
-  FilteredInfiniteScrollGrid,
-  graphql`
+export const FilteredInfiniteScrollGridContainer = createFragmentContainer(FilteredInfiniteScrollGrid, {
+  filteredArtworks: graphql`
     fragment FilteredInfiniteScrollGrid_filteredArtworks on FilterArtworks {
       ...Filters_filteredArtworks
       ...ArtworksGridPaginationContainer_filteredArtworks
     }
-  `
-)
+  `,
+})

--- a/src/lib/Components/FilteredInfiniteScrollGrid/Filters.tsx
+++ b/src/lib/Components/FilteredInfiniteScrollGrid/Filters.tsx
@@ -46,9 +46,8 @@ export const Filters: React.SFC<Props> = ({ onFilterChange, mediumValue, priceRa
   )
 }
 
-export const FiltersContainer = createFragmentContainer(
-  Filters,
-  graphql`
+export const FiltersContainer = createFragmentContainer(Filters, {
+  filteredArtworks: graphql`
     fragment Filters_filteredArtworks on FilterArtworks {
       aggregations {
         slice
@@ -58,5 +57,5 @@ export const FiltersContainer = createFragmentContainer(
         }
       }
     }
-  `
-)
+  `,
+})

--- a/src/lib/Components/Gene/About.tsx
+++ b/src/lib/Components/Gene/About.tsx
@@ -50,14 +50,13 @@ const styles = StyleSheet.create<Styles>({
   },
 })
 
-export default createFragmentContainer(
-  About,
-  graphql`
+export default createFragmentContainer(About, {
+  gene: graphql`
     fragment About_gene on Gene {
       ...Biography_gene
       trending_artists {
         ...RelatedArtists_artists
       }
     }
-  `
-)
+  `,
+})

--- a/src/lib/Components/Gene/Biography.tsx
+++ b/src/lib/Components/Gene/Biography.tsx
@@ -48,11 +48,10 @@ const styles = StyleSheet.create({
   },
 })
 
-export default createFragmentContainer(
-  Biography,
-  graphql`
+export default createFragmentContainer(Biography, {
+  gene: graphql`
     fragment Biography_gene on Gene {
       description
     }
-  `
-)
+  `,
+})

--- a/src/lib/Components/Gene/Header.tsx
+++ b/src/lib/Components/Gene/Header.tsx
@@ -143,13 +143,12 @@ const styles = StyleSheet.create<Styles>({
   },
 })
 
-export default createFragmentContainer(
-  Header,
-  graphql`
+export default createFragmentContainer(Header, {
+  gene: graphql`
     fragment Header_gene on Gene {
       _id
       id
       name
     }
-  `
-)
+  `,
+})

--- a/src/lib/Components/Home/ArtistRails/ArtistCard.tsx
+++ b/src/lib/Components/Home/ArtistRails/ArtistCard.tsx
@@ -207,9 +207,8 @@ const styles = StyleSheet.create<Styles>({
   },
 })
 
-const ArtistCardContainer = createFragmentContainer(
-  ArtistCard,
-  graphql`
+const ArtistCardContainer = createFragmentContainer(ArtistCard, {
+  artist: graphql`
     fragment ArtistCard_artist on Artist {
       id
       _id
@@ -221,8 +220,8 @@ const ArtistCardContainer = createFragmentContainer(
         url(version: "large")
       }
     }
-  `
-)
+  `,
+})
 
 export interface ArtistCardResponse {
   id: string

--- a/src/lib/Components/Home/ArtistRails/ArtistRail.tsx
+++ b/src/lib/Components/Home/ArtistRails/ArtistRail.tsx
@@ -248,9 +248,8 @@ function suggestedArtistQuery(artistID: string): string {
   `
 }
 
-export default createFragmentContainer(
-  ArtistRail,
-  graphql`
+export default createFragmentContainer(ArtistRail, {
+  rail: graphql`
     fragment ArtistRail_rail on HomePageArtistModule {
       __id
       key
@@ -260,5 +259,5 @@ export default createFragmentContainer(
         ...ArtistCard_artist
       }
     }
-  `
-)
+  `,
+})

--- a/src/lib/Components/Home/ArtworkRails/ArtworkRail.tsx
+++ b/src/lib/Components/Home/ArtworkRails/ArtworkRail.tsx
@@ -299,42 +299,44 @@ const styles = StyleSheet.create<Styles>({
 
 export default createRefetchContainer(
   ArtworkRail,
-  graphql`
-    fragment ArtworkRail_rail on HomePageArtworkModule
-      @argumentDefinitions(fetchContent: { type: "Boolean!", defaultValue: false }) {
-      ...ArtworkRailHeader_rail
-      __id
-      key
-      params {
-        medium
-        price_range
-      }
-      context {
-        ... on HomePageModuleContextFollowedArtist {
-          artist {
+  {
+    rail: graphql`
+      fragment ArtworkRail_rail on HomePageArtworkModule
+        @argumentDefinitions(fetchContent: { type: "Boolean!", defaultValue: false }) {
+        ...ArtworkRailHeader_rail
+        __id
+        key
+        params {
+          medium
+          price_range
+        }
+        context {
+          ... on HomePageModuleContextFollowedArtist {
+            artist {
+              href
+            }
+          }
+          ... on HomePageModuleContextRelatedArtist {
+            artist {
+              href
+            }
+          }
+          ... on HomePageModuleContextFair {
+            href
+          }
+          ... on HomePageModuleContextGene {
+            href
+          }
+          ... on HomePageModuleContextSale {
             href
           }
         }
-        ... on HomePageModuleContextRelatedArtist {
-          artist {
-            href
-          }
-        }
-        ... on HomePageModuleContextFair {
-          href
-        }
-        ... on HomePageModuleContextGene {
-          href
-        }
-        ... on HomePageModuleContextSale {
-          href
+        results @include(if: $fetchContent) {
+          ...GenericGrid_artworks
         }
       }
-      results @include(if: $fetchContent) {
-        ...GenericGrid_artworks
-      }
-    }
-  `,
+    `,
+  },
   graphql`
     query ArtworkRailRefetchQuery($__id: ID!, $fetchContent: Boolean!) {
       node(__id: $__id) {

--- a/src/lib/Components/Home/ArtworkRails/ArtworkRailHeader.tsx
+++ b/src/lib/Components/Home/ArtworkRails/ArtworkRailHeader.tsx
@@ -149,9 +149,8 @@ const styles = StyleSheet.create<Styles>({
   },
 })
 
-export default createFragmentContainer(
-  ArtworkRailHeader,
-  graphql`
+export default createFragmentContainer(ArtworkRailHeader, {
+  rail: graphql`
     fragment ArtworkRailHeader_rail on HomePageArtworkModule {
       title
       key
@@ -166,5 +165,5 @@ export default createFragmentContainer(
         }
       }
     }
-  `
-)
+  `,
+})

--- a/src/lib/Components/Home/HeroUnits.tsx
+++ b/src/lib/Components/Home/HeroUnits.tsx
@@ -89,9 +89,8 @@ class HeroUnits extends React.Component<Props, State> {
   }
 }
 
-export default createFragmentContainer(
-  HeroUnits,
-  graphql`
+export default createFragmentContainer(HeroUnits, {
+  hero_units: graphql`
     fragment HeroUnits_hero_units on HomePageHeroUnit @relay(plural: true) {
       __id
       href
@@ -100,5 +99,5 @@ export default createFragmentContainer(
       narrow_image_url: background_image_url(version: NARROW)
       wide_image_url: background_image_url(version: WIDE)
     }
-  `
-)
+  `,
+})

--- a/src/lib/Components/Inbox/ActiveBids/ActiveBid.tsx
+++ b/src/lib/Components/Inbox/ActiveBids/ActiveBid.tsx
@@ -150,9 +150,8 @@ class ActiveBid extends React.Component<Props, State> {
   }
 }
 
-export default createFragmentContainer(
-  ActiveBid,
-  graphql`
+export default createFragmentContainer(ActiveBid, {
+  bid: graphql`
     fragment ActiveBid_bid on LotStanding {
       is_leading_bidder
       sale {
@@ -183,5 +182,5 @@ export default createFragmentContainer(
         }
       }
     }
-  `
-)
+  `,
+})

--- a/src/lib/Components/Inbox/Conversations/ConversationSnippet.tsx
+++ b/src/lib/Components/Inbox/Conversations/ConversationSnippet.tsx
@@ -174,9 +174,8 @@ export class ConversationSnippet extends React.Component<Props> {
   }
 }
 
-export default createFragmentContainer(
-  ConversationSnippet,
-  graphql`
+export default createFragmentContainer(ConversationSnippet, {
+  conversation: graphql`
     fragment ConversationSnippet_conversation on Conversation {
       id
       to {
@@ -208,5 +207,5 @@ export default createFragmentContainer(
         }
       }
     }
-  `
-)
+  `,
+})

--- a/src/lib/Components/Inbox/Conversations/Message.tsx
+++ b/src/lib/Components/Inbox/Conversations/Message.tsx
@@ -198,9 +198,8 @@ export class Message extends React.Component<Props> {
   }
 }
 
-export default createFragmentContainer(
-  Message,
-  graphql`
+export default createFragmentContainer(Message, {
+  message: graphql`
     fragment Message_message on Message {
       body
       created_at
@@ -222,5 +221,5 @@ export default createFragmentContainer(
         ...PDFPreview_attachment
       }
     }
-  `
-)
+  `,
+})

--- a/src/lib/Components/Inbox/Conversations/Preview/ArtworkPreview.tsx
+++ b/src/lib/Components/Inbox/Conversations/Preview/ArtworkPreview.tsx
@@ -98,9 +98,8 @@ export class ArtworkPreview extends React.Component<Props> {
   }
 }
 
-export default createFragmentContainer(
-  ArtworkPreview,
-  graphql`
+export default createFragmentContainer(ArtworkPreview, {
+  artwork: graphql`
     fragment ArtworkPreview_artwork on Artwork {
       id
       _id
@@ -111,5 +110,5 @@ export default createFragmentContainer(
         url
       }
     }
-  `
-)
+  `,
+})

--- a/src/lib/Components/Inbox/Conversations/Preview/Attachment/AttachmentPreview.tsx
+++ b/src/lib/Components/Inbox/Conversations/Preview/Attachment/AttachmentPreview.tsx
@@ -38,11 +38,10 @@ export class AttachmentPreview extends React.Component<Props> {
   }
 }
 
-export default createFragmentContainer(
-  AttachmentPreview,
-  graphql`
+export default createFragmentContainer(AttachmentPreview, {
+  attachment: graphql`
     fragment AttachmentPreview_attachment on Attachment {
       id
     }
-  `
-)
+  `,
+})

--- a/src/lib/Components/Inbox/Conversations/Preview/Attachment/ImagePreview.tsx
+++ b/src/lib/Components/Inbox/Conversations/Preview/Attachment/ImagePreview.tsx
@@ -22,12 +22,11 @@ export const ImagePreview: React.SFC<Props> = ({ attachment, onSelected }) => (
   </AttachmentPreview>
 )
 
-export default createFragmentContainer(
-  ImagePreview,
-  graphql`
+export default createFragmentContainer(ImagePreview, {
+  attachment: graphql`
     fragment ImagePreview_attachment on Attachment {
       download_url
       ...AttachmentPreview_attachment
     }
-  `
-)
+  `,
+})

--- a/src/lib/Components/Inbox/Conversations/Preview/Attachment/PDFPreview.tsx
+++ b/src/lib/Components/Inbox/Conversations/Preview/Attachment/PDFPreview.tsx
@@ -46,12 +46,11 @@ export const PDFPreview: React.SFC<Props> = ({ attachment, onSelected }) => (
   </AttachmentPreview>
 )
 
-export default createFragmentContainer(
-  PDFPreview,
-  graphql`
+export default createFragmentContainer(PDFPreview, {
+  attachment: graphql`
     fragment PDFPreview_attachment on Attachment {
       file_name
       ...AttachmentPreview_attachment
     }
-  `
-)
+  `,
+})

--- a/src/lib/Components/Inbox/Conversations/Preview/InvoicePreview.tsx
+++ b/src/lib/Components/Inbox/Conversations/Preview/InvoicePreview.tsx
@@ -172,14 +172,16 @@ export class InvoicePreview extends React.Component<Props, State> {
 
 export default createRefetchContainer(
   InvoicePreview,
-  graphql`
-    fragment InvoicePreview_invoice on Invoice {
-      payment_url
-      state
-      total
-      lewitt_invoice_id
-    }
-  `,
+  {
+    invoice: graphql`
+      fragment InvoicePreview_invoice on Invoice {
+        payment_url
+        state
+        total
+        lewitt_invoice_id
+      }
+    `,
+  },
   graphql`
     query InvoicePreviewRefetchQuery($conversationId: String!, $invoiceId: String!) {
       me {

--- a/src/lib/Components/Inbox/Conversations/Preview/ShowPreview.tsx
+++ b/src/lib/Components/Inbox/Conversations/Preview/ShowPreview.tsx
@@ -86,9 +86,8 @@ export class ShowPreview extends React.Component<Props> {
   }
 }
 
-export default createFragmentContainer(
-  ShowPreview,
-  graphql`
+export default createFragmentContainer(ShowPreview, {
+  show: graphql`
     fragment ShowPreview_show on Show {
       id
       _id
@@ -105,5 +104,5 @@ export default createFragmentContainer(
         }
       }
     }
-  `
-)
+  `,
+})

--- a/src/lib/Components/LocationMap/index.tsx
+++ b/src/lib/Components/LocationMap/index.tsx
@@ -173,9 +173,8 @@ export class LocationMap extends React.Component<Props> {
   }
 }
 
-export const LocationMapContainer = createFragmentContainer(
-  LocationMap,
-  graphql`
+export const LocationMapContainer = createFragmentContainer(LocationMap, {
+  location: graphql`
     fragment LocationMap_location on Location {
       __id
       id
@@ -205,5 +204,5 @@ export const LocationMapContainer = createFragmentContainer(
         }
       }
     }
-  `
-)
+  `,
+})

--- a/src/lib/Components/RelatedArtists/RelatedArtist.tsx
+++ b/src/lib/Components/RelatedArtists/RelatedArtist.tsx
@@ -75,9 +75,8 @@ const styles = StyleSheet.create<Styles>({
   },
 })
 
-export default createFragmentContainer(
-  RelatedArtist,
-  graphql`
+export default createFragmentContainer(RelatedArtist, {
+  artist: graphql`
     fragment RelatedArtist_artist on Artist {
       href
       name
@@ -89,5 +88,5 @@ export default createFragmentContainer(
         url(version: "large")
       }
     }
-  `
-)
+  `,
+})

--- a/src/lib/Components/RelatedArtists/index.tsx
+++ b/src/lib/Components/RelatedArtists/index.tsx
@@ -108,12 +108,11 @@ const styles = StyleSheet.create<Styles>({
   },
 })
 
-export default createFragmentContainer(
-  RelatedArtists,
-  graphql`
+export default createFragmentContainer(RelatedArtists, {
+  artists: graphql`
     fragment RelatedArtists_artists on Artist @relay(plural: true) {
       __id
       ...RelatedArtist_artist
     }
-  `
-)
+  `,
+})

--- a/src/lib/Components/Sale/Header.tsx
+++ b/src/lib/Components/Sale/Header.tsx
@@ -34,17 +34,16 @@ class Header extends React.Component<Props> {
   }
 }
 
-export default createFragmentContainer(
-  Header,
-  graphql`
+export default createFragmentContainer(Header, {
+  sale: graphql`
     fragment Header_sale on Sale {
       name
       cover_image {
         href
       }
     }
-  `
-)
+  `,
+})
 
 const isPad = Dimensions.get("window").width > 700
 

--- a/src/lib/Components/Show/ShowArtists.tsx
+++ b/src/lib/Components/Show/ShowArtists.tsx
@@ -51,9 +51,8 @@ export class ShowArtists extends React.Component<Props, State> {
   }
 }
 
-export const ShowArtistsContainer = createFragmentContainer(
-  ShowArtists,
-  graphql`
+export const ShowArtistsContainer = createFragmentContainer(ShowArtists, {
+  show: graphql`
     fragment ShowArtists_show on Show {
       _id
       id
@@ -66,5 +65,5 @@ export const ShowArtistsContainer = createFragmentContainer(
         }
       }
     }
-  `
-)
+  `,
+})

--- a/src/lib/Components/Show/ShowArtistsPreview.tsx
+++ b/src/lib/Components/Show/ShowArtistsPreview.tsx
@@ -65,9 +65,8 @@ export class ShowArtistsPreview extends React.Component<Props> {
   }
 }
 
-export const ShowArtistsPreviewContainer = createFragmentContainer(
-  ShowArtistsPreview,
-  graphql`
+export const ShowArtistsPreviewContainer = createFragmentContainer(ShowArtistsPreview, {
+  show: graphql`
     fragment ShowArtistsPreview_show on Show {
       _id
       id
@@ -88,5 +87,5 @@ export const ShowArtistsPreviewContainer = createFragmentContainer(
         ...ArtistListItem_artist
       }
     }
-  `
-)
+  `,
+})

--- a/src/lib/Components/Show/ShowArtworks.tsx
+++ b/src/lib/Components/Show/ShowArtworks.tsx
@@ -51,25 +51,27 @@ export class ShowArtworks extends React.Component<Props, State> {
 
 export const ShowArtworksContainer = createRefetchContainer(
   ShowArtworks,
-  graphql`
-    fragment ShowArtworks_show on Show
-      @argumentDefinitions(
-        medium: { type: "String", defaultValue: "*" }
-        price_range: { type: "String", defaultValue: "*-*" }
-      ) {
-      __id
-      id
-      _id
-      filteredArtworks(
-        size: 0
-        medium: $medium
-        price_range: $price_range
-        aggregations: [MEDIUM, PRICE_RANGE, TOTAL]
-      ) {
-        ...FilteredInfiniteScrollGrid_filteredArtworks
+  {
+    show: graphql`
+      fragment ShowArtworks_show on Show
+        @argumentDefinitions(
+          medium: { type: "String", defaultValue: "*" }
+          price_range: { type: "String", defaultValue: "*-*" }
+        ) {
+        __id
+        id
+        _id
+        filteredArtworks(
+          size: 0
+          medium: $medium
+          price_range: $price_range
+          aggregations: [MEDIUM, PRICE_RANGE, TOTAL]
+        ) {
+          ...FilteredInfiniteScrollGrid_filteredArtworks
+        }
       }
-    }
-  `,
+    `,
+  },
   graphql`
     query ShowArtworksRefetchQuery($showID: String!, $medium: String, $price_range: String) {
       show(id: $showID) {

--- a/src/lib/Components/WorksForYou/Notification.tsx
+++ b/src/lib/Components/WorksForYou/Notification.tsx
@@ -98,9 +98,8 @@ const styles = StyleSheet.create<Styles>({
   },
 })
 
-export default createFragmentContainer(
-  Notification,
-  graphql`
+export default createFragmentContainer(Notification, {
+  notification: graphql`
     fragment Notification_notification on FollowedArtistsArtworksGroup {
       summary
       artists
@@ -116,5 +115,5 @@ export default createFragmentContainer(
         }
       }
     }
-  `
-)
+  `,
+})

--- a/src/lib/Containers/Artist.tsx
+++ b/src/lib/Containers/Artist.tsx
@@ -158,9 +158,8 @@ const styles = StyleSheet.create<Styles>({
   },
 })
 
-export default createFragmentContainer(
-  Artist,
-  graphql`
+export default createFragmentContainer(Artist, {
+  artist: graphql`
     fragment Artist_artist on Artist {
       _id
       id
@@ -176,5 +175,5 @@ export default createFragmentContainer(
       ...Shows_artist
       ...Artworks_artist
     }
-  `
-)
+  `,
+})

--- a/src/lib/Containers/Gene.tsx
+++ b/src/lib/Containers/Gene.tsx
@@ -350,37 +350,39 @@ const styles = StyleSheet.create<Styles>({
 
 export default createRefetchContainer(
   Gene,
-  graphql`
-    fragment Gene_gene on Gene
-      @argumentDefinitions(
-        sort: { type: "String", defaultValue: "-partner_updated_at" }
-        medium: { type: "String", defaultValue: "*" }
-        price_range: { type: "String", defaultValue: "*-*" }
-      ) {
-      ...Header_gene
-      ...About_gene
+  {
+    gene: graphql`
+      fragment Gene_gene on Gene
+        @argumentDefinitions(
+          sort: { type: "String", defaultValue: "-partner_updated_at" }
+          medium: { type: "String", defaultValue: "*" }
+          price_range: { type: "String", defaultValue: "*-*" }
+        ) {
+        ...Header_gene
+        ...About_gene
 
-      filtered_artworks(
-        size: 0
-        medium: $medium
-        price_range: $price_range
-        sort: $sort
-        aggregations: [MEDIUM, PRICE_RANGE, TOTAL]
-        for_sale: true
-      ) {
-        total
-        aggregations {
-          slice
-          counts {
-            id
-            name
-            count
+        filtered_artworks(
+          size: 0
+          medium: $medium
+          price_range: $price_range
+          sort: $sort
+          aggregations: [MEDIUM, PRICE_RANGE, TOTAL]
+          for_sale: true
+        ) {
+          total
+          aggregations {
+            slice
+            counts {
+              id
+              name
+              count
+            }
           }
+          ...GeneArtworksGrid_filtered_artworks @arguments(sort: $sort)
         }
-        ...GeneArtworksGrid_filtered_artworks @arguments(sort: $sort)
       }
-    }
-  `,
+    `,
+  },
   graphql`
     query GeneRefetchQuery($geneID: String!, $sort: String, $medium: String, $price_range: String) {
       gene(id: $geneID) {

--- a/src/lib/Containers/Inquiry.tsx
+++ b/src/lib/Containers/Inquiry.tsx
@@ -239,9 +239,8 @@ export class Inquiry extends React.Component<Props, State> {
   }
 }
 
-export default createFragmentContainer(
-  Inquiry,
-  graphql`
+export default createFragmentContainer(Inquiry, {
+  artwork: graphql`
     fragment Inquiry_artwork on Artwork {
       _id
       id
@@ -251,5 +250,5 @@ export default createFragmentContainer(
       }
       ...ArtworkPreview_artwork
     }
-  `
-)
+  `,
+})

--- a/src/lib/Containers/Sale.tsx
+++ b/src/lib/Containers/Sale.tsx
@@ -158,14 +158,16 @@ const styles = StyleSheet.create<Styles>({
 
 export default createRefetchContainer(
   Sale,
-  graphql`
-    fragment Sale_sale on Sale {
-      id
-      name
-      ...Header_sale
-      ...SaleArtworksGrid_sale
-    }
-  `,
+  {
+    sale: graphql`
+      fragment Sale_sale on Sale {
+        id
+        name
+        ...Header_sale
+        ...SaleArtworksGrid_sale
+      }
+    `,
+  },
   graphql`
     query SaleRefetchQuery($saleID: String!) {
       sale(id: $saleID) {

--- a/src/lib/Scenes/City/CitySavedList.tsx
+++ b/src/lib/Scenes/City/CitySavedList.tsx
@@ -76,48 +76,50 @@ class CitySavedList extends React.Component<Props, State> {
 
 export default createPaginationContainer(
   CitySavedList,
-  graphql`
-    fragment CitySavedList_viewer on Viewer
-      @argumentDefinitions(count: { type: "Int", defaultValue: 20 }, cursor: { type: "String", defaultValue: "" }) {
-      city(slug: $citySlug) {
-        name
-      }
-      me {
-        followsAndSaves {
-          shows(first: $count, status: RUNNING_AND_UPCOMING, city: $citySlug, after: $cursor)
-            @connection(key: "CitySavedList_shows") {
-            edges {
-              node {
-                id
-                _id
-                __id
-                name
-                isStubShow
-                status
-                href
-                is_followed
-                isStubShow
-                exhibition_period
-                cover_image {
-                  url
-                }
-                location {
-                  coordinates {
-                    lat
-                    lng
+  {
+    viewer: graphql`
+      fragment CitySavedList_viewer on Viewer
+        @argumentDefinitions(count: { type: "Int", defaultValue: 20 }, cursor: { type: "String", defaultValue: "" }) {
+        city(slug: $citySlug) {
+          name
+        }
+        me {
+          followsAndSaves {
+            shows(first: $count, status: RUNNING_AND_UPCOMING, city: $citySlug, after: $cursor)
+              @connection(key: "CitySavedList_shows") {
+              edges {
+                node {
+                  id
+                  _id
+                  __id
+                  name
+                  isStubShow
+                  status
+                  href
+                  is_followed
+                  isStubShow
+                  exhibition_period
+                  cover_image {
+                    url
                   }
-                }
-                type
-                start_at
-                end_at
-                partner {
-                  ... on Partner {
-                    name
-                    type
-                    profile {
-                      # This is only used for stubbed shows
-                      image {
-                        url(version: "square")
+                  location {
+                    coordinates {
+                      lat
+                      lng
+                    }
+                  }
+                  type
+                  start_at
+                  end_at
+                  partner {
+                    ... on Partner {
+                      name
+                      type
+                      profile {
+                        # This is only used for stubbed shows
+                        image {
+                          url(version: "square")
+                        }
                       }
                     }
                   }
@@ -127,8 +129,8 @@ export default createPaginationContainer(
           }
         }
       }
-    }
-  `,
+    `,
+  },
   {
     direction: "forward",
     getConnectionFromProps(props) {

--- a/src/lib/Scenes/Fair/Components/ArtworksPreview.tsx
+++ b/src/lib/Scenes/Fair/Components/ArtworksPreview.tsx
@@ -41,9 +41,8 @@ export class ArtworksPreview extends React.Component<Props> {
   }
 }
 
-export const ArtworksPreviewContainer = createFragmentContainer(
-  ArtworksPreview,
-  graphql`
+export const ArtworksPreviewContainer = createFragmentContainer(ArtworksPreview, {
+  fair: graphql`
     fragment ArtworksPreview_fair on Fair {
       id
       __id
@@ -60,5 +59,5 @@ export const ArtworksPreviewContainer = createFragmentContainer(
         }
       }
     }
-  `
-)
+  `,
+})

--- a/src/lib/Scenes/Fair/Components/FairBoothHeader.tsx
+++ b/src/lib/Scenes/Fair/Components/FairBoothHeader.tsx
@@ -166,9 +166,8 @@ export class FairBoothHeader extends React.Component<Props, State> {
   }
 }
 
-export const FairBoothHeaderContainer = createFragmentContainer(
-  FairBoothHeader,
-  graphql`
+export const FairBoothHeaderContainer = createFragmentContainer(FairBoothHeader, {
+  show: graphql`
     fragment FairBoothHeader_show on Show {
       fair {
         name
@@ -195,5 +194,5 @@ export const FairBoothHeaderContainer = createFragmentContainer(
         display
       }
     }
-  `
-)
+  `,
+})

--- a/src/lib/Scenes/Fair/Components/FairBoothPreview/index.tsx
+++ b/src/lib/Scenes/Fair/Components/FairBoothPreview/index.tsx
@@ -170,9 +170,8 @@ export class FairBoothPreview extends React.Component<Props, State> {
   }
 }
 
-export const FairBoothPreviewContainer = createFragmentContainer(
-  FairBoothPreview,
-  graphql`
+export const FairBoothPreviewContainer = createFragmentContainer(FairBoothPreview, {
+  show: graphql`
     fragment FairBoothPreview_show on Show {
       id
       _id
@@ -211,5 +210,5 @@ export const FairBoothPreviewContainer = createFragmentContainer(
         }
       }
     }
-  `
-)
+  `,
+})

--- a/src/lib/Scenes/Fair/Components/FairHeader/index.tsx
+++ b/src/lib/Scenes/Fair/Components/FairHeader/index.tsx
@@ -158,9 +158,8 @@ export class FairHeader extends React.Component<Props, State> {
   }
 }
 
-export const FairHeaderContainer = createFragmentContainer(
-  FairHeader,
-  graphql`
+export const FairHeaderContainer = createFragmentContainer(FairHeader, {
+  fair: graphql`
     fragment FairHeader_fair on Fair {
       id
       _id
@@ -233,5 +232,5 @@ export const FairHeaderContainer = createFragmentContainer(
       end_at
       exhibition_period
     }
-  `
-)
+  `,
+})

--- a/src/lib/Scenes/Fair/Fair.tsx
+++ b/src/lib/Scenes/Fair/Fair.tsx
@@ -20,9 +20,8 @@ export class Fair extends React.Component<Props> {
   }
 }
 
-export const FairContainer = createFragmentContainer(
-  Fair,
-  graphql`
+export const FairContainer = createFragmentContainer(Fair, {
+  fair: graphql`
     fragment Fair_fair on Fair {
       id
       __id
@@ -34,5 +33,5 @@ export const FairContainer = createFragmentContainer(
       about
       ticketsLink
     }
-  `
-)
+  `,
+})

--- a/src/lib/Scenes/Fair/Screens/FairArtworks.tsx
+++ b/src/lib/Scenes/Fair/Screens/FairArtworks.tsx
@@ -54,25 +54,27 @@ export class FairArtworks extends React.Component<Props, State> {
 
 export const FairArtworksContainer = createRefetchContainer(
   FairArtworks,
-  graphql`
-    fragment FairArtworks_fair on Fair
-      @argumentDefinitions(
-        medium: { type: "String", defaultValue: "*" }
-        price_range: { type: "String", defaultValue: "*-*" }
-      ) {
-      __id
-      _id
-      id
-      artworks: filteredArtworks(
-        size: 0
-        medium: $medium
-        price_range: $price_range
-        aggregations: [MEDIUM, PRICE_RANGE, TOTAL]
-      ) {
-        ...FilteredInfiniteScrollGrid_filteredArtworks
+  {
+    fair: graphql`
+      fragment FairArtworks_fair on Fair
+        @argumentDefinitions(
+          medium: { type: "String", defaultValue: "*" }
+          price_range: { type: "String", defaultValue: "*-*" }
+        ) {
+        __id
+        _id
+        id
+        artworks: filteredArtworks(
+          size: 0
+          medium: $medium
+          price_range: $price_range
+          aggregations: [MEDIUM, PRICE_RANGE, TOTAL]
+        ) {
+          ...FilteredInfiniteScrollGrid_filteredArtworks
+        }
       }
-    }
-  `,
+    `,
+  },
   graphql`
     query FairArtworksRefetchQuery($fairID: String!, $medium: String, $price_range: String) {
       fair(id: $fairID) {

--- a/src/lib/Scenes/Fair/Screens/FairBooth.tsx
+++ b/src/lib/Scenes/Fair/Screens/FairBooth.tsx
@@ -104,9 +104,8 @@ export class FairBooth extends React.Component<Props, State> {
   }
 }
 
-export const FairBoothContainer = createFragmentContainer(
-  FairBooth,
-  graphql`
+export const FairBoothContainer = createFragmentContainer(FairBooth, {
+  show: graphql`
     fragment FairBooth_show on Show {
       id
       _id
@@ -116,8 +115,8 @@ export const FairBoothContainer = createFragmentContainer(
       ...ShowArtists_show
       ...ShowArtworks_show
     }
-  `
-)
+  `,
+})
 
 export const FairBoothRenderer: React.SFC<{ showID: string }> = ({ showID }) => (
   <QueryRenderer<FairBoothQuery>

--- a/src/lib/Scenes/Home/Components/ForYou/Components/ArtworkCarousel.tsx
+++ b/src/lib/Scenes/Home/Components/ForYou/Components/ArtworkCarousel.tsx
@@ -267,9 +267,8 @@ const styles = StyleSheet.create<Styles>({
   },
 })
 
-export default createFragmentContainer(
-  ArtworkCarousel,
-  graphql`
+export default createFragmentContainer(ArtworkCarousel, {
+  rail: graphql`
     fragment ArtworkCarousel_rail on HomePageArtworkModule {
       ...ArtworkCarouselHeader_rail
       __id
@@ -303,5 +302,5 @@ export default createFragmentContainer(
         ...GenericGrid_artworks
       }
     }
-  `
-)
+  `,
+})

--- a/src/lib/Scenes/Home/Components/ForYou/Components/ArtworkCarouselHeader.tsx
+++ b/src/lib/Scenes/Home/Components/ForYou/Components/ArtworkCarouselHeader.tsx
@@ -159,9 +159,8 @@ const styles = StyleSheet.create<Styles>({
   },
 })
 
-export default createFragmentContainer(
-  ArtworkCarouselHeader,
-  graphql`
+export default createFragmentContainer(ArtworkCarouselHeader, {
+  rail: graphql`
     fragment ArtworkCarouselHeader_rail on HomePageArtworkModule {
       title
       key
@@ -211,5 +210,5 @@ export default createFragmentContainer(
       #   }
       # }
     }
-  `
-)
+  `,
+})

--- a/src/lib/Scenes/Home/Components/ForYou/Components/FairsRail.tsx
+++ b/src/lib/Scenes/Home/Components/ForYou/Components/FairsRail.tsx
@@ -89,9 +89,8 @@ export class FairsRail extends Component<Props, null> {
   }
 }
 
-export default createFragmentContainer(
-  FairsRail,
-  graphql`
+export default createFragmentContainer(FairsRail, {
+  fairs_module: graphql`
     fragment FairsRail_fairs_module on HomePageFairsModule {
       results {
         id
@@ -105,5 +104,5 @@ export default createFragmentContainer(
         }
       }
     }
-  `
-)
+  `,
+})

--- a/src/lib/Scenes/Home/Components/ForYou/index.tsx
+++ b/src/lib/Scenes/Home/Components/ForYou/index.tsx
@@ -120,38 +120,40 @@ export class ForYou extends React.Component<Props, State> {
 
 export default createRefetchContainer(
   ForYou,
-  graphql`
-    fragment ForYou_forYou on HomePage {
-      artwork_modules(
-        max_rails: -1
-        max_followed_gene_rails: -1
-        order: [
-          ACTIVE_BIDS
-          RECENTLY_VIEWED_WORKS
-          RECOMMENDED_WORKS
-          FOLLOWED_ARTISTS
-          RELATED_ARTISTS
-          FOLLOWED_GALLERIES
-          SAVED_WORKS
-          LIVE_AUCTIONS
-          CURRENT_FAIRS
-          FOLLOWED_GENES
-          GENERIC_GENES
-        ]
-        exclude: [FOLLOWED_ARTISTS]
-      ) {
-        __id
-        ...ArtworkCarousel_rail
+  {
+    forYou: graphql`
+      fragment ForYou_forYou on HomePage {
+        artwork_modules(
+          max_rails: -1
+          max_followed_gene_rails: -1
+          order: [
+            ACTIVE_BIDS
+            RECENTLY_VIEWED_WORKS
+            RECOMMENDED_WORKS
+            FOLLOWED_ARTISTS
+            RELATED_ARTISTS
+            FOLLOWED_GALLERIES
+            SAVED_WORKS
+            LIVE_AUCTIONS
+            CURRENT_FAIRS
+            FOLLOWED_GENES
+            GENERIC_GENES
+          ]
+          exclude: [FOLLOWED_ARTISTS]
+        ) {
+          __id
+          ...ArtworkCarousel_rail
+        }
+        artist_modules {
+          __id
+          ...ArtistRail_rail
+        }
+        fairs_module {
+          ...FairsRail_fairs_module
+        }
       }
-      artist_modules {
-        __id
-        ...ArtistRail_rail
-      }
-      fairs_module {
-        ...FairsRail_fairs_module
-      }
-    }
-  `,
+    `,
+  },
   graphql`
     query ForYouRefetchQuery {
       forYou: home_page {

--- a/src/lib/Scenes/Home/Components/Sales/Components/LotsByFollowedArtists.tsx
+++ b/src/lib/Scenes/Home/Components/Sales/Components/LotsByFollowedArtists.tsx
@@ -57,31 +57,33 @@ export class LotsByFollowedArtists extends Component<Props, State> {
 
 export default createPaginationContainer(
   LotsByFollowedArtists,
-  graphql`
-    fragment LotsByFollowedArtists_viewer on Viewer
-      @argumentDefinitions(count: { type: "Int", defaultValue: 10 }, cursor: { type: "String" }) {
-      sale_artworks: sale_artworks(
-        first: $count
-        after: $cursor
-        live_sale: true
-        is_auction: true
-        include_artworks_by_followed_artists: true
-      ) @connection(key: "LotsByFollowedArtists_sale_artworks") {
-        pageInfo {
-          endCursor
-          hasNextPage
-        }
-        edges {
-          cursor
-          node {
-            artwork {
-              ...GenericGrid_artworks
+  {
+    viewer: graphql`
+      fragment LotsByFollowedArtists_viewer on Viewer
+        @argumentDefinitions(count: { type: "Int", defaultValue: 10 }, cursor: { type: "String" }) {
+        sale_artworks: sale_artworks(
+          first: $count
+          after: $cursor
+          live_sale: true
+          is_auction: true
+          include_artworks_by_followed_artists: true
+        ) @connection(key: "LotsByFollowedArtists_sale_artworks") {
+          pageInfo {
+            endCursor
+            hasNextPage
+          }
+          edges {
+            cursor
+            node {
+              artwork {
+                ...GenericGrid_artworks
+              }
             }
           }
         }
       }
-    }
-  `,
+    `,
+  },
   {
     getConnectionFromProps: ({ viewer }) => viewer && (viewer.sale_artworks as ConnectionData),
     getFragmentVariables: (prevVars, totalCount) => ({ ...prevVars, count: totalCount }),

--- a/src/lib/Scenes/Home/Components/Sales/index.tsx
+++ b/src/lib/Scenes/Home/Components/Sales/index.tsx
@@ -91,16 +91,18 @@ class Sales extends React.Component<Props, State> {
 
 export default createRefetchContainer(
   Sales,
-  graphql`
-    fragment Sales_viewer on Viewer {
-      sales(live: true, is_auction: true, size: 100, sort: TIMELY_AT_NAME_ASC) {
-        ...SaleListItem_sale
-        href
-        live_start_at
+  {
+    viewer: graphql`
+      fragment Sales_viewer on Viewer {
+        sales(live: true, is_auction: true, size: 100, sort: TIMELY_AT_NAME_ASC) {
+          ...SaleListItem_sale
+          href
+          live_start_at
+        }
+        ...LotsByFollowedArtists_viewer
       }
-      ...LotsByFollowedArtists_viewer
-    }
-  `,
+    `,
+  },
   graphql`
     query SalesQuery {
       viewer {

--- a/src/lib/Scenes/Map/GlobalMap.tsx
+++ b/src/lib/Scenes/Map/GlobalMap.tsx
@@ -777,9 +777,8 @@ const SelectedCluster = styled(Flex)`
   align-items: center;
 `
 
-export const GlobalMapContainer = createFragmentContainer(
-  GlobalMap,
-  graphql`
+export const GlobalMapContainer = createFragmentContainer(GlobalMap, {
+  viewer: graphql`
     fragment GlobalMap_viewer on Viewer @argumentDefinitions(citySlug: { type: "String!" }, maxInt: { type: "Int!" }) {
       city(slug: $citySlug) {
         name
@@ -953,5 +952,5 @@ export const GlobalMapContainer = createFragmentContainer(
         }
       }
     }
-  `
-)
+  `,
+})

--- a/src/lib/Scenes/Settings/MyProfile.tsx
+++ b/src/lib/Scenes/Settings/MyProfile.tsx
@@ -124,12 +124,11 @@ export class MyProfile extends React.Component<Props> {
   }
 }
 
-export default createFragmentContainer(
-  MyProfile,
-  graphql`
+export default createFragmentContainer(MyProfile, {
+  me: graphql`
     fragment MyProfile_me on Me {
       name
       initials
     }
-  `
-)
+  `,
+})

--- a/src/lib/Scenes/Show/Components/ShowEventSection.tsx
+++ b/src/lib/Scenes/Show/Components/ShowEventSection.tsx
@@ -56,14 +56,13 @@ const ShowEventSection: React.SFC<Props> = ({ event: { start_at, end_at, event_t
   </>
 )
 
-export const ShowEventSectionContainer = createFragmentContainer(
-  ShowEventSection,
-  graphql`
+export const ShowEventSectionContainer = createFragmentContainer(ShowEventSection, {
+  event: graphql`
     fragment ShowEventSection_event on PartnerShowEventType {
       event_type
       description
       start_at
       end_at
     }
-  `
-)
+  `,
+})

--- a/src/lib/Scenes/Show/Components/ShowHeader/ShowHeader.tsx
+++ b/src/lib/Scenes/Show/Components/ShowHeader/ShowHeader.tsx
@@ -202,9 +202,8 @@ export class ShowHeader extends React.Component<Props, State> {
   }
 }
 
-export const ShowHeaderContainer = createFragmentContainer(
-  ShowHeader,
-  graphql`
+export const ShowHeaderContainer = createFragmentContainer(ShowHeader, {
+  show: graphql`
     fragment ShowHeader_show on Show {
       id
       _id
@@ -246,5 +245,5 @@ export const ShowHeaderContainer = createFragmentContainer(
         _id
       }
     }
-  `
-)
+  `,
+})

--- a/src/lib/Scenes/Show/Components/Shows/Components/ShowItem.tsx
+++ b/src/lib/Scenes/Show/Components/Shows/Components/ShowItem.tsx
@@ -76,9 +76,8 @@ export class ShowItem extends React.Component<Props> {
   }
 }
 
-export const ShowItemContainer = createFragmentContainer(
-  ShowItem,
-  graphql`
+export const ShowItemContainer = createFragmentContainer(ShowItem, {
+  show: graphql`
     fragment ShowItem_show on Show {
       _id
       id
@@ -95,5 +94,5 @@ export const ShowItemContainer = createFragmentContainer(
         }
       }
     }
-  `
-)
+  `,
+})

--- a/src/lib/Scenes/Show/Components/Shows/index.tsx
+++ b/src/lib/Scenes/Show/Components/Shows/index.tsx
@@ -29,9 +29,8 @@ export const Shows: React.SFC<Props> = ({ show }) => {
   )
 }
 
-export const ShowsContainer = createFragmentContainer(
-  Shows,
-  graphql`
+export const ShowsContainer = createFragmentContainer(Shows, {
+  show: graphql`
     fragment Shows_show on Show {
       nearbyShows(first: 20) {
         edges {
@@ -42,5 +41,5 @@ export const ShowsContainer = createFragmentContainer(
         }
       }
     }
-  `
-)
+  `,
+})

--- a/src/lib/Scenes/Show/Screens/Detail.tsx
+++ b/src/lib/Scenes/Show/Screens/Detail.tsx
@@ -192,9 +192,8 @@ function eventProps(actionName: Schema.ActionNames, actionType: Schema.ActionTyp
   })
 }
 
-export const DetailContainer = createFragmentContainer(
-  Detail,
-  graphql`
+export const DetailContainer = createFragmentContainer(Detail, {
+  show: graphql`
     fragment Detail_show on Show {
       _id
       id
@@ -243,5 +242,5 @@ export const DetailContainer = createFragmentContainer(
         }
       }
     }
-  `
-)
+  `,
+})

--- a/src/lib/Scenes/Show/Screens/MoreInfo.tsx
+++ b/src/lib/Scenes/Show/Screens/MoreInfo.tsx
@@ -151,9 +151,8 @@ export class MoreInfo extends React.Component<Props, State> {
   }
 }
 
-export const MoreInfoContainer = createFragmentContainer(
-  MoreInfo,
-  graphql`
+export const MoreInfoContainer = createFragmentContainer(MoreInfo, {
+  show: graphql`
     fragment MoreInfo_show on Show {
       _id
       id
@@ -171,5 +170,5 @@ export const MoreInfoContainer = createFragmentContainer(
         ...ShowEventSection_event
       }
     }
-  `
-)
+  `,
+})

--- a/src/lib/Scenes/Show/Show.tsx
+++ b/src/lib/Scenes/Show/Show.tsx
@@ -20,14 +20,13 @@ export class Show extends React.Component<Props> {
   }
 }
 
-export const ShowContainer = createFragmentContainer(
-  Show,
-  graphql`
+export const ShowContainer = createFragmentContainer(Show, {
+  show: graphql`
     fragment Show_show on Show {
       ...Detail_show
       ...MoreInfo_show
       ...ShowArtists_show
       ...ShowArtworks_show
     }
-  `
-)
+  `,
+})

--- a/src/lib/tests/__tests__/MockRelayRendererFixtures.tsx
+++ b/src/lib/tests/__tests__/MockRelayRendererFixtures.tsx
@@ -12,11 +12,13 @@ import renderWithLoadProgress from "../../utils/renderWithLoadProgress"
 
 const Metadata = createFragmentContainer(
   (props: { artworkMetadata: MockRelayRendererFixtures_artworkMetadata }) => <Text>{props.artworkMetadata.title}</Text>,
-  graphql`
-    fragment MockRelayRendererFixtures_artworkMetadata on Artwork {
-      title
-    }
-  `
+  {
+    artworkMetadata: graphql`
+      fragment MockRelayRendererFixtures_artworkMetadata on Artwork {
+        title
+      }
+    `,
+  }
 )
 
 export const Artwork = createFragmentContainer(
@@ -27,26 +29,30 @@ export const Artwork = createFragmentContainer(
       {props.artwork.artist && <ArtistQueryRenderer id={props.artwork.artist.id} />}
     </View>
   ),
-  graphql`
-    fragment MockRelayRendererFixtures_artwork on Artwork {
-      image {
-        url
+  {
+    artwork: graphql`
+      fragment MockRelayRendererFixtures_artwork on Artwork {
+        image {
+          url
+        }
+        artist {
+          id
+        }
+        ...MockRelayRendererFixtures_artworkMetadata
       }
-      artist {
-        id
-      }
-      ...MockRelayRendererFixtures_artworkMetadata
-    }
-  `
+    `,
+  }
 )
 
 const Artist = createFragmentContainer(
   (props: { artist: MockRelayRendererFixtures_artist }) => <Text>{props.artist.name}</Text>,
-  graphql`
-    fragment MockRelayRendererFixtures_artist on Artist {
-      name
-    }
-  `
+  {
+    artist: graphql`
+      fragment MockRelayRendererFixtures_artist on Artist {
+        name
+      }
+    `,
+  }
 )
 
 const ArtistQueryRenderer = (props: { id: string }) => (


### PR DESCRIPTION
Runs a jscodemod transform over all of our Relay code to deal with implicit prop assignment deprecation. See https://mobile.twitter.com/kassens/status/1116018336192548865 for more info. 

Related: https://github.com/artsy/reaction/pull/2289. 

**Details:**

Relay has deprecated implicit property assignment in GraphQL calls in favor of explicitness; e.g.,: 

```
graphql`
  fragment Foo_artist on Artist { ... }
`
```
Would automatically attach the response to an `artist` prop. Post codemod, this now looks like this: 

```
artist: graphql`
  fragment Foo_artist on Artist { ... }
`
```

#skip_new_tests