### PR TITLE
Removes yellow boxes, adds pull-to-refresh controls, pre-renders sibling tabs for Home+Favs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Master
 
+- Removes yellow box warnings from node_modules - ash
+
 ### 1.10.0
 
 ### 1.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Master
 
 - Removes yellow box warnings from node_modules - ash
+- Adds pull-to-refresh controls to fav tab components - ash
 
 ### 1.10.0
 

--- a/src/lib/AppRegistry.tsx
+++ b/src/lib/AppRegistry.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { AppRegistry, View } from "react-native"
+import { AppRegistry, View, YellowBox } from "react-native"
 import { RelayContainer } from "react-relay"
 
 import Consignments from "./Components/Consignments"
@@ -41,6 +41,25 @@ import { BucketKey } from "./Scenes/Map/bucketCityResults"
 import { ShowArtistsRenderer, ShowArtworksRenderer, ShowMoreInfoRenderer } from "./Scenes/Show"
 import renderWithLoadProgress from "./utils/renderWithLoadProgress"
 import { Schema, screenTrack as track } from "./utils/track"
+
+YellowBox.ignoreWarnings([
+  // Deprecated, we'll transition when it's removed.
+  "Warning: ListView is deprecated and will be removed in a future release. See https://fb.me/nolistview for more information",
+
+  // RN 0.59.0 ships with RNCameraRoll with this issue: https://github.com/facebook/react-native/issues/23755
+  // We can remove this once this PR gets shipped and we update: https://github.com/facebook/react-native/pull/24314
+  "Module RCTImagePickerManager requires main queue setup since it overrides `init`",
+
+  // RN 0.59.0 ships with this bug, see: https://github.com/facebook/react-native/issues/16376
+  "RCTBridge required dispatch_sync to load RCTDevLoadingView. This may lead to deadlocks",
+
+  // The following two items exist in node_modules. Once this PR is merged, to make warnings opt-in, we can ignore: https://github.com/facebook/metro/issues/287
+
+  // react-native-sentry ships with this error, tracked here: https://github.com/getsentry/react-native-sentry/issues/479
+  "Require cycle: node_modules/react-native-sentry/lib/Sentry.js -> node_modules/react-native-sentry/lib/RavenClient.js -> node_modules/react-native-sentry/lib/Sentry.js",
+  // RN 0.59.0 ships with this issue, which has been effectively marked as #wontfix: https://github.com/facebook/react-native/issues/23130
+  "Require cycle: node_modules/react-native/Libraries/Network/fetch.js -> node_modules/react-native/Libraries/vendor/core/whatwg-fetch.js -> node_modules/react-native/Libraries/Network/fetch.js",
+])
 
 interface ArtistProps {
   artistID: string

--- a/src/lib/Scenes/Favorites/Components/Artists/index.tsx
+++ b/src/lib/Scenes/Favorites/Components/Artists/index.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { FlatList } from "react-native"
+import { FlatList, RefreshControl } from "react-native"
 import { ConnectionData, createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 
 import SavedItemRow from "lib/Components/Lists/SavedItemRow"
@@ -17,11 +17,13 @@ interface Props {
 
 interface State {
   fetchingMoreData: boolean
+  refreshingFromPull: boolean
 }
 
 class Artists extends React.Component<Props, State> {
   state = {
     fetchingMoreData: false,
+    refreshingFromPull: false,
   }
 
   loadMore = () => {
@@ -36,6 +38,17 @@ class Artists extends React.Component<Props, State> {
         console.error("Artists/index.tsx", error.message)
       }
       this.setState({ fetchingMoreData: false })
+    })
+  }
+
+  handleRefresh = () => {
+    this.setState({ refreshingFromPull: true })
+    this.props.relay.refetchConnection(PAGE_SIZE, error => {
+      if (error) {
+        // FIXME: Handle error
+        console.error("Artists/index.tsx #handleRefresh", error.message)
+      }
+      this.setState({ refreshingFromPull: false })
     })
   }
 
@@ -59,6 +72,7 @@ class Artists extends React.Component<Props, State> {
         renderItem={item => <SavedItemRow {...item.item} />}
         onEndReached={this.loadMore}
         onEndReachedThreshold={0.2}
+        refreshControl={<RefreshControl refreshing={this.state.refreshingFromPull} onRefresh={this.handleRefresh} />}
         ListFooterComponent={
           this.state.fetchingMoreData ? <Spinner style={{ marginTop: 20, marginBottom: 20 }} /> : null
         }

--- a/src/lib/Scenes/Favorites/Components/Artworks/index.tsx
+++ b/src/lib/Scenes/Favorites/Components/Artworks/index.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from "react"
-import { ScrollView } from "react-native"
+import { RefreshControl, ScrollView } from "react-native"
 import { ConnectionData, createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 
 import GenericGrid from "lib/Components/ArtworkGrids/GenericGrid"
@@ -17,11 +17,13 @@ interface Props {
 
 interface State {
   fetchingMoreData: boolean
+  refreshingFromPull: boolean
 }
 
 export class SavedWorks extends Component<Props, State> {
   state = {
     fetchingMoreData: false,
+    refreshingFromPull: false,
   }
 
   loadMore = () => {
@@ -40,9 +42,20 @@ export class SavedWorks extends Component<Props, State> {
     this.props.relay.loadMore(PAGE_SIZE, error => {
       if (error) {
         // FIXME: Handle error
-        console.error("Artworks/index.tsx", error.message)
+        console.error("SavedWorks/index.tsx", error.message)
       }
       updateState(false)
+    })
+  }
+
+  handleRefresh = () => {
+    this.setState({ refreshingFromPull: true })
+    this.props.relay.refetchConnection(PAGE_SIZE, error => {
+      if (error) {
+        // FIXME: Handle error
+        console.error("SavedWorks/index.tsx #handleRefresh", error.message)
+      }
+      this.setState({ refreshingFromPull: false })
     })
   }
 
@@ -65,6 +78,7 @@ export class SavedWorks extends Component<Props, State> {
         scrollEventThrottle={400}
         style={{ flex: 1 }}
         contentContainerStyle={{ padding: 20 }}
+        refreshControl={<RefreshControl refreshing={this.state.refreshingFromPull} onRefresh={this.handleRefresh} />}
       >
         <GenericGrid artworks={artworks as any} isLoading={this.state.fetchingMoreData} />
       </ScrollView>

--- a/src/lib/Scenes/Favorites/Components/Categories/index.tsx
+++ b/src/lib/Scenes/Favorites/Components/Categories/index.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { FlatList } from "react-native"
+import { FlatList, RefreshControl } from "react-native"
 import { ConnectionData, createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 
 import SavedItemRow from "lib/Components/Lists/SavedItemRow"
@@ -16,11 +16,13 @@ interface Props {
 
 interface State {
   fetchingMoreData: boolean
+  refreshingFromPull: boolean
 }
 
 export class Categories extends React.Component<Props, State> {
   state = {
     fetchingMoreData: false,
+    refreshingFromPull: false,
   }
 
   loadMore = () => {
@@ -32,9 +34,20 @@ export class Categories extends React.Component<Props, State> {
     this.props.relay.loadMore(PAGE_SIZE, error => {
       if (error) {
         // FIXME: Handle error
-        console.error("Artists/index.tsx", error.message)
+        console.error("Categories/index.tsx", error.message)
       }
       this.setState({ fetchingMoreData: false })
+    })
+  }
+
+  handleRefresh = () => {
+    this.setState({ refreshingFromPull: true })
+    this.props.relay.refetchConnection(PAGE_SIZE, error => {
+      if (error) {
+        // FIXME: Handle error
+        console.error("Categories/index.tsx #handleRefresh", error.message)
+      }
+      this.setState({ refreshingFromPull: false })
     })
   }
 
@@ -58,6 +71,7 @@ export class Categories extends React.Component<Props, State> {
         renderItem={data => <SavedItemRow square_image {...data.item} />}
         onEndReached={this.loadMore}
         onEndReachedThreshold={0.2}
+        refreshControl={<RefreshControl refreshing={this.state.refreshingFromPull} onRefresh={this.handleRefresh} />}
         ListFooterComponent={
           this.state.fetchingMoreData ? <Spinner style={{ marginTop: 20, marginBottom: 20 }} /> : null
         }

--- a/src/lib/Scenes/Favorites/Components/Shows/index.tsx
+++ b/src/lib/Scenes/Favorites/Components/Shows/index.tsx
@@ -3,7 +3,7 @@ import Spinner from "lib/Components/Spinner"
 import ZeroState from "lib/Components/States/ZeroState"
 import { PAGE_SIZE } from "lib/data/constants"
 import React, { Component } from "react"
-import { FlatList } from "react-native"
+import { FlatList, RefreshControl } from "react-native"
 import { ConnectionData, createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 
 import { Box, Separator, Theme } from "@artsy/palette"
@@ -17,11 +17,13 @@ interface Props {
 
 interface State {
   fetchingMoreData: boolean
+  refreshingFromPull: boolean
 }
 
 export class Shows extends Component<Props, State> {
   state = {
     fetchingMoreData: false,
+    refreshingFromPull: false,
   }
 
   loadMore = () => {
@@ -36,6 +38,17 @@ export class Shows extends Component<Props, State> {
         console.error("Shows/index.tsx", error.message)
       }
       this.setState({ fetchingMoreData: false })
+    })
+  }
+
+  handleRefresh = () => {
+    this.setState({ refreshingFromPull: true })
+    this.props.relay.refetchConnection(PAGE_SIZE, error => {
+      if (error) {
+        // FIXME: Handle error
+        console.error("Shows/index.tsx #handleRefresh", error.message)
+      }
+      this.setState({ refreshingFromPull: false })
     })
   }
 
@@ -65,6 +78,7 @@ export class Shows extends Component<Props, State> {
           onEndReached={this.loadMore}
           onEndReachedThreshold={0.2}
           ItemSeparatorComponent={() => <Separator />}
+          refreshControl={<RefreshControl refreshing={this.state.refreshingFromPull} onRefresh={this.handleRefresh} />}
           ListFooterComponent={
             this.state.fetchingMoreData ? <Spinner style={{ marginTop: 20, marginBottom: 20 }} /> : null
           }


### PR DESCRIPTION
Related to [DISCO-978](https://artsyproduct.atlassian.net/browse/DISCO-978). Here's what's up:

- I removed the yellow boxes from our dev experience, with links back to why we're ignoring those warnings.
- I added pull-to-refresh controls to the favs tab components (Works, Artists, Shows, etc). The control doesn't work on empty data sets, so there's still room for improvement, but having a pull-to-refresh on the fav artworks page is an important step forward.
- ~I specified the Home and Favs tabs to pre-render sibling components on load. This means that, when the app launches on the home tab (artists sub-tab), the WFY and Auctions sub-tabs will load in the background, making the app feel more responsive.~

That last one is the most contentious – I'm hoping to get a 👍 from @orta to make sure we're not doing it for a reason. Otherwise, it seems like a low-effort, high-impact change. 

The components are really similar – I've [opened a ticket](https://artsyproduct.atlassian.net/browse/DISCO-983) to return to them to refactor.