### PR TITLE
Adds react-native-navigator-ios to Podspec, points to Ash's fork #trivial

### DIFF
--- a/Emission.podspec
+++ b/Emission.podspec
@@ -1,7 +1,7 @@
 require 'json'
 require 'date'
 
-root = ENV["EMISSION_ROOT"] || __dir__
+root = ENV['EMISSION_ROOT'] || __dir__
 pkg_version = lambda do |dir_from_root = '', version = 'version'|
   path = File.join(root, dir_from_root, 'package.json')
   JSON.load(File.read(path))[version]
@@ -18,7 +18,7 @@ podspec = Pod::Spec.new do |s|
   s.homepage       = 'https://github.com/artsy/emission'
   s.license        = 'MIT'
   s.author         = { 'Artsy Mobile' => 'mobile@artsy.net' }
-  s.source         = { :git => 'https://github.com/artsy/emission.git', :tag => "v#{s.version}" }
+  s.source         = { git: 'https://github.com/artsy/emission.git', tag: "v#{s.version}" }
   s.platform       = :ios, '9.0'
   s.source_files   = 'Pod/Classes/**/*.{h,m}'
   s.preserve_paths = 'Pod/Classes/**/*.generated.objc'
@@ -55,7 +55,7 @@ podspec = Pod::Spec.new do |s|
   react_podspecs = [
     'node_modules/react-native/third-party-podspecs/DoubleConversion.podspec',
     'node_modules/react-native/third-party-podspecs/Folly.podspec',
-    'node_modules/react-native/third-party-podspecs/glog.podspec',
+    'node_modules/react-native/third-party-podspecs/glog.podspec'
   ]
 
   # Native dependencies of Emission, which come from node_modules
@@ -63,7 +63,8 @@ podspec = Pod::Spec.new do |s|
     'node_modules/tipsi-stripe/tipsi-stripe.podspec',
     'node_modules/@mapbox/react-native-mapbox-gl/react-native-mapbox-gl.podspec',
     'node_modules/react-native-sentry/SentryReactNative.podspec',
-    'node_modules/react-native-svg/RNSVG.podspec'
+    'node_modules/react-native-svg/RNSVG.podspec',
+    'node_modules/react-native-navigator-ios/react-native-navigator-ios.podspec'
   ]
 
   # Ties the exact versions so host apps don't need to guess the version
@@ -71,17 +72,17 @@ podspec = Pod::Spec.new do |s|
   podspecs = react_podspecs + dep_podspecs
   podspecs.each do |podspec_path|
     spec = Pod::Specification.from_file podspec_path
-    s.dependency spec.name, "#{spec.version}"
+    s.dependency spec.name, spec.version.to_s
   end
 end
 
-if ENV["INCLUDE_METADATA"]
+if ENV['INCLUDE_METADATA']
   # Attach the useful metadata to the podspec, which can be used in admin tools
   podspec.attributes_hash['native_version'] = emission_native_version
-  podspec.attributes_hash['release_date'] = DateTime.now.strftime("%h %d, %Y")
+  podspec.attributes_hash['release_date'] = DateTime.now.strftime('%h %d, %Y')
   podspec.attributes_hash['sha'] = `git rev-parse HEAD`.strip
   podspec.attributes_hash['react_native_version'] = react_native_version
-  podspec.attributes_hash['app_registry'] = File.read("./src/lib/AppRegistry.tsx").scan(/AppRegistry.registerComponent\(\"(.*)\"/).flatten
+  podspec.attributes_hash['app_registry'] = File.read('./src/lib/AppRegistry.tsx').scan(/AppRegistry.registerComponent\(\"(.*)\"/).flatten
 end
 
 podspec

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -21,6 +21,7 @@ PODS:
     - ISO8601DateFormatter
     - Pulley
     - react-native-mapbox-gl (= 6.1.4)
+    - react-native-navigator-ios (= 1.0.0)
     - React/Core (= 0.59.2)
     - React/CxxBridge (= 0.59.2)
     - React/RCTActionSheet (= 0.59.2)
@@ -268,7 +269,7 @@ SPEC CHECKSUMS:
   Artsy-UIButtons: 3c396f0fad352a7b0332100e0ffcb0ca577e0082
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: bb338842f62ab1d708ceb63ec3d999f0f3d98ecd
-  Emission: 339a1aa0637d709bc507ac027da7a6d3aecd6f56
+  Emission: e397596f22f8c3c632dcdab7432422afa181ceb3
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   Extraction: 642a73b8ccc7806e9a7daf95ebb4c14c374829f1
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -2123,148 +2123,148 @@
 			isa = PBXContainerItemProxy;
 			containerPortal = 000000000000 /* Project object */;
 			proxyType = 1;
+			remoteGlobalIDString = 00000000F790;
+			remoteInfo = "react-native-navigator-ios";
+		};
+		000000010660 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 000000000000 /* Project object */;
+			proxyType = 1;
 			remoteGlobalIDString = 000000009EF0;
 			remoteInfo = ORStackView;
 		};
-		000000010660 /* PBXContainerItemProxy */ = {
+		000000010680 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 000000000000 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 000000007B70;
 			remoteInfo = "Artsy-UIButtons";
 		};
-		000000010680 /* PBXContainerItemProxy */ = {
+		0000000106A0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 000000000000 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 00000000EC80;
 			remoteInfo = "UIView+BooleanAnimations";
 		};
-		0000000106A0 /* PBXContainerItemProxy */ = {
+		0000000106C0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 000000000000 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 000000007A70;
 			remoteInfo = "Artsy+UIFonts";
 		};
-		0000000106C0 /* PBXContainerItemProxy */ = {
+		0000000106E0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 000000000000 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 000000007950;
 			remoteInfo = "Artsy+UIColors";
 		};
-		0000000106E0 /* PBXContainerItemProxy */ = {
+		000000010700 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 000000000000 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 000000008F70;
 			remoteInfo = FLKAutoLayout;
 		};
-		000000010700 /* PBXContainerItemProxy */ = {
+		000000010720 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 000000000000 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 00000000ED80;
 			remoteInfo = "boost-for-react-native";
 		};
-		000000010720 /* PBXContainerItemProxy */ = {
+		000000010740 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 000000000000 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 000000007C70;
 			remoteInfo = DoubleConversion;
 		};
-		000000010740 /* PBXContainerItemProxy */ = {
+		000000010760 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 000000000000 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 00000000EDF0;
 			remoteInfo = glog;
 		};
-		000000010760 /* PBXContainerItemProxy */ = {
+		000000010780 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 000000000000 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 000000008F70;
 			remoteInfo = FLKAutoLayout;
 		};
-		000000010780 /* PBXContainerItemProxy */ = {
+		0000000107A0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 000000000000 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 00000000AA00;
 			remoteInfo = React;
 		};
-		0000000107A0 /* PBXContainerItemProxy */ = {
+		0000000107C0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 000000000000 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 00000000FA70;
 			remoteInfo = yoga;
 		};
-		0000000107C0 /* PBXContainerItemProxy */ = {
+		0000000107E0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 000000000000 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 000000009140;
 			remoteInfo = Folly;
 		};
-		0000000107E0 /* PBXContainerItemProxy */ = {
+		000000010800 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 000000000000 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 00000000ED80;
 			remoteInfo = "boost-for-react-native";
 		};
-		000000010800 /* PBXContainerItemProxy */ = {
+		000000010820 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 000000000000 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 000000007C70;
 			remoteInfo = DoubleConversion;
 		};
-		000000010820 /* PBXContainerItemProxy */ = {
+		000000010840 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 000000000000 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 00000000EDF0;
 			remoteInfo = glog;
 		};
-		000000010840 /* PBXContainerItemProxy */ = {
+		000000010860 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 000000000000 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 000000009410;
 			remoteInfo = KSCrash;
 		};
-		000000010860 /* PBXContainerItemProxy */ = {
+		000000010880 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 000000000000 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 00000000AA00;
 			remoteInfo = React;
 		};
-		000000010880 /* PBXContainerItemProxy */ = {
+		0000000108A0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 000000000000 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 00000000CD90;
 			remoteInfo = Sentry;
 		};
-		0000000108A0 /* PBXContainerItemProxy */ = {
+		0000000108C0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 000000000000 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 00000000D670;
 			remoteInfo = "Stripe-Stripe";
-		};
-		0000000108C0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 000000000000 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 00000000AA00;
-			remoteInfo = React;
 		};
 		0000000108E0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -2281,6 +2281,13 @@
 			remoteInfo = React;
 		};
 		000000010920 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 000000000000 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 00000000AA00;
+			remoteInfo = React;
+		};
+		000000010940 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 000000000000 /* Project object */;
 			proxyType = 1;
@@ -9009,6 +9016,7 @@
 				000000010610 /* PBXTargetDependency */,
 				0000000105B0 /* PBXTargetDependency */,
 				0000000105F0 /* PBXTargetDependency */,
+				000000010650 /* PBXTargetDependency */,
 				0000000105D0 /* PBXTargetDependency */,
 				000000010550 /* PBXTargetDependency */,
 			);
@@ -9045,12 +9053,12 @@
 			buildRules = (
 			);
 			dependencies = (
-				0000000106D0 /* PBXTargetDependency */,
-				0000000106B0 /* PBXTargetDependency */,
-				000000010670 /* PBXTargetDependency */,
 				0000000106F0 /* PBXTargetDependency */,
-				000000010650 /* PBXTargetDependency */,
+				0000000106D0 /* PBXTargetDependency */,
 				000000010690 /* PBXTargetDependency */,
+				000000010710 /* PBXTargetDependency */,
+				000000010670 /* PBXTargetDependency */,
+				0000000106B0 /* PBXTargetDependency */,
 			);
 			name = Extraction;
 			productName = Extraction;
@@ -9103,9 +9111,9 @@
 			buildRules = (
 			);
 			dependencies = (
-				000000010730 /* PBXTargetDependency */,
-				000000010710 /* PBXTargetDependency */,
 				000000010750 /* PBXTargetDependency */,
+				000000010730 /* PBXTargetDependency */,
+				000000010770 /* PBXTargetDependency */,
 			);
 			name = Folly;
 			productName = Folly;
@@ -9191,7 +9199,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				000000010770 /* PBXTargetDependency */,
+				000000010790 /* PBXTargetDependency */,
 			);
 			name = ORStackView;
 			productName = ORStackView;
@@ -9227,7 +9235,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				000000010790 /* PBXTargetDependency */,
+				0000000107B0 /* PBXTargetDependency */,
 			);
 			name = RNSVG;
 			productName = RNSVG;
@@ -9245,11 +9253,11 @@
 			buildRules = (
 			);
 			dependencies = (
-				000000010810 /* PBXTargetDependency */,
-				0000000107D0 /* PBXTargetDependency */,
-				0000000107F0 /* PBXTargetDependency */,
 				000000010830 /* PBXTargetDependency */,
-				0000000107B0 /* PBXTargetDependency */,
+				0000000107F0 /* PBXTargetDependency */,
+				000000010810 /* PBXTargetDependency */,
+				000000010850 /* PBXTargetDependency */,
+				0000000107D0 /* PBXTargetDependency */,
 			);
 			name = React;
 			productName = React;
@@ -9301,7 +9309,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				000000010850 /* PBXTargetDependency */,
+				000000010870 /* PBXTargetDependency */,
 			);
 			name = Sentry;
 			productName = Sentry;
@@ -9319,8 +9327,8 @@
 			buildRules = (
 			);
 			dependencies = (
-				000000010870 /* PBXTargetDependency */,
 				000000010890 /* PBXTargetDependency */,
+				0000000108B0 /* PBXTargetDependency */,
 			);
 			name = SentryReactNative;
 			productName = SentryReactNative;
@@ -9355,7 +9363,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				0000000108B0 /* PBXTargetDependency */,
+				0000000108D0 /* PBXTargetDependency */,
 			);
 			name = Stripe;
 			productName = Stripe;
@@ -9424,7 +9432,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				0000000108D0 /* PBXTargetDependency */,
+				0000000108F0 /* PBXTargetDependency */,
 			);
 			name = "react-native-mapbox-gl";
 			productName = "react-native-mapbox-gl";
@@ -9442,7 +9450,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				0000000108F0 /* PBXTargetDependency */,
+				000000010910 /* PBXTargetDependency */,
 			);
 			name = "react-native-navigator-ios";
 			productName = "react-native-navigator-ios";
@@ -9460,8 +9468,8 @@
 			buildRules = (
 			);
 			dependencies = (
-				000000010910 /* PBXTargetDependency */,
 				000000010930 /* PBXTargetDependency */,
+				000000010950 /* PBXTargetDependency */,
 			);
 			name = "tipsi-stripe";
 			productName = "tipsi-stripe";
@@ -11116,128 +11124,128 @@
 		};
 		000000010650 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = ORStackView;
-			target = 000000009EF0 /* ORStackView */;
+			name = "react-native-navigator-ios";
+			target = 00000000F790 /* react-native-navigator-ios */;
 			targetProxy = 000000010640 /* PBXContainerItemProxy */;
 		};
 		000000010670 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = "Artsy-UIButtons";
-			target = 000000007B70 /* Artsy-UIButtons */;
+			name = ORStackView;
+			target = 000000009EF0 /* ORStackView */;
 			targetProxy = 000000010660 /* PBXContainerItemProxy */;
 		};
 		000000010690 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = "UIView+BooleanAnimations";
-			target = 00000000EC80 /* UIView+BooleanAnimations */;
+			name = "Artsy-UIButtons";
+			target = 000000007B70 /* Artsy-UIButtons */;
 			targetProxy = 000000010680 /* PBXContainerItemProxy */;
 		};
 		0000000106B0 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = "Artsy+UIFonts";
-			target = 000000007A70 /* Artsy+UIFonts */;
+			name = "UIView+BooleanAnimations";
+			target = 00000000EC80 /* UIView+BooleanAnimations */;
 			targetProxy = 0000000106A0 /* PBXContainerItemProxy */;
 		};
 		0000000106D0 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = "Artsy+UIColors";
-			target = 000000007950 /* Artsy+UIColors */;
+			name = "Artsy+UIFonts";
+			target = 000000007A70 /* Artsy+UIFonts */;
 			targetProxy = 0000000106C0 /* PBXContainerItemProxy */;
 		};
 		0000000106F0 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = FLKAutoLayout;
-			target = 000000008F70 /* FLKAutoLayout */;
+			name = "Artsy+UIColors";
+			target = 000000007950 /* Artsy+UIColors */;
 			targetProxy = 0000000106E0 /* PBXContainerItemProxy */;
 		};
 		000000010710 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = "boost-for-react-native";
-			target = 00000000ED80 /* boost-for-react-native */;
+			name = FLKAutoLayout;
+			target = 000000008F70 /* FLKAutoLayout */;
 			targetProxy = 000000010700 /* PBXContainerItemProxy */;
 		};
 		000000010730 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = DoubleConversion;
-			target = 000000007C70 /* DoubleConversion */;
+			name = "boost-for-react-native";
+			target = 00000000ED80 /* boost-for-react-native */;
 			targetProxy = 000000010720 /* PBXContainerItemProxy */;
 		};
 		000000010750 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = glog;
-			target = 00000000EDF0 /* glog */;
+			name = DoubleConversion;
+			target = 000000007C70 /* DoubleConversion */;
 			targetProxy = 000000010740 /* PBXContainerItemProxy */;
 		};
 		000000010770 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = FLKAutoLayout;
-			target = 000000008F70 /* FLKAutoLayout */;
+			name = glog;
+			target = 00000000EDF0 /* glog */;
 			targetProxy = 000000010760 /* PBXContainerItemProxy */;
 		};
 		000000010790 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = React;
-			target = 00000000AA00 /* React */;
+			name = FLKAutoLayout;
+			target = 000000008F70 /* FLKAutoLayout */;
 			targetProxy = 000000010780 /* PBXContainerItemProxy */;
 		};
 		0000000107B0 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = yoga;
-			target = 00000000FA70 /* yoga */;
+			name = React;
+			target = 00000000AA00 /* React */;
 			targetProxy = 0000000107A0 /* PBXContainerItemProxy */;
 		};
 		0000000107D0 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = Folly;
-			target = 000000009140 /* Folly */;
+			name = yoga;
+			target = 00000000FA70 /* yoga */;
 			targetProxy = 0000000107C0 /* PBXContainerItemProxy */;
 		};
 		0000000107F0 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = "boost-for-react-native";
-			target = 00000000ED80 /* boost-for-react-native */;
+			name = Folly;
+			target = 000000009140 /* Folly */;
 			targetProxy = 0000000107E0 /* PBXContainerItemProxy */;
 		};
 		000000010810 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = DoubleConversion;
-			target = 000000007C70 /* DoubleConversion */;
+			name = "boost-for-react-native";
+			target = 00000000ED80 /* boost-for-react-native */;
 			targetProxy = 000000010800 /* PBXContainerItemProxy */;
 		};
 		000000010830 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = glog;
-			target = 00000000EDF0 /* glog */;
+			name = DoubleConversion;
+			target = 000000007C70 /* DoubleConversion */;
 			targetProxy = 000000010820 /* PBXContainerItemProxy */;
 		};
 		000000010850 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = KSCrash;
-			target = 000000009410 /* KSCrash */;
+			name = glog;
+			target = 00000000EDF0 /* glog */;
 			targetProxy = 000000010840 /* PBXContainerItemProxy */;
 		};
 		000000010870 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = React;
-			target = 00000000AA00 /* React */;
+			name = KSCrash;
+			target = 000000009410 /* KSCrash */;
 			targetProxy = 000000010860 /* PBXContainerItemProxy */;
 		};
 		000000010890 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = Sentry;
-			target = 00000000CD90 /* Sentry */;
+			name = React;
+			target = 00000000AA00 /* React */;
 			targetProxy = 000000010880 /* PBXContainerItemProxy */;
 		};
 		0000000108B0 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = "Stripe-Stripe";
-			target = 00000000D670 /* Stripe-Stripe */;
+			name = Sentry;
+			target = 00000000CD90 /* Sentry */;
 			targetProxy = 0000000108A0 /* PBXContainerItemProxy */;
 		};
 		0000000108D0 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = React;
-			target = 00000000AA00 /* React */;
+			name = "Stripe-Stripe";
+			target = 00000000D670 /* Stripe-Stripe */;
 			targetProxy = 0000000108C0 /* PBXContainerItemProxy */;
 		};
 		0000000108F0 /* PBXTargetDependency */ = {
@@ -11254,9 +11262,15 @@
 		};
 		000000010930 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
+			name = React;
+			target = 00000000AA00 /* React */;
+			targetProxy = 000000010920 /* PBXContainerItemProxy */;
+		};
+		000000010950 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
 			name = Stripe;
 			target = 00000000D5E0 /* Stripe */;
-			targetProxy = 000000010920 /* PBXContainerItemProxy */;
+			targetProxy = 000000010940 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "react": "16.8.3",
     "react-native": "0.59.2",
     "react-native-hyperlink": "0.0.11",
-    "react-native-navigator-ios": "https://github.com/orta/react-native-navigator-ios#license_podspec",
+    "react-native-navigator-ios": "https://github.com/ashfurrow/react-native-navigator-ios#license_podspec",
     "react-native-parallax-scroll-view": "orta/react-native-parallax-scroll-view",
     "react-native-scrollable-tab-view": "^0.9.0",
     "react-native-sentry": "^0.30.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11877,9 +11877,9 @@ react-native-iphone-x-helper@^1.0.1:
   resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.2.0.tgz#9f8a376eb00bc712115abff4420318a0063fa796"
   integrity sha512-xIeTo4s77wwKgBZLVRIZC9tM9/PkXS46Ul76NXmvmixEb3ZwqGdQesR3zRiLMOoIdfOURB6N9bba9po7+x9Bag==
 
-"react-native-navigator-ios@https://github.com/orta/react-native-navigator-ios#license_podspec":
+"react-native-navigator-ios@https://github.com/ashfurrow/react-native-navigator-ios#license_podspec":
   version "1.0.0"
-  resolved "https://github.com/orta/react-native-navigator-ios#695725296669114ceeed76bba218fd91cde381c1"
+  resolved "https://github.com/ashfurrow/react-native-navigator-ios#695725296669114ceeed76bba218fd91cde381c1"
 
 react-native-parallax-scroll-view@orta/react-native-parallax-scroll-view:
   version "0.18.2"


### PR DESCRIPTION
This was [discussed on Slack](https://artsy.slack.com/archives/C02BAQ5K7/p1557936869065400). Since we have a dependency on `react-native-navigator-ios`, that dependency should be reflected in the podspec. I've also forked Orta's changes of the repo to my account.

Prettier's done a job on the podspec, too.