### PR TITLE
PURCHASE-1121: Adds flags for AREnabled and CurrentLocale to support artwork view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - Adds a non-interactive ArtworkActions component - sweir27
 - Adds basic ArtworkAvailability component - ashkan18
+- Exposes AREnabled and a user's current locale - sweir27
 
 ### 1.11.3
 

--- a/Pod/Classes/Core/ARCocoaConstantsModule.m
+++ b/Pod/Classes/Core/ARCocoaConstantsModule.m
@@ -1,3 +1,5 @@
+@import ARKit;
+
 #import "ARCocoaConstantsModule.h"
 
 #import <UIKit/UIKit.h>
@@ -13,9 +15,17 @@ RCT_EXPORT_MODULE();
 
 - (NSDictionary *)constantsToExport;
 {
+    BOOL isAREnabled = NO;
+
+    if (@available(iOS 11.3, *)) {
+        isAREnabled = [ARWorldTrackingConfiguration isSupported];
+    }
+
     return @{
         @"UIApplicationOpenSettingsURLString": UIApplicationOpenSettingsURLString,
         @"LocalTimeZone": [[NSTimeZone localTimeZone] name],
+        @"CurrentLocale": [[NSLocale currentLocale] localeIdentifier],
+        @"AREnabled": @(isAREnabled),
     };
 }
 

--- a/src/lib/Scenes/Artwork/Components/ArtworkActions.tsx
+++ b/src/lib/Scenes/Artwork/Components/ArtworkActions.tsx
@@ -2,9 +2,11 @@ import { Box, Flex, Sans } from "@artsy/palette"
 import { ArtworkActions_artwork } from "__generated__/ArtworkActions_artwork.graphql"
 import SearchIcon from "lib/Icons/SearchIcon"
 import React from "react"
-import { View } from "react-native"
+import { NativeModules, View } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components/native"
+
+const Constants = NativeModules.ARCocoaConstantsModule || {}
 
 interface ArtworkActionsProps {
   artwork: ArtworkActions_artwork
@@ -20,12 +22,14 @@ export const ArtworkActions: React.FC<ArtworkActionsProps> = () => {
           </Box>
           <Sans size="3">Save</Sans>
         </UtilButton>
-        <UtilButton pr={3}>
-          <Box mr={0.5}>
-            <SearchIcon />
-          </Box>
-          <Sans size="3">View in Room</Sans>
-        </UtilButton>
+        {Constants.AREnabled && (
+          <UtilButton pr={3}>
+            <Box mr={0.5}>
+              <SearchIcon />
+            </Box>
+            <Sans size="3">View in Room</Sans>
+          </UtilButton>
+        )}
         <UtilButton>
           <Box mr={0.5}>
             <SearchIcon />

--- a/src/lib/Scenes/Artwork/Components/__tests__/ArtworkActions-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/__tests__/ArtworkActions-tests.tsx
@@ -1,36 +1,66 @@
 import { Sans } from "@artsy/palette"
 import { shallow } from "enzyme"
 import React from "react"
+import { NativeModules } from "react-native"
 import { ArtworkActions } from "../ArtworkActions"
 
 describe("ArtworkActions", () => {
-  it("renders buttons correctly", () => {
-    const component = shallow(<ArtworkActions artwork={artworkActionsArtwork} />)
-    expect(component.find(Sans).length).toEqual(3)
+  describe("with AR enabled", () => {
+    it("renders buttons correctly", () => {
+      const component = shallow(<ArtworkActions artwork={artworkActionsArtwork} />)
+      expect(component.find(Sans).length).toEqual(3)
 
-    expect(
-      component
-        .find(Sans)
-        .at(0)
-        .render()
-        .text()
-    ).toMatchInlineSnapshot(`"Save"`)
+      expect(
+        component
+          .find(Sans)
+          .at(0)
+          .render()
+          .text()
+      ).toMatchInlineSnapshot(`"Save"`)
 
-    expect(
-      component
-        .find(Sans)
-        .at(1)
-        .render()
-        .text()
-    ).toMatchInlineSnapshot(`"View in Room"`)
+      expect(
+        component
+          .find(Sans)
+          .at(1)
+          .render()
+          .text()
+      ).toMatchInlineSnapshot(`"View in Room"`)
 
-    expect(
-      component
-        .find(Sans)
-        .at(2)
-        .render()
-        .text()
-    ).toMatchInlineSnapshot(`"Share"`)
+      expect(
+        component
+          .find(Sans)
+          .at(2)
+          .render()
+          .text()
+      ).toMatchInlineSnapshot(`"Share"`)
+    })
+  })
+
+  describe("without AR enabled", () => {
+    beforeAll(() => {
+      NativeModules.ARCocoaConstantsModule.AREnabled = false
+    })
+
+    it("does not show the View in Room option if the phone does not have AREnabled", () => {
+      const component = shallow(<ArtworkActions artwork={artworkActionsArtwork} />)
+      expect(component.find(Sans).length).toEqual(2)
+
+      expect(
+        component
+          .find(Sans)
+          .at(0)
+          .render()
+          .text()
+      ).toMatchInlineSnapshot(`"Save"`)
+
+      expect(
+        component
+          .find(Sans)
+          .at(1)
+          .render()
+          .text()
+      ).toMatchInlineSnapshot(`"Share"`)
+    })
   })
 })
 

--- a/src/setupJest.ts
+++ b/src/setupJest.ts
@@ -95,6 +95,7 @@ NativeModules.ARTakeCameraPhotoModule = {
 }
 NativeModules.ARCocoaConstantsModule = {
   UIApplicationOpenSettingsURLString: "UIApplicationOpenSettingsURLString",
+  AREnabled: true,
 }
 NativeModules.ARSwitchBoardModule = {
   presentNavigationViewController: jest.fn(),


### PR DESCRIPTION
Thank you to @l2succes for pairing on this!

This PR exposes `currentLocale` and `AREnabled`, based on settings from a user's native environment.

It also updates the `ArtworkActions` component to consume the `AREnabled` flag and use it to hide/show the "View in Room" button.