### PR TITLE
Removes extraneous guards, improves Jest setup #trivial

### DIFF
--- a/src/lib/Scenes/Artwork/Components/ArtworkActions.tsx
+++ b/src/lib/Scenes/Artwork/Components/ArtworkActions.tsx
@@ -6,7 +6,7 @@ import { NativeModules, View } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components/native"
 
-const Constants = NativeModules.ARCocoaConstantsModule || {}
+const Constants = NativeModules.ARCocoaConstantsModule
 
 interface ArtworkActionsProps {
   artwork: ArtworkActions_artwork

--- a/src/lib/relay/createEnvironment.ts
+++ b/src/lib/relay/createEnvironment.ts
@@ -6,8 +6,8 @@ import { metaphysicsURL } from "./config"
 import { cacheMiddleware } from "./middlewares/cacheMiddleware"
 import { metaphysicsExtensionsLoggerMiddleware } from "./middlewares/metaphysicsMiddleware"
 
-const Emission = NativeModules.Emission || {}
-const Constants = NativeModules.ARCocoaConstantsModule || {}
+const Emission = NativeModules.Emission
+const Constants = NativeModules.ARCocoaConstantsModule
 
 /// WARNING: Creates a whole new, separate Relay environment. Useful for testing and in Storybooks.
 /// Use `defaultEnvironment` for production code.

--- a/src/setupJest.ts
+++ b/src/setupJest.ts
@@ -97,6 +97,9 @@ NativeModules.ARCocoaConstantsModule = {
   UIApplicationOpenSettingsURLString: "UIApplicationOpenSettingsURLString",
   AREnabled: true,
 }
+NativeModules.Emission = {
+  userAgent: "Jest Unit Tests",
+}
 NativeModules.ARSwitchBoardModule = {
   presentNavigationViewController: jest.fn(),
   presentModalViewController: jest.fn(),


### PR DESCRIPTION
Follow-up from #1599. This removes some unneeded ` || {}` and adds a stub value for `NativeModules.Emission` in the Jest setup.