### PR TITLE
Allow .tests to also be picked up by jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
       "^lib/(.*)": "<rootDir>/src/lib/$1"
     },
     "testMatch": [
-      "<rootDir>/src/**/__tests__/*-tests.(ts|tsx|js)"
+      "<rootDir>/src/**/__tests__/*tests.(ts|tsx|js)"
     ],
     "testEnvironment": "jsdom",
     "testURL": "http://localhost/",


### PR DESCRIPTION
# Problem
Omakase by default [creates](https://github.com/omakase-js/omakase/blob/master/packages/cli/src/generator/templates/Component.test.tsx.ejs) tests with `.test.tsx` format and emission is currently only picks up `-tests` files.

# Solution
pick all `*tests.(ts|tsx|js)` files.