### PR TITLE
Avoid naming conflict with a variable name in cocoapods-core

### DIFF
--- a/Emission.podspec
+++ b/Emission.podspec
@@ -3,8 +3,8 @@ require 'date'
 
 root = ENV['EMISSION_ROOT'] || __dir__
 pkg_version = lambda do |dir_from_root = '', version = 'version'|
-  path = File.join(root, dir_from_root, 'package.json')
-  JSON.load(File.read(path))[version]
+  _path = File.join(root, dir_from_root, 'package.json')
+  JSON.load(File.read(_path))[version]
 end
 
 emission_version = pkg_version.call


### PR DESCRIPTION
The variable name `path` seems very safe to use here, but it turns out it is not. This entire code of podspec will be `eval`-ed by the `Pod._eval_podspec` method, which, literally, uses the `eval` method. In `_eval_podspec`, there is [an argument called `path`][1], which happens to be used in `Emission.podspec` as well. As a result of this, setting a value to `path` in a podspec file overrides  `path` (the argument).

And if you are lucky (or unlucky) and the execution fails, this `_eval_podspec` rescues an exception and attempts to generate a message with the assumption that the `path` responds to `:basename`. However, since the `path` has been ovrriden by the `Emission.podspec`, it is no longer ture and the call ends up raising another exception.

We could work around this by just using a different name. There may be something that needs to be done on the cocoapods-side, but for now this should eliminate potential confution around how CocoaPods behaves in case of nested exceptions.

#trivial

[1]: https://github.com/CocoaPods/Core/blob/1e0479d5577f1dbc78d559162c4012cbb2bb9f32/lib/cocoapods-core/specification.rb#L785