### PR TITLE
Fixes crash with empty country selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 
 ### Master
 
+- Fixes crash with empty country selection - ash
+
+### 1.12.x develop
+
 - Update typings for Relay to v4 and usage thereof - alloy
 - Use gravity ID when opening artwork from artwork grid instead of global object ID - alloy
 

--- a/src/lib/Components/Bidding/Screens/SelectCountry.tsx
+++ b/src/lib/Components/Bidding/Screens/SelectCountry.tsx
@@ -117,7 +117,7 @@ export class SelectCountry extends React.Component<SelectCountryProps, SelectCou
                       </Serif>
                     </TouchableWithoutFeedback>
                   ))
-                : query &&
+                : !!query &&
                   !isLoading && (
                     <Serif size="4" ml={3} color="black30">
                       Could not find “{query}


### PR DESCRIPTION
App crashes when back-spacing country-select name. This is happening on App Store build so I want to get a fix in so we can release this week.

## Steps to reproduce

- Login with a user that has no credit card on file.
- Create a timed auction.
- Register for the sale through the app.
- In the Billing Address screen, tap "Country" to go to the country select screen.
- Start typing.
- Backspace until the text field is empty.

## Expected results:

- The country select screen shows no countries until text is entered

## Actual results:

- The app crashes when the text field contents are cleared.

---

The crash is caused by the expression `query && !isLoading && (<Components ... />)` in the case that `query = ""` and `isLoading = true`. In this case, JavaScript short-circuits `&&` after `!isLoading` and the whole expression evaluates to `""`, and React Native crashes because of an invariant violation that all strings must be wrapped in `<Text>` components. 
