### PR TITLE
[PURCHASE-1224, PURCHASE-1230] Small adjustments to the new artwork page

### DIFF
--- a/src/lib/Scenes/Artwork/Components/ArtworkActions.tsx
+++ b/src/lib/Scenes/Artwork/Components/ArtworkActions.tsx
@@ -74,7 +74,7 @@ export class ArtworkActions extends React.Component<ArtworkActionsProps> {
       <View>
         <Flex flexDirection="row">
           <TouchableWithoutFeedback onPress={() => this.handleArtworkSave()}>
-            <UtilButton pr={3} width="110px">
+            <UtilButton pr={3}>
               <Box mr={0.5}>{is_saved ? <HeartFillIcon fill="purple100" /> : <HeartIcon />}</Box>
               <Sans size="3" color={is_saved ? color("purple100") : color("black100")}>
                 {is_saved ? "Saved" : "Save"}

--- a/src/lib/Scenes/Artwork/Components/FollowArtistButton.tsx
+++ b/src/lib/Scenes/Artwork/Components/FollowArtistButton.tsx
@@ -45,11 +45,11 @@ export class FollowArtistButton extends React.Component<Props> {
     const followButtonText = this.props.artist.is_followed ? "Following" : "Follow"
     return (
       <>
-        <Sans color="black60" size="6" mx={1}>
-          &middot;
+        <Sans color="black60" size="3t" mx={0.5} mt="2px">
+          •
         </Sans>
         <TouchableWithoutFeedback onPress={this.handleFollowArtist.bind(this)}>
-          <Sans color="black60" weight="medium" size="3t">
+          <Sans color="black60" weight="medium" size="3t" mt="2px">
             {followButtonText}
           </Sans>
         </TouchableWithoutFeedback>


### PR DESCRIPTION
# PURCHASE-1224: "View in room" button should be centered

__Before:__
<img width="350" alt="Screen Shot 2019-07-08 at 4 38 16 PM" src="https://user-images.githubusercontent.com/5643895/60844576-ae74a080-a1a7-11e9-8425-f31c5d1e7f90.png">

__After:__
<img width="352" alt="Screen Shot 2019-07-08 at 4 40 58 PM" src="https://user-images.githubusercontent.com/5643895/60844583-b7fe0880-a1a7-11e9-9617-e16c8bfc43e1.png">

# PURCHASE-1230: "•" between artist name and follow should be round and align correctly with artist name

__Before:__
<img width="349" alt="Screen Shot 2019-07-08 at 1 25 54 PM" src="https://user-images.githubusercontent.com/5643895/60844605-d3691380-a1a7-11e9-9fb8-70fc7583f521.png">

__After:__
<img width="352" alt="Screen Shot 2019-07-08 at 1 48 21 PM" src="https://user-images.githubusercontent.com/5643895/60844588-c3513400-a1a7-11e9-8eff-62acade3b2ab.png">

#trivial