### PR TITLE
Ensure `edition_of` is never an empty string

### DIFF
--- a/src/lib/Scenes/Artwork/Components/ArtworkTombstone.tsx
+++ b/src/lib/Scenes/Artwork/Components/ArtworkTombstone.tsx
@@ -115,7 +115,7 @@ export class ArtworkTombstone extends React.Component<ArtworkTombstoneProps, Art
         <Serif color="black60" size="3t">
           {Constants.CurrentLocale === "en_US" ? artwork.dimensions.in : artwork.dimensions.cm}
         </Serif>
-        {artwork.edition_of && (
+        {!!artwork.edition_of && (
           <Serif color="black60" size="3t">
             {artwork.edition_of}
           </Serif>


### PR DESCRIPTION
While testing something unrelated I ran across an invariant issue where `edition_of` returned an empty string.

This is related to a lot of other fixes that @kierangillen did in https://github.com/artsy/emission/pull/1559

See https://github.com/facebook/react-native/issues/20764 for more context.

#trivial