### PR TITLE
PURCHASE-1224: "View in room" button should be centered

### DIFF
--- a/src/lib/Scenes/Artwork/Components/ArtworkActions.tsx
+++ b/src/lib/Scenes/Artwork/Components/ArtworkActions.tsx
@@ -74,7 +74,7 @@ export class ArtworkActions extends React.Component<ArtworkActionsProps> {
       <View>
         <Flex flexDirection="row">
           <TouchableWithoutFeedback onPress={() => this.handleArtworkSave()}>
-            <UtilButton pr={3} width="110px">
+            <UtilButton pr={3}>
               <Box mr={0.5}>{is_saved ? <HeartFillIcon fill="purple100" /> : <HeartIcon />}</Box>
               <Sans size="3" color={is_saved ? color("purple100") : color("black100")}>
                 {is_saved ? "Saved" : "Save"}


### PR DESCRIPTION
__Before:__
<img width="350" alt="Screen Shot 2019-07-08 at 4 38 16 PM" src="https://user-images.githubusercontent.com/5643895/60844576-ae74a080-a1a7-11e9-8425-f31c5d1e7f90.png">

__After:__
<img width="352" alt="Screen Shot 2019-07-08 at 4 40 58 PM" src="https://user-images.githubusercontent.com/5643895/60844583-b7fe0880-a1a7-11e9-9617-e16c8bfc43e1.png">
#trivial