### PR TITLE
[GROW-1392] Fixes crash and map UX for city guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Removes InvertedButton - kierangillen
 - Adds ContextCard - kierangillen
 - Fixes BottomAlignedButton keyboard clipping - kierangillen
+- Fixes crash and map UX for city guides - ash
 
 ### 1.12.5
 

--- a/src/lib/Scenes/Map/GlobalMap.tsx
+++ b/src/lib/Scenes/Map/GlobalMap.tsx
@@ -209,13 +209,15 @@ export class GlobalMap extends React.Component<Props, State> {
   }
 
   resetZoomAndCamera = () => {
-    this.map.setCamera({
-      mode: DefaultCameraMode,
-      zoom: DefaultZoomLevel,
-      pitch: 0,
-      heading: 0,
-      duration: 1000,
-    })
+    if (this.map) {
+      this.map.setCamera({
+        mode: DefaultCameraMode,
+        zoom: DefaultZoomLevel,
+        pitch: 0,
+        heading: 0,
+        duration: 1000,
+      })
+    }
   }
 
   componentDidMount() {
@@ -572,7 +574,7 @@ export class GlobalMap extends React.Component<Props, State> {
 
   storeMapRef = (c: any) => {
     if (c) {
-      this.map = c.root
+      this.map = c
     }
   }
 
@@ -683,6 +685,9 @@ export class GlobalMap extends React.Component<Props, State> {
    * access to the shows that the user has tapped on.
    */
   async handleFeaturePress(nativeEvent: any) {
+    if (!this.map) {
+      return
+    }
     const {
       payload: {
         properties: { id, cluster, type },


### PR DESCRIPTION
This code was [recently refactored](https://github.com/artsy/emission/commit/a73a34de3abfc1e6df2176a1b6a903726b7fed83) by @alloy  but I don't quite understand how this was _ever_ working. The ref we were storing was always `undefined`. According to [the docs](https://reactjs.org/docs/refs-and-the-dom.html), the call to `.root` is unnecessary. @ds300 ran into a similar problem here: https://github.com/artsy/emission/pull/1700/files#r300014570

In any case, this is working now! h/t to @ansor4 for debugging this with me.