### PR TITLE
[PURCHASE-1262] Consignment landing page should open in modal instead of as a new page sliding in

### DIFF
--- a/src/lib/Scenes/Artwork/Components/ArtworkExtraLinks.tsx
+++ b/src/lib/Scenes/Artwork/Components/ArtworkExtraLinks.tsx
@@ -34,7 +34,7 @@ export class ArtworkExtraLinks extends React.Component<ArtworkExtraLinksProps> {
     const { artwork } = this.props
     const consignableArtistsCount = artwork.artists.filter(artist => artist.is_consignable).length
 
-    return <Box>{this.renderConsignmentsLine(consignableArtistsCount)}</Box>
+    return <Box>{!!consignableArtistsCount && this.renderConsignmentsLine(consignableArtistsCount)}</Box>
   }
 }
 

--- a/src/lib/Scenes/Artwork/Components/ArtworkExtraLinks.tsx
+++ b/src/lib/Scenes/Artwork/Components/ArtworkExtraLinks.tsx
@@ -1,6 +1,7 @@
 import { Box, Serif } from "@artsy/palette"
 import { ArtworkExtraLinks_artwork } from "__generated__/ArtworkExtraLinks_artwork.graphql"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
+import { Router } from "lib/utils/router"
 import React from "react"
 import { Text } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -14,11 +15,15 @@ export class ArtworkExtraLinks extends React.Component<ArtworkExtraLinksProps> {
     SwitchBoard.presentNavigationViewController(this, href)
   }
 
+  handleConsignmentsTap() {
+    SwitchBoard.presentNavigationViewController(this, Router.ConsignmentsStartSubmission)
+  }
+
   renderConsignmentsLine(artistsCount) {
     return (
       <Serif size="3t" color="black60">
         Want to sell a work by {artistsCount === 1 ? "this artist" : "these artists"}?{" "}
-        <Text style={{ textDecorationLine: "underline" }} onPress={() => this.handleTap("/consign/info")}>
+        <Text style={{ textDecorationLine: "underline" }} onPress={() => this.handleConsignmentsTap()}>
           Consign with Artsy.
         </Text>
       </Serif>
@@ -29,7 +34,7 @@ export class ArtworkExtraLinks extends React.Component<ArtworkExtraLinksProps> {
     const { artwork } = this.props
     const consignableArtistsCount = artwork.artists.filter(artist => artist.is_consignable).length
 
-    return <Box>{!!consignableArtistsCount && this.renderConsignmentsLine(consignableArtistsCount)}</Box>
+    return <Box>{this.renderConsignmentsLine(consignableArtistsCount)}</Box>
   }
 }
 

--- a/src/lib/Scenes/Artwork/Components/__tests__/ArtworkExtraLinks-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/__tests__/ArtworkExtraLinks-tests.tsx
@@ -20,7 +20,7 @@ describe("ArtworkExtraLinks", () => {
     const consignmentsLink = component.find(Text).at(1)
     expect(consignmentsLink.text()).toContain("Consign with Artsy.")
     consignmentsLink.props().onPress()
-    expect(SwitchBoard.presentNavigationViewController).toHaveBeenCalledWith(expect.anything(), "/consign/info")
+    expect(SwitchBoard.presentNavigationViewController).toHaveBeenCalledWith(expect.anything(), "/consign/submission")
   })
 
   describe("for an artwork with more than 1 consignable artist", () => {


### PR DESCRIPTION
Used existing link that the consignments banner uses. Doesn't appear to open modally in Emission but behavior in Eigen should be the same as the banner and present modally. 

#trivial