### PR TITLE
Fixes spurious, intermittent crash from home feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Adds ContextCard - kierangillen
 - Fixes BottomAlignedButton keyboard clipping - kierangillen
 - Fixes crash and map UX for city guides - ash
+- Fixes spurious, intermittent crash from home feed - ash
 
 ### 1.12.5
 

--- a/src/lib/Components/ArtworkGrids/ArtworkGridItem.tsx
+++ b/src/lib/Components/ArtworkGrids/ArtworkGridItem.tsx
@@ -10,6 +10,7 @@ import styled from "styled-components/native"
 import SerifText from "../Text/Serif"
 
 import { ArtworkGridItem_artwork } from "__generated__/ArtworkGridItem_artwork.graphql"
+import { get } from "lib/utils/get"
 
 const Badges = styled.View`
   position: absolute;
@@ -149,11 +150,10 @@ export class Artwork extends React.Component<Props, any> {
   saleMessageOrBidInfo() {
     const { artwork } = this.props
     const { sale, sale_artwork } = artwork
-    const inRunningAuction = sale && sale_artwork && sale.is_auction && !sale.is_closed
+    const inRunningAuction = sale && sale.is_auction && !sale.is_closed
 
     if (inRunningAuction) {
-      const currentBid = sale_artwork.current_bid
-      return currentBid && currentBid.display
+      return get(sale_artwork, sa => sa.current_bid.display)
     }
 
     // TODO: Extract this sentence-cased version and apply everywhere.


### PR DESCRIPTION
During the bug bash I wanted to look into this: https://sentry.io/organizations/artsynet/issues/587358816/events/2fed3e7952624a95a408e8113d194e7b/?project=157493&query=is%3Aunresolved This Sentry error is a bucket for all "undefined/null is not an object" errors, which is annoying, but I wanted to look into this.

The code _should_ work:

```tsx
const { sale, sale_artwork } = artwork
const inRunningAuction = sale && sale_artwork && sale.is_auction && !sale.is_closed
if (inRunningAuction) {
  const currentBid = sale_artwork.current_bid
  return currentBid && currentBid.display
}
```

Like, it shouldn't crash. So what's up? Well I looked at the bundled Emission and it gets transpiled into this:

```tsx
var e = this.props.artwork,
  t = e.sale;
if (t && t.is_auction && !t.is_closed) {
  var a = e.sale_artwork.current_bid;
  return a && a.display;
}
```

You'll notice that the requirement for `sale_artwork` to exist is no longer present. So if `sale_artwork` is not defined, `e.sale_artwork.current_bid` is causing a crash (which is what we see in Sentry).

Not sure why the code gets transpiled that way, any ideas? /cc @alloy The last time we looked at this crash, I wrote a unit test for the crash, but I couldn't get it to fail as I expected it to (I think because `yarn bundle` probably runs some optimizations that aren't present during Jest runs).

Since we have a new, TypeSafe `get()` function, I thought we should switch to that. It should fix the crash, too. I also removed `sale_artwork &&` from the `inRunningAuction` since it's not unnecessary (and isn't strictly related to if the auction is running).