### PR TITLE
Add image thumbnail to the confirm bid screen 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,11 @@
 
 ### Master
 
+- Display the image of an artwork on the confirm bid screen - yuki24
+
 ### 1.12.6
 
 - Added partner type to partner card - lilyfromseattle
-
 - Removes InvertedButton - kierangillen
 - Adds ContextCard - kierangillen
 - Fixes BottomAlignedButton keyboard clipping - kierangillen

--- a/src/__generated__/BidFlowSelectMaxBidRendererQuery.graphql.ts
+++ b/src/__generated__/BidFlowSelectMaxBidRendererQuery.graphql.ts
@@ -49,6 +49,9 @@ fragment ConfirmBid_sale_artwork on SaleArtwork {
     title
     date
     artist_names
+    image {
+      url(version: "small")
+    }
     id
   }
   lot_label
@@ -239,6 +242,30 @@ return {
                 "args": null,
                 "storageKey": null
               },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "image",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "Image",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "url",
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "version",
+                        "value": "small"
+                      }
+                    ],
+                    "storageKey": "url(version:\"small\")"
+                  }
+                ]
+              },
               (v5/*: any*/)
             ]
           },
@@ -277,7 +304,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "BidFlowSelectMaxBidRendererQuery",
-    "id": "f62155080608fb9835de0c0925a87952",
+    "id": "8b9bf477e39ad48905e390c4a3019a46",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ConfirmBid_sale_artwork.graphql.ts
+++ b/src/__generated__/ConfirmBid_sale_artwork.graphql.ts
@@ -16,6 +16,9 @@ export type ConfirmBid_sale_artwork = {
         readonly title: string | null;
         readonly date: string | null;
         readonly artist_names: string | null;
+        readonly image: {
+            readonly url: string | null;
+        } | null;
     } | null;
     readonly lot_label: string | null;
     readonly " $fragmentRefs": BidResult_sale_artwork$ref;
@@ -102,6 +105,30 @@ return {
           "name": "artist_names",
           "args": null,
           "storageKey": null
+        },
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "image",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "Image",
+          "plural": false,
+          "selections": [
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "url",
+              "args": [
+                {
+                  "kind": "Literal",
+                  "name": "version",
+                  "value": "small"
+                }
+              ],
+              "storageKey": "url(version:\"small\")"
+            }
+          ]
         }
       ]
     },
@@ -120,5 +147,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '1b9a43f0c7c6b39496d6c12620502354';
+(node as any).hash = '40452e0f6179b4f0c772d5d60fd1ebf8';
 export default node;

--- a/src/__generated__/QueryRenderersBidFlowQuery.graphql.ts
+++ b/src/__generated__/QueryRenderersBidFlowQuery.graphql.ts
@@ -84,6 +84,9 @@ fragment ConfirmBid_sale_artwork on SaleArtwork {
     title
     date
     artist_names
+    image {
+      url(version: "small")
+    }
     id
   }
   lot_label
@@ -323,6 +326,30 @@ return {
                     "args": null,
                     "storageKey": null
                   },
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "image",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Image",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "url",
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "version",
+                            "value": "small"
+                          }
+                        ],
+                        "storageKey": "url(version:\"small\")"
+                      }
+                    ]
+                  },
                   (v6/*: any*/)
                 ]
               },
@@ -402,7 +429,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "QueryRenderersBidFlowQuery",
-    "id": "adb4180b29b50202816e7a75aefe898b",
+    "id": "5d26329cb874d2e52788cd10d14cbaf0",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/SelectMaxBidRefetchQuery.graphql.ts
+++ b/src/__generated__/SelectMaxBidRefetchQuery.graphql.ts
@@ -49,6 +49,9 @@ fragment ConfirmBid_sale_artwork on SaleArtwork {
     title
     date
     artist_names
+    image {
+      url(version: "small")
+    }
     id
   }
   lot_label
@@ -239,6 +242,30 @@ return {
                 "args": null,
                 "storageKey": null
               },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "image",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "Image",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "url",
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "version",
+                        "value": "small"
+                      }
+                    ],
+                    "storageKey": "url(version:\"small\")"
+                  }
+                ]
+              },
               (v5/*: any*/)
             ]
           },
@@ -277,7 +304,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "SelectMaxBidRefetchQuery",
-    "id": "7411f4c27efe23350e9d331e26473045",
+    "id": "097a6b35c99dd5ef54d9e05a9d420227",
     "text": null,
     "metadata": {}
   }

--- a/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
@@ -1,7 +1,7 @@
 import { Box, Button, Serif } from "@artsy/palette"
 import { get, isEmpty } from "lodash"
 import React from "react"
-import { NativeModules, View, ViewProperties } from "react-native"
+import { Image, NativeModules, ScrollView, View, ViewProperties } from "react-native"
 import NavigatorIOS from "react-native-navigator-ios"
 import { commitMutation, createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
 import stripe from "tipsi-stripe"
@@ -16,7 +16,6 @@ import { LinkText } from "../../Text/LinkText"
 import { BiddingThemeProvider } from "../Components/BiddingThemeProvider"
 import { BidInfoRow } from "../Components/BidInfoRow"
 import { Checkbox } from "../Components/Checkbox"
-import { Container } from "../Components/Containers"
 import { Divider } from "../Components/Divider"
 import { PaymentInfo } from "../Components/PaymentInfo"
 import { Timer } from "../Components/Timer"
@@ -429,60 +428,64 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
 
     return (
       <BiddingThemeProvider>
-        <Container m={0}>
-          <Flex alignItems="center">
-            <Title mb={3}>Confirm your bid</Title>
-            <Timer liveStartsAt={sale.live_start_at} endsAt={sale.end_at} />
-          </Flex>
-
-          <View>
-            <Flex m={4} mt={0} alignItems="center">
-              <Serif size="4t" weight="semibold" numberOfLines={1} ellipsizeMode={"tail"}>
-                {artwork.artist_names}
-              </Serif>
-              <Serif size="2" weight="semibold">
-                Lot {lot_label}
-              </Serif>
-
-              <Serif italic size="2" color="black60" textAlign="center" numberOfLines={1} ellipsizeMode={"tail"}>
-                {artwork.title}
-                {artwork.date && <Serif size="2">, {artwork.date}</Serif>}
-              </Serif>
+        <Flex m={0} flex={1} flexDirection="column">
+          <ScrollView scrollEnabled>
+            <Flex alignItems="center">
+              <Title mb={3}>Confirm your bid</Title>
+              <Timer liveStartsAt={sale.live_start_at} endsAt={sale.end_at} />
             </Flex>
 
-            <Divider />
+            <View>
+              <Flex m={4} alignItems="center">
+                <Image resizeMode="contain" style={{ width: 50, height: 50 }} source={{ uri: artwork.image.url }} />
 
-            <BidInfoRow
-              label="Max bid"
-              value={this.selectedBid().display}
-              onPress={isLoading ? () => null : () => this.goBackToSelectMaxBid()}
-            />
+                <Serif mt={4} size="4t" weight="semibold" numberOfLines={1} ellipsizeMode={"tail"}>
+                  {artwork.artist_names}
+                </Serif>
+                <Serif size="2" weight="semibold">
+                  Lot {lot_label}
+                </Serif>
 
-            {requiresPaymentInformation ? (
-              <PaymentInfo
-                navigator={isLoading ? ({ push: () => null } as any) : this.props.navigator}
-                onCreditCardAdded={this.onCreditCardAdded.bind(this)}
-                onBillingAddressAdded={this.onBillingAddressAdded.bind(this)}
-                billingAddress={this.state.billingAddress}
-                creditCardFormParams={this.state.creditCardFormParams}
-                creditCardToken={this.state.creditCardToken}
+                <Serif italic size="2" color="black60" textAlign="center" numberOfLines={1} ellipsizeMode={"tail"}>
+                  {artwork.title}
+                  {artwork.date && <Serif size="2">, {artwork.date}</Serif>}
+                </Serif>
+              </Flex>
+
+              <Divider />
+
+              <BidInfoRow
+                label="Max bid"
+                value={this.selectedBid().display}
+                onPress={isLoading ? () => null : () => this.goBackToSelectMaxBid()}
               />
-            ) : (
-              <Divider mb={9} />
-            )}
 
-            <Modal
-              visible={this.state.errorModalVisible}
-              headerText="An error occurred"
-              detailText={this.state.errorModalDetailText}
-              closeModal={this.closeModal.bind(this)}
-            />
-          </View>
+              {requiresPaymentInformation ? (
+                <PaymentInfo
+                  navigator={isLoading ? ({ push: () => null } as any) : this.props.navigator}
+                  onCreditCardAdded={this.onCreditCardAdded.bind(this)}
+                  onBillingAddressAdded={this.onBillingAddressAdded.bind(this)}
+                  billingAddress={this.state.billingAddress}
+                  creditCardFormParams={this.state.creditCardFormParams}
+                  creditCardToken={this.state.creditCardToken}
+                />
+              ) : (
+                <Divider mb={9} />
+              )}
+
+              <Modal
+                visible={this.state.errorModalVisible}
+                headerText="An error occurred"
+                detailText={this.state.errorModalDetailText}
+                closeModal={this.closeModal.bind(this)}
+              />
+            </View>
+          </ScrollView>
 
           <View>
             {requiresCheckbox ? (
               <Checkbox
-                mb={4}
+                mt={3}
                 justifyContent="center"
                 onPress={() => this.onConditionsOfSaleCheckboxPressed()}
                 disabled={isLoading}
@@ -519,7 +522,7 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
               </Button>
             </Box>
           </View>
-        </Container>
+        </Flex>
       </BiddingThemeProvider>
     )
   }
@@ -552,6 +555,9 @@ export const ConfirmBidScreen = createRefetchContainer(
           title
           date
           artist_names
+          image {
+            url(version: "small")
+          }
         }
         lot_label
         ...BidResult_sale_artwork

--- a/src/lib/Components/Bidding/Screens/__tests__/ConfirmBid-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/ConfirmBid-tests.tsx
@@ -816,6 +816,9 @@ const saleArtwork = {
     title: "Meteor Shower",
     date: "2015",
     artist_names: "Makiko Kudo",
+    image: {
+      url: "https://d32dm0rphc51dk.cloudfront.net/5RvuM9YF68AyD8OgcdLw7g/small.jpg",
+    },
   },
   sale: {
     id: "best-art-sale-in-town",

--- a/src/lib/Components/Bidding/Screens/__tests__/SelectMaxBid-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/SelectMaxBid-tests.tsx
@@ -24,6 +24,9 @@ const SaleArtwork = ({
     title: "Meteor Shower",
     date: "2015",
     artist_names: "Makiko Kudo",
+    image: {
+      url: "https://d32dm0rphc51dk.cloudfront.net/5RvuM9YF68AyD8OgcdLw7g/small.jpg",
+    },
   },
   sale: {
     id: "best-art-sale-in-town",

--- a/src/lib/Components/Bidding/__stories__/BidFlow.story.tsx
+++ b/src/lib/Components/Bidding/__stories__/BidFlow.story.tsx
@@ -47,7 +47,15 @@ storiesOf("Bidding")
           {
             internalID: "saleartwork12345",
             sale: { id: "sale-id", live_start_at: "2018-08-13T18:00:00+00:00", end_at: null },
-            artwork: { id: "artwork-id", title: "Morgan Hill (Prototype)", date: "1973", artist_names: "Lewis balts" },
+            artwork: {
+              id: "artwork-id",
+              title: "Morgan Hill (Prototype)",
+              date: "1973",
+              artist_names: "Lewis balts",
+              image: {
+                url: "https://d32dm0rphc51dk.cloudfront.net/5RvuM9YF68AyD8OgcdLw7g/small.jpg",
+              },
+            },
             lot_label: "2",
           } as any
         }
@@ -66,7 +74,15 @@ storiesOf("Bidding")
           {
             internalID: "saleartwork12345",
             sale: { id: "sale-id", live_start_at: "2018-08-11T01:00:00+00:00", end_at: null },
-            artwork: { id: "artwork-id", title: "Morgan Hill (Prototype)", date: null, artist_names: "Lewis balts" },
+            artwork: {
+              id: "artwork-id",
+              title: "Morgan Hill (Prototype)",
+              date: null,
+              artist_names: "Lewis balts",
+              image: {
+                url: "https://d32dm0rphc51dk.cloudfront.net/5RvuM9YF68AyD8OgcdLw7g/small.jpg",
+              },
+            },
             lot_label: "2",
           } as any
         }
@@ -87,7 +103,15 @@ storiesOf("Bidding")
           passProps: {
             sale_artwork: {
               sale: { id: "1", live_start_at: "2018-06-11T01:00:00+00:00", end_at: null },
-              artwork: { id: "1", title: "Morgan Hill (Prototype)", date: "1973", artist_names: "Lewis balts" },
+              artwork: {
+                id: "1",
+                title: "Morgan Hill (Prototype)",
+                date: "1973",
+                artist_names: "Lewis balts",
+                image: {
+                  url: "https://d32dm0rphc51dk.cloudfront.net/5RvuM9YF68AyD8OgcdLw7g/small.jpg",
+                },
+              },
               lot_label: "1",
             },
             me: { has_qualified_credit_cards: false, bidders: [] },
@@ -118,6 +142,9 @@ storiesOf("Bidding")
                 title: "Morgan Hill (Prototype)",
                 date: "1973",
                 artist_names: "Lewis balts",
+                image: {
+                  url: "https://d32dm0rphc51dk.cloudfront.net/5RvuM9YF68AyD8OgcdLw7g/small.jpg",
+                },
               },
               lot_label: "1",
             },

--- a/src/lib/Components/Bidding/__tests__/BidFlow-tests.tsx
+++ b/src/lib/Components/Bidding/__tests__/BidFlow-tests.tsx
@@ -182,6 +182,9 @@ const SaleArtwork = {
     title: "Meteor Shower",
     date: "2015",
     artist_names: "Makiko Kudo",
+    image: {
+      url: "https://d32dm0rphc51dk.cloudfront.net/5RvuM9YF68AyD8OgcdLw7g/small.jpg",
+    },
   },
   sale: {
     id: "best-art-sale-in-town",


### PR DESCRIPTION
finishes https://artsyproduct.atlassian.net/browse/AUCT-473

 * Adds `image { url(...) }` to the GraphQL query to retrieve a URL to the `small` image of the artwork
 * Replaces the `<Containers>` with a `<ScrollView>` so smaller screens can host all these elements without getting them squashed
 * Updates tests, snapshots and storybooks to reflect the design change
 * The `“A valid credit card is required for bidding.”` message has already been added as part of https://github.com/artsy/emission/pull/1730 so we get that for free everywhere else

## Screenshots

### iPhone XS

<img width="501" alt="Screen Shot 2019-07-16 at 3 51 46 PM" src="https://user-images.githubusercontent.com/386234/61326706-60821d00-a7e5-11e9-8719-221899a0545e.png">

### iPhone SE

<img width="504" alt="Screen Shot 2019-07-16 at 3 53 06 PM" src="https://user-images.githubusercontent.com/386234/61326722-6972ee80-a7e5-11e9-8678-307865266c1f.png">
