### PR TITLE
Fixes top padding on artwork view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Master
 
+- Fixes a persistent top border when integrated with Eigen - ash
+
 ### 1.12.8
 
 - Fixes a CI build/deploy failure caused by an unexpected local change - yuki24

--- a/src/lib/Scenes/Artwork/Artwork.tsx
+++ b/src/lib/Scenes/Artwork/Artwork.tsx
@@ -155,7 +155,7 @@ export class Artwork extends React.Component<Props> {
   render() {
     return (
       <Theme>
-        <Box pt={this.props.safeAreaInsets.top}>
+        <Box>
           <FlatList
             data={this.sections()}
             ItemSeparatorComponent={() => (
@@ -163,6 +163,7 @@ export class Artwork extends React.Component<Props> {
                 <Separator />
               </Box>
             )}
+            style={{ paddingTop: this.props.safeAreaInsets.top }}
             keyExtractor={(item, index) => item.type + String(index)}
             renderItem={item =>
               item.item === "header" ? this.renderItem(item) : <Box px={2}>{this.renderItem(item)}</Box>


### PR DESCRIPTION
When integrated with Eigen, the Artwork component had a persistent 20px white bar on top. This PR fixes that by moving the spacing from the containing box to the padding of the scrollview itself.

| Before  | After  |
|---|---|
| <img width="559" alt="Screen Shot 2019-07-17 at 16 09 12" src="https://user-images.githubusercontent.com/498212/61408910-21200300-a8af-11e9-96a1-6c1b7ace2210.png">  | <img width="559" alt="Screen Shot 2019-07-17 at 16 08 08" src="https://user-images.githubusercontent.com/498212/61408917-25e4b700-a8af-11e9-98fb-0e3cf82e94e2.png">  |

And it looks good on iPhone X, too:

<img width="545" alt="Screen Shot 2019-07-17 at 16 19 56" src="https://user-images.githubusercontent.com/498212/61409064-6e9c7000-a8af-11e9-91c9-07c1e1bd15fa.png">

Although, it looks like Eigen is still adding a black bar at the top, under the notch. I'd bet this is because we're nesting the view controllers, so it'll be a change in Eigen to get those removed. 