### PR TITLE
Fixes odd spacing and one case where an artwork wasn't loading

### DIFF
--- a/src/lib/Scenes/Artwork/Artwork.tsx
+++ b/src/lib/Scenes/Artwork/Artwork.tsx
@@ -79,10 +79,7 @@ export class Artwork extends React.Component<Props> {
 
   sections = () => {
     const { artwork } = this.props
-    const {
-      artist: { biography_blurb },
-      context,
-    } = artwork
+    const { artist, context } = artwork
 
     const sections = []
 
@@ -101,7 +98,7 @@ export class Artwork extends React.Component<Props> {
       sections.push("history")
     }
 
-    if (biography_blurb) {
+    if (artist && artist.biography_blurb) {
       sections.push("aboutArtist")
     }
 
@@ -157,6 +154,7 @@ export class Artwork extends React.Component<Props> {
                 <Separator />
               </Box>
             )}
+            contentInset={{ bottom: 40 }}
             style={{ paddingTop: this.props.safeAreaInsets.top }}
             keyExtractor={(item, index) => item.type + String(index)}
             renderItem={item =>

--- a/src/lib/Scenes/Artwork/Components/CommercialInformation.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialInformation.tsx
@@ -15,11 +15,13 @@ export class CommercialInformation extends React.Component<CommercialInformation
     const { artwork } = this.props
     const consignableArtistsCount = artwork.artists.filter(artist => artist.is_consignable).length
     const inClosedAuction = artwork.sale && artwork.sale.is_auction && artwork.sale.is_closed
+    const showsSellerInfo = artwork.partner && artwork.partner.name && !inClosedAuction
+
     return (
       <Box>
         {artwork.availability && <ArtworkAvailability artwork={artwork} />}
-        {artwork.availability && artwork.partner && artwork.partner.name && <Spacer mb={2} />}
-        {artwork.partner && artwork.partner.name && !inClosedAuction && <SellerInfo artwork={artwork} />}
+        {artwork.availability && showsSellerInfo && <Spacer mb={2} />}
+        {showsSellerInfo && <SellerInfo artwork={artwork} />}
         {!!consignableArtistsCount && <Spacer mb={2} />}
         <ArtworkExtraLinks consignableArtistsCount={consignableArtistsCount} />
       </Box>


### PR DESCRIPTION
While I was QAing I noticed a couple of bugs:
- Some artworks have non-public artists. We were failing to load pages in those cases due to a missing `biography_blurb`
- Added a `contentInset` which seems to be the way to add spacing after a `FlatList` (otherwise the bottom part of `OtherWorks` was being cut off).
- Fixed an issue where we had extra spacing if there was no "partner" line

Before:
<img width="415" alt="Screen Shot 2019-07-19 at 12 56 53 PM" src="https://user-images.githubusercontent.com/2081340/61553984-d70f5c80-aa29-11e9-8ae7-0538515ad4b3.png">

After:
<img width="418" alt="Screen Shot 2019-07-19 at 12 59 10 PM" src="https://user-images.githubusercontent.com/2081340/61553987-d971b680-aa29-11e9-804f-02498fca6cbe.png">

#trivial