### PR TITLE
[PURCHASE-1261] Artwork date should always appear on same line as title

### DIFF
--- a/src/lib/Scenes/Artwork/Components/ArtworkTombstone.tsx
+++ b/src/lib/Scenes/Artwork/Components/ArtworkTombstone.tsx
@@ -116,14 +116,16 @@ export class ArtworkTombstone extends React.Component<ArtworkTombstoneProps, Art
             this.renderArtistName(artwork.cultural_maker, null)}
         </Flex>
         <Flex flexDirection="row" flexWrap="wrap">
-          <Serif italic color="black60" size="3t">
-            {artwork.title + addedComma}
-          </Serif>
-          {artwork.date && (
-            <Serif color="black60" size="3t">
-              {artwork.date}
+          <Serif size="3t">
+            <Serif italic color="black60" size="3t">
+              {artwork.title + addedComma}
             </Serif>
-          )}
+            {artwork.date && (
+              <Serif color="black60" size="3t">
+                {artwork.date}
+              </Serif>
+            )}
+          </Serif>
         </Flex>
         <Serif color="black60" size="3t">
           {artwork.medium}


### PR DESCRIPTION
__Before:__
<img width="358" alt="Screen Shot 2019-07-22 at 4 17 53 PM" src="https://user-images.githubusercontent.com/5643895/61662544-a2efa200-ac9c-11e9-9202-e2434a9d17ba.png">

__After:__
<img width="352" alt="Screen Shot 2019-07-22 at 4 17 21 PM" src="https://user-images.githubusercontent.com/5643895/61662565-a97e1980-ac9c-11e9-950a-958916fddb5d.png">

#trivial