### PR TITLE
Fixes an issue where placing a bid hangs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Master
 
+- Fixes an issue where placing a bid hangs - yuki24
+
 ### 1.12.9
 
 - Fixes a persistent top border when integrated with Eigen - ash

--- a/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
@@ -61,7 +61,7 @@ interface ConfirmBidState {
 
 const MAX_POLL_ATTEMPTS = 20
 
-const queryForBidPosition = (bidderPositionID: string) => {
+const queryForBidderPosition = (bidderPositionID: string) => {
   return metaphysics({
     query: `
       query ConfirmBidBidderPositionQuery($bidderPositionID: String!) {
@@ -259,7 +259,7 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
   createBidderPosition() {
     commitMutation<ConfirmBidCreateBidderPositionMutation>(this.props.relay.environment, {
       onCompleted: (results, errors) =>
-        isEmpty(errors) ? this.verifyBidPosition(results) : this.presentErrorResult(errors),
+        isEmpty(errors) ? this.verifyBidderPosition(results) : this.presentErrorResult(errors),
       onError: this.presentErrorResult.bind(this),
       mutation: graphql`
         mutation ConfirmBidCreateBidderPositionMutation($input: BidderPositionInput!) {
@@ -290,7 +290,7 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
     })
   }
 
-  verifyBidPosition(results) {
+  verifyBidderPosition(results) {
     const { result } = results.createBidderPosition
 
     if (result.status === "SUCCESS") {
@@ -305,16 +305,16 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
     action_name: Schema.ActionNames.BidFlowPlaceBid,
   })
   bidPlacedSuccessfully(positionId) {
-    queryForBidPosition(positionId).then(this.checkBidPosition.bind(this))
+    queryForBidderPosition(positionId).then(this.checkBidderPosition.bind(this))
   }
 
-  checkBidPosition(result) {
+  checkBidderPosition(result) {
     const { bidder_position } = result.data.me
 
     if (bidder_position.status === "PENDING" && this.pollCount < MAX_POLL_ATTEMPTS) {
       // initiating new request here (vs setInterval) to make sure we wait for the previous call to return before making a new one
       setTimeout(
-        () => queryForBidPosition(bidder_position.position.internalID).then(this.checkBidPosition.bind(this)),
+        () => queryForBidderPosition(bidder_position.position.internalID).then(this.checkBidderPosition.bind(this)),
         1000
       )
 

--- a/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
@@ -64,14 +64,14 @@ const MAX_POLL_ATTEMPTS = 20
 const queryForBidPosition = (bidderPositionID: string) => {
   return metaphysics({
     query: `
-      {
+      query ConfirmBidBidderPositionQuery($bidderPositionID: String!) {
         me {
-          bidder_position(id: "${bidderPositionID}") {
+          bidder_position(id: $bidderPositionID) {
             status
             message_header
             message_description_md
             position {
-              id
+              internalID
               suggested_next_bid {
                 cents
                 display
@@ -81,6 +81,7 @@ const queryForBidPosition = (bidderPositionID: string) => {
         }
       }
     `,
+    variables: { bidderPositionID },
   })
 }
 
@@ -293,7 +294,7 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
     const { result } = results.createBidderPosition
 
     if (result.status === "SUCCESS") {
-      this.bidPlacedSuccessfully(result.position.id)
+      this.bidPlacedSuccessfully(result.position.internalID)
     } else {
       this.presentBidResult(result)
     }
@@ -312,7 +313,10 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
 
     if (bidder_position.status === "PENDING" && this.pollCount < MAX_POLL_ATTEMPTS) {
       // initiating new request here (vs setInterval) to make sure we wait for the previous call to return before making a new one
-      setTimeout(() => queryForBidPosition(bidder_position.position.id).then(this.checkBidPosition.bind(this)), 1000)
+      setTimeout(
+        () => queryForBidPosition(bidder_position.position.internalID).then(this.checkBidPosition.bind(this)),
+        1000
+      )
 
       this.pollCount += 1
     } else {


### PR DESCRIPTION
fixes https://artsyproduct.atlassian.net/browse/AUCT-499
blocked by https://github.com/artsy/emission/pull/1741

eThis is the actual fix for the bug. Basically the issue is that `result.position.id` was not replaced even after we switched to MP v2. As a result of this, `undefined` is passed on to the polling query which causes the server to return an error. This PR replaces all the occurances of `id` in the `<ConfirmBid>` component.

I have another PR that adds more type checks to mitigate the same type of risks: https://github.com/artsy/emission/compare/master...add-more-type-checks