### PR TITLE
Display an error message when polling fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Master
 
+- Display an error message when polling fails on bidding - yuki24
 - Fixes an issue where placing a bid hangs - yuki24
 
 ### 1.12.9

--- a/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
@@ -305,7 +305,9 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
     action_name: Schema.ActionNames.BidFlowPlaceBid,
   })
   bidPlacedSuccessfully(positionId) {
-    queryForBidderPosition(positionId).then(this.checkBidderPosition.bind(this))
+    queryForBidderPosition(positionId)
+      .then(this.checkBidderPosition.bind(this))
+      .catch(error => this.presentErrorResult(error))
   }
 
   checkBidderPosition(result) {
@@ -314,7 +316,10 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
     if (bidder_position.status === "PENDING" && this.pollCount < MAX_POLL_ATTEMPTS) {
       // initiating new request here (vs setInterval) to make sure we wait for the previous call to return before making a new one
       setTimeout(
-        () => queryForBidderPosition(bidder_position.position.internalID).then(this.checkBidderPosition.bind(this)),
+        () =>
+          queryForBidderPosition(bidder_position.position.internalID)
+            .then(this.checkBidderPosition.bind(this))
+            .catch(error => this.presentErrorResult(error)),
         1000
       )
 

--- a/src/lib/Components/Bidding/Screens/__tests__/ConfirmBid-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/ConfirmBid-tests.tsx
@@ -729,6 +729,26 @@ describe("ConfirmBid for unqualified user", () => {
       expect(mockphysics.mock.calls[0][0].variables).toEqual({ bidderPositionID: "bidder-position-id-from-mutation" })
       expect(mockphysics.mock.calls[1][0].variables).toEqual({ bidderPositionID: "bidder-position-id-from-polling" })
     })
+
+    it("displays an error message on polling failure", () => {
+      console.error = jest.fn() // Silences component logging.
+      mockphysics.mockReturnValueOnce(Promise.reject({ message: "error" }))
+
+      const component = mountConfirmBidComponent(initialPropsForUnqualifiedUser)
+
+      fillOutFormAndSubmit(component)
+
+      expect(nextStep.component).toEqual(BidResultScreen)
+      expect(nextStep.passProps).toEqual(
+        expect.objectContaining({
+          bidderPositionResult: {
+            message_header: "An error occurred",
+            message_description_md:
+              "Your bid couldn’t be placed. Please\ncheck your internet connection\nand try again.",
+          },
+        })
+      )
+    })
   })
 })
 


### PR DESCRIPTION
finishes https://artsyproduct.atlassian.net/browse/AUCT-501
blocked by https://github.com/artsy/emission/pull/1742

 * [x] self-QA

## Successful case

![ezgif com-gif-maker](https://user-images.githubusercontent.com/386234/61745519-b6b40a80-ad67-11e9-8093-7e04f4d075b3.gif)

## Failing case

![AUCT-501](https://user-images.githubusercontent.com/386234/61745696-1ca09200-ad68-11e9-947c-93959e6563f4.gif)

tested with the diff of:

```diff
diff --git a/src/lib/Components/Bidding/Screens/ConfirmBid.tsx b/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
index c001482c2..7222f6a07 100644
--- a/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmBid.tsx
@@ -294,7 +294,7 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
     const { result } = results.createBidderPosition

     if (result.status === "SUCCESS") {
-      this.bidPlacedSuccessfully(result.position.internalID)
+      this.bidPlacedSuccessfully(result.position.id)
     } else {
       this.presentBidResult(result)
     }
@@ -317,7 +317,7 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
       // initiating new request here (vs setInterval) to make sure we wait for the previous call to return before making a new one
       setTimeout(
         () =>
-          queryForBidderPosition(bidder_position.position.internalID)
+          queryForBidderPosition(bidder_position.position.id)
             .then(this.checkBidderPosition.bind(this))
             .catch(error => this.presentErrorResult(error)),
         1000
```