### PR TITLE
WIP: [PURCHASE-1276] Adds RetryErrorBoundary, adds to Artwork page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Fixes a persistent top border when integrated with Eigen - ash
 - Adds remaining Other Works Grids to the artwork view - sweir27
 - Adds tracking to Artwork page - kierangillen
+- Adds error-handling to Artwork page - ash
 
 ### 1.12.8
 

--- a/src/lib/Components/RetryErrorBoundary.tsx
+++ b/src/lib/Components/RetryErrorBoundary.tsx
@@ -8,7 +8,7 @@ enum ErrorState {
 }
 
 interface Props {
-  render: (isRetry) => React.ReactNode
+  render: ({ isRetry: boolean }) => React.ReactNode
 }
 
 interface State {
@@ -30,11 +30,11 @@ export class RetryErrorBoundary extends React.Component<Props, State> {
   render() {
     const { render } = this.props
     const containers = {
-      [ErrorState.Okay]: () => render(false),
+      [ErrorState.Okay]: () => render({ isRetry: false }),
       [ErrorState.Error]: () => (
         <LoadFailureView style={{ flex: 1 }} onRetry={() => this.setState({ errorState: ErrorState.Retry })} />
       ),
-      [ErrorState.Retry]: () => render(true),
+      [ErrorState.Retry]: () => render({ isRetry: true }),
     }
     return containers[this.state.errorState]()
   }

--- a/src/lib/Components/RetryErrorBoundary.tsx
+++ b/src/lib/Components/RetryErrorBoundary.tsx
@@ -4,10 +4,11 @@ import LoadFailureView from "./LoadFailureView"
 enum ErrorState {
   Okay,
   Error,
+  Retry,
 }
 
 interface Props {
-  render: () => React.ReactNode
+  render: (isRetry) => React.ReactNode
 }
 
 interface State {
@@ -26,10 +27,11 @@ export class RetryErrorBoundary extends React.Component<Props, State> {
   render() {
     const { render } = this.props
     const containers = {
-      [ErrorState.Okay]: render,
+      [ErrorState.Okay]: () => render(false),
       [ErrorState.Error]: () => (
-        <LoadFailureView style={{ flex: 1 }} onRetry={() => this.setState({ errorState: ErrorState.Okay })} />
+        <LoadFailureView style={{ flex: 1 }} onRetry={() => this.setState({ errorState: ErrorState.Retry })} />
       ),
+      [ErrorState.Retry]: () => render(true),
     }
     return containers[this.state.errorState]()
   }

--- a/src/lib/Components/RetryErrorBoundary.tsx
+++ b/src/lib/Components/RetryErrorBoundary.tsx
@@ -19,7 +19,7 @@ interface State {
 /// the render prop with a parameter value of `true`.
 export class RetryErrorBoundary extends React.Component<Props, State> {
   static getDerivedStateFromError(error) {
-    console.log("[RetryErrorBoundary] Caught error: ", error)
+    console.warn("[RetryErrorBoundary] Caught error: ", error)
     return { errorState: ErrorState.Error }
   }
 

--- a/src/lib/Components/RetryErrorBoundary.tsx
+++ b/src/lib/Components/RetryErrorBoundary.tsx
@@ -14,6 +14,9 @@ interface Props {
 interface State {
   errorState: ErrorState
 }
+
+/// Catches any errors and shows a failure screen. The user can tap a button to retry the render, which is indicated to
+/// the render prop with a parameter value of `true`.
 export class RetryErrorBoundary extends React.Component<Props, State> {
   static getDerivedStateFromError(error) {
     console.log("[RetryErrorBoundary] Caught error: ", error)

--- a/src/lib/Components/RetryErrorBoundary.tsx
+++ b/src/lib/Components/RetryErrorBoundary.tsx
@@ -1,0 +1,36 @@
+import React from "react"
+import LoadFailureView from "./LoadFailureView"
+
+enum ErrorState {
+  Okay,
+  Error,
+}
+
+interface Props {
+  render: () => React.ReactNode
+}
+
+interface State {
+  errorState: ErrorState
+}
+export class RetryErrorBoundary extends React.Component<Props, State> {
+  static getDerivedStateFromError(error) {
+    console.log("[RetryErrorBoundary] Caught error: ", error)
+    return { errorState: ErrorState.Error }
+  }
+
+  state = {
+    errorState: ErrorState.Okay,
+  }
+
+  render() {
+    const { render } = this.props
+    const containers = {
+      [ErrorState.Okay]: render,
+      [ErrorState.Error]: () => (
+        <LoadFailureView style={{ flex: 1 }} onRetry={() => this.setState({ errorState: ErrorState.Okay })} />
+      ),
+    }
+    return containers[this.state.errorState]()
+  }
+}

--- a/src/lib/Components/__tests__/RetryErrorBoundary-tests.tsx
+++ b/src/lib/Components/__tests__/RetryErrorBoundary-tests.tsx
@@ -18,7 +18,7 @@ it("passes false for isRetry to render prop on first pass", () => {
   let receivedIsRetry = true
   renderer.create(
     <RetryErrorBoundary
-      render={isRetry => {
+      render={({ isRetry }) => {
         receivedIsRetry = isRetry
         return <CrashingComponent shouldCrash={true} />
       }}
@@ -31,7 +31,7 @@ it("passes true for isRetry to render prop on retry", () => {
   let receivedIsRetry = false
   const tree = renderer.create(
     <RetryErrorBoundary
-      render={isRetry => {
+      render={({ isRetry }) => {
         receivedIsRetry = isRetry
         // Only crash on the first attempt, succeed on the retry.
         return <CrashingComponent shouldCrash={isRetry ? false : true} />

--- a/src/lib/Components/__tests__/RetryErrorBoundary-tests.tsx
+++ b/src/lib/Components/__tests__/RetryErrorBoundary-tests.tsx
@@ -1,0 +1,52 @@
+import React from "react"
+import "react-native"
+import * as renderer from "react-test-renderer"
+
+import LoadFailureView from "../LoadFailureView"
+import { RetryErrorBoundary } from "../RetryErrorBoundary"
+
+beforeEach(() => {
+  console.log = jest.fn()
+})
+
+it("Renders the fallback view when the rendered component crashes", () => {
+  const tree = renderer.create(<RetryErrorBoundary render={() => <CrashingComponent shouldCrash={true} />} />).toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+it("passes false for isRetry to render prop on first pass", () => {
+  let receivedIsRetry = true
+  renderer.create(
+    <RetryErrorBoundary
+      render={isRetry => {
+        receivedIsRetry = isRetry
+        return <CrashingComponent shouldCrash={true} />
+      }}
+    />
+  )
+  expect(receivedIsRetry).toBeFalsy()
+})
+
+it("passes true for isRetry to render prop on retry", () => {
+  let receivedIsRetry = false
+  const tree = renderer.create(
+    <RetryErrorBoundary
+      render={isRetry => {
+        receivedIsRetry = isRetry
+        // Only crash on the first attempt, succeed on the retry.
+        return <CrashingComponent shouldCrash={isRetry ? false : true} />
+      }}
+    />
+  )
+  // Simulate user pressing retry button
+  tree.root.findAllByType(LoadFailureView)[0].props.onRetry()
+  expect(receivedIsRetry).toBeTruthy()
+})
+
+const CrashingComponent: React.SFC<{ shouldCrash: boolean }> = ({ shouldCrash }) => {
+  const thing: any = null
+  if (shouldCrash && thing.thisshouldcrash) {
+    return null
+  }
+  return null
+}

--- a/src/lib/Components/__tests__/RetryErrorBoundary-tests.tsx
+++ b/src/lib/Components/__tests__/RetryErrorBoundary-tests.tsx
@@ -6,7 +6,7 @@ import LoadFailureView from "../LoadFailureView"
 import { RetryErrorBoundary } from "../RetryErrorBoundary"
 
 beforeEach(() => {
-  console.log = jest.fn()
+  console.warn = jest.fn()
 })
 
 it("Renders the fallback view when the rendered component crashes", () => {

--- a/src/lib/Components/__tests__/__snapshots__/RetryErrorBoundary-tests.tsx.snap
+++ b/src/lib/Components/__tests__/__snapshots__/RetryErrorBoundary-tests.tsx.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Renders the fallback view when the rendered component crashes 1`] = `
+<ARLoadFailureView
+  onRetry={[Function]}
+  style={
+    Object {
+      "flex": 1,
+    }
+  }
+/>
+`;

--- a/src/lib/Scenes/Artwork/Artwork.tsx
+++ b/src/lib/Scenes/Artwork/Artwork.tsx
@@ -1,6 +1,7 @@
 import { Box, Theme } from "@artsy/palette"
 import { Artwork_artwork } from "__generated__/Artwork_artwork.graphql"
 import { ArtworkQuery } from "__generated__/ArtworkQuery.graphql"
+import { RetryErrorBoundary } from "lib/Components/RetryErrorBoundary"
 import Separator from "lib/Components/Separator"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { SafeAreaInsets } from "lib/types/SafeAreaInsets"
@@ -156,6 +157,9 @@ export class Artwork extends React.Component<Props> {
   }
 
   render() {
+    console.log("[RetryErrorBoundary] Rendering Artwork page")
+    const a: any = {}
+    console.log(a.thing.thisshouldcrash)
     return (
       <Theme>
         <FlatList
@@ -257,19 +261,25 @@ export const ArtworkRenderer: React.SFC<{ artworkID: string; safeAreaInsets: Saf
   ...others
 }) => {
   return (
-    <QueryRenderer<ArtworkQuery>
-      environment={defaultEnvironment}
-      query={graphql`
-        query ArtworkQuery($artworkID: String!) {
-          artwork(id: $artworkID) {
-            ...Artwork_artwork
-          }
-        }
-      `}
-      variables={{
-        artworkID,
+    <RetryErrorBoundary
+      render={() => {
+        return (
+          <QueryRenderer<ArtworkQuery>
+            environment={defaultEnvironment}
+            query={graphql`
+              query ArtworkQuery($artworkID: String!) {
+                artwork(id: $artworkID) {
+                  ...Artwork_artwork
+                }
+              }
+            `}
+            variables={{
+              artworkID,
+            }}
+            render={renderWithLoadProgress(ArtworkContainer, others)}
+          />
+        )
       }}
-      render={renderWithLoadProgress(ArtworkContainer, others)}
     />
   )
 }

--- a/src/lib/Scenes/Artwork/Artwork.tsx
+++ b/src/lib/Scenes/Artwork/Artwork.tsx
@@ -262,7 +262,8 @@ export const ArtworkRenderer: React.SFC<{ artworkID: string; safeAreaInsets: Saf
 }) => {
   return (
     <RetryErrorBoundary
-      render={() => {
+      render={isRetry => {
+        console.log({ isRetry })
         return (
           <QueryRenderer<ArtworkQuery>
             environment={defaultEnvironment}
@@ -275,6 +276,10 @@ export const ArtworkRenderer: React.SFC<{ artworkID: string; safeAreaInsets: Saf
             `}
             variables={{
               artworkID,
+            }}
+            cacheConfig={{
+              // Bypass Relay cache on retries.
+              ...(isRetry && { force: true }),
             }}
             render={renderWithLoadProgress(ArtworkContainer, others)}
           />

--- a/src/lib/Scenes/Artwork/Artwork.tsx
+++ b/src/lib/Scenes/Artwork/Artwork.tsx
@@ -259,7 +259,7 @@ export const ArtworkRenderer: React.SFC<{ artworkID: string; safeAreaInsets: Saf
 }) => {
   return (
     <RetryErrorBoundary
-      render={isRetry => {
+      render={({ isRetry }) => {
         return (
           <QueryRenderer<ArtworkQuery>
             environment={defaultEnvironment}

--- a/src/lib/Scenes/Artwork/Artwork.tsx
+++ b/src/lib/Scenes/Artwork/Artwork.tsx
@@ -157,9 +157,6 @@ export class Artwork extends React.Component<Props> {
   }
 
   render() {
-    console.log("[RetryErrorBoundary] Rendering Artwork page")
-    const a: any = {}
-    console.log(a.thing.thisshouldcrash)
     return (
       <Theme>
         <FlatList
@@ -263,7 +260,6 @@ export const ArtworkRenderer: React.SFC<{ artworkID: string; safeAreaInsets: Saf
   return (
     <RetryErrorBoundary
       render={isRetry => {
-        console.log({ isRetry })
         return (
           <QueryRenderer<ArtworkQuery>
             environment={defaultEnvironment}


### PR DESCRIPTION
This PR adds a new RetryErrorBoundary component and uses that component to wrap the Artwork page in a `LoadFailureView`. I settled on the same approach that `QueryRenderer` itself uses (a `render` prop) but I'm open to feedback on the component name and its API. This should work with a modified `renderWithProgress` that will show a [custom skeleton loading page](https://artsyproduct.atlassian.net/browse/PURCHASE-1278).

This PR is a work-in-progress because:

- [x] This needs tests.
- [x] I want to add a `isRetry` parameter to the `render` function, so that we can configure Relay to re-fetch its data.
- [x] General cleanup.