### PR TITLE
[PURCHASE-1328, PURCHASE-1257, PURCHASE-1349] Small changes to padding and font size 

### DIFF
--- a/Pod/Classes/ViewControllers/ARArtworkAttributionClassFAQViewController.m
+++ b/Pod/Classes/ViewControllers/ARArtworkAttributionClassFAQViewController.m
@@ -11,4 +11,10 @@
                         moduleName:@"ArtworkAttributionClassFAQ"
                  initialProperties:@{}];
 }
+
+- (BOOL)shouldInjectSafeAreaInsets
+{
+    return YES;
+}
+
 @end

--- a/src/lib/Scenes/Artwork/Components/ArtworkExtraLinks.tsx
+++ b/src/lib/Scenes/Artwork/Components/ArtworkExtraLinks.tsx
@@ -28,7 +28,7 @@ export class ArtworkExtraLinks extends React.Component<ArtworkExtraLinksProps> {
 
   renderConsignmentsLine(artistsCount) {
     return (
-      <Sans size="3t" color="black60">
+      <Sans size="2" color="black60">
         Want to sell a work by {artistsCount === 1 ? "this artist" : "these artists"}?{" "}
         <Text style={{ textDecorationLine: "underline" }} onPress={() => this.handleConsignmentsTap()}>
           Consign with Artsy.

--- a/src/lib/Scenes/Artwork/Components/CommercialInformation.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialInformation.tsx
@@ -20,7 +20,7 @@ export class CommercialInformation extends React.Component<CommercialInformation
     return (
       <Box>
         {artwork.availability && <ArtworkAvailability artwork={artwork} />}
-        {artwork.availability && showsSellerInfo && <Spacer mb={2} />}
+        {artwork.availability && showsSellerInfo && <Spacer mb={1} />}
         {showsSellerInfo && <SellerInfo artwork={artwork} />}
         {!!consignableArtistsCount && <Spacer mb={2} />}
         <ArtworkExtraLinks consignableArtistsCount={consignableArtistsCount} />

--- a/src/lib/Scenes/ArtworkAttributionClassFAQ/ArtworkAttributionClassFAQ.tsx
+++ b/src/lib/Scenes/ArtworkAttributionClassFAQ/ArtworkAttributionClassFAQ.tsx
@@ -3,12 +3,14 @@ import { ArtworkAttributionClassFAQ_artworkAttributionClasses } from "__generate
 import { ArtworkAttributionClassFAQRendererQuery } from "__generated__/ArtworkAttributionClassFAQRendererQuery.graphql"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
+import { SafeAreaInsets } from "lib/types/SafeAreaInsets"
 import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
 import React from "react"
 import { ScrollView } from "react-native"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 
 interface Props {
+  safeAreaInsets: SafeAreaInsets
   artworkAttributionClasses: ArtworkAttributionClassFAQ_artworkAttributionClasses
 }
 
@@ -33,11 +35,12 @@ export class ArtworkAttributionClassFAQ extends React.Component<Props> {
         </React.Fragment>
       )
     })
+
     return (
       <Theme>
-        <Box px={2}>
-          <ScrollView>
-            <Spacer m={4} />
+        <ScrollView>
+          <Box pt={this.props.safeAreaInsets.top} pb={this.props.safeAreaInsets.top} px={2}>
+            <Spacer mt={3} />
             <Serif mb={2} size="8">
               Artwork classifications
             </Serif>
@@ -50,9 +53,8 @@ export class ArtworkAttributionClassFAQ extends React.Component<Props> {
                 OK
               </Button>
             </Box>
-            <Spacer m={2} />
-          </ScrollView>
-        </Box>
+          </Box>
+        </ScrollView>
       </Theme>
     )
   }
@@ -67,7 +69,7 @@ export const ArtworkAttributionClassFAQContainer = createFragmentContainer(Artwo
   `,
 })
 
-export const ArtworkAttributionClassFAQRenderer: React.SFC = () => {
+export const ArtworkAttributionClassFAQRenderer: React.SFC<{ safeAreaInsets: SafeAreaInsets }> = props => {
   return (
     <QueryRenderer<ArtworkAttributionClassFAQRendererQuery>
       environment={defaultEnvironment}
@@ -79,7 +81,7 @@ export const ArtworkAttributionClassFAQRenderer: React.SFC = () => {
         }
       `}
       variables={{}}
-      render={renderWithLoadProgress(ArtworkAttributionClassFAQContainer)}
+      render={renderWithLoadProgress(ArtworkAttributionClassFAQContainer, props)}
     />
   )
 }

--- a/src/lib/Scenes/ArtworkAttributionClassFAQ/__tests__/ArtworkAttributionClassFAQ-tests.tsx
+++ b/src/lib/Scenes/ArtworkAttributionClassFAQ/__tests__/ArtworkAttributionClassFAQ-tests.tsx
@@ -12,7 +12,12 @@ import SwitchBoard from "lib/NativeModules/SwitchBoard"
 
 describe("ArtworkAttributionClassFAQ", () => {
   it("renders FAQ header", () => {
-    const component = mount(<ArtworkAttributionClassFAQ artworkAttributionClasses={attributionClasses} />)
+    const component = mount(
+      <ArtworkAttributionClassFAQ
+        safeAreaInsets={{ top: 20, left: 0, right: 0, bottom: 0 }}
+        artworkAttributionClasses={attributionClasses}
+      />
+    )
     expect(
       component
         .find(Serif)
@@ -22,7 +27,12 @@ describe("ArtworkAttributionClassFAQ", () => {
   })
 
   it("renders Ok button", () => {
-    const component = mount(<ArtworkAttributionClassFAQ artworkAttributionClasses={attributionClasses} />)
+    const component = mount(
+      <ArtworkAttributionClassFAQ
+        safeAreaInsets={{ top: 20, left: 0, right: 0, bottom: 0 }}
+        artworkAttributionClasses={attributionClasses}
+      />
+    )
     expect(
       component
         .find(Button)
@@ -33,7 +43,12 @@ describe("ArtworkAttributionClassFAQ", () => {
   })
 
   it("renders attribution classes", () => {
-    const component = mount(<ArtworkAttributionClassFAQ artworkAttributionClasses={attributionClasses} />)
+    const component = mount(
+      <ArtworkAttributionClassFAQ
+        safeAreaInsets={{ top: 20, left: 0, right: 0, bottom: 0 }}
+        artworkAttributionClasses={attributionClasses}
+      />
+    )
     expect(
       component
         .find(Serif)
@@ -50,7 +65,12 @@ describe("ArtworkAttributionClassFAQ", () => {
   })
 
   it("returns to previous page when ok button is clicked", () => {
-    const component = mount(<ArtworkAttributionClassFAQ artworkAttributionClasses={attributionClasses} />)
+    const component = mount(
+      <ArtworkAttributionClassFAQ
+        safeAreaInsets={{ top: 20, left: 0, right: 0, bottom: 0 }}
+        artworkAttributionClasses={attributionClasses}
+      />
+    )
     const okButton = component.find(Button).at(0)
     okButton.props().onPress()
     expect(SwitchBoard.dismissNavigationViewController).toHaveBeenCalled()


### PR DESCRIPTION
# PURCHASE-1328 Adjust spacing and font size in Availability section
In the Availability section, we want to update the spacing between availability, partner name, and consignment link according to the spec below. We also need to adjust the font size for the consignment link down to Sans2 (12px size / 16px line-height)

__Before:__
<img width="348" alt="Screen Shot 2019-07-24 at 5 23 01 PM" src="https://user-images.githubusercontent.com/5643895/61829830-b84d0380-ae37-11e9-9db7-fc45e0addac9.png">

__After:__
<img width="345" alt="Screen Shot 2019-07-24 at 5 17 36 PM" src="https://user-images.githubusercontent.com/5643895/61829625-5b514d80-ae37-11e9-89bb-25b57d002395.png">

For auctions (bidding closed state), when partner name is not available, we should move the consignment text up (20px spacing between “Bidding Closed” and “Want to sell a work by this artist?…”)

# PURCHASE-1257 Scrub through Artwork view to make sure we're not adding padding/margin to the outer wrapper of child components

No changes made. Outer wrapper padding has been removed from child components already

# PURCHASE-1349 Add SafeAreaInsets to Artwork Attribution Class FAQ
Added safeAreaInsets to Artwork Attribution Class FAQ page and adjusted padding to Sam's specifications.

<img width="372" alt="Screen Shot 2019-07-24 at 5 20 01 PM" src="https://user-images.githubusercontent.com/5643895/61829613-5391a900-ae37-11e9-950f-4cdb48baf1b8.png">

#trivial