### PR TITLE
Add input textContentType for registration BillingAddress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Update after dropping deprecations from MP v2 - alloy
 - Add full screen carousel support in artwork view - ds300
 - Update after dropping duplicated types from MP v2 - zephraph
+- Updates textContentType for inputs on BillingAddress component - ash
 
 ### 1.12.11
 

--- a/src/lib/Components/Bidding/Components/Input.tsx
+++ b/src/lib/Components/Bidding/Components/Input.tsx
@@ -2,7 +2,7 @@ import React, { Component } from "react"
 import { TextInputProperties } from "react-native"
 import { TextInput, TextInputProps } from "../Elements/TextInput"
 
-interface InputProps extends TextInputProps, TextInputProperties {
+export interface InputProps extends TextInputProps, TextInputProperties {
   error?: boolean
   inputRef?: (component: any) => void
 }

--- a/src/lib/Components/Bidding/Screens/BillingAddress.tsx
+++ b/src/lib/Components/Bidding/Screens/BillingAddress.tsx
@@ -21,7 +21,7 @@ import { validatePresence } from "../Validators"
 import { BackButton } from "../Components/BackButton"
 import { BiddingThemeProvider } from "../Components/BiddingThemeProvider"
 import { Container } from "../Components/Containers"
-import { Input } from "../Components/Input"
+import { Input, InputProps } from "../Components/Input"
 import { Title } from "../Components/Title"
 import { Address, Country } from "../types"
 
@@ -35,15 +35,19 @@ interface StyledInputInterface {
   }
 }
 
-const StyledInput = ({ label, error, onLayout, ...props }) => (
+interface StyledInputProps extends InputProps {
+  label: string
+  errorMessage?: string
+}
+const StyledInput: React.FC<StyledInputProps> = ({ label, errorMessage, onLayout, ...props }) => (
   <Flex mb={4} onLayout={onLayout}>
     <Serif size="3" mb={2}>
       {label}
     </Serif>
-    <Input mb={3} error={Boolean(error)} {...props} />
-    {!!error && (
+    <Input mb={3} error={Boolean(errorMessage)} {...props} />
+    {!!errorMessage && (
       <Sans size="2" color="red100">
-        {error}
+        {errorMessage}
       </Sans>
     )}
   </Flex>
@@ -197,6 +201,7 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
                 label="Full name"
                 placeholder="Add your full name"
                 autoFocus={true}
+                textContentType="name"
                 onSubmitEditing={() => this.addressLine1.root.focus()}
                 onLayout={({ nativeEvent }) => (this.fullNameLayout = nativeEvent.layout)}
                 onFocus={() => this.scrollView.scrollTo({ x: 0, y: this.yPosition(this.fullNameLayout) })}
@@ -206,6 +211,7 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
                 {...this.defaultPropsForInput("addressLine1")}
                 label="Address line 1"
                 placeholder="Add your street address"
+                textContentType="streetAddressLine1"
                 onSubmitEditing={() => this.addressLine2.root.focus()}
                 onLayout={({ nativeEvent }) => (this.addressLine1Layout = nativeEvent.layout)}
                 onFocus={() => this.scrollView.scrollTo({ x: 0, y: this.yPosition(this.addressLine1Layout) })}
@@ -215,6 +221,7 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
                 {...this.defaultPropsForInput("addressLine2")}
                 label="Address line 2 (optional)"
                 placeholder="Add your apt, floor, suite, etc."
+                textContentType="streetAddressLine2"
                 onSubmitEditing={() => this.city.root.focus()}
                 onLayout={({ nativeEvent }) => (this.addressLine2Layout = nativeEvent.layout)}
                 onFocus={() => this.scrollView.scrollTo({ x: 0, y: this.yPosition(this.addressLine2Layout) })}
@@ -224,6 +231,7 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
                 {...this.defaultPropsForInput("city")}
                 label="City"
                 placeholder="Add your city"
+                textContentType="addressCity"
                 onSubmitEditing={() => this.stateProvinceRegion.root.focus()}
                 onLayout={({ nativeEvent }) => (this.cityLayout = nativeEvent.layout)}
                 onFocus={() => this.scrollView.scrollTo({ x: 0, y: this.yPosition(this.cityLayout) })}
@@ -233,6 +241,7 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
                 {...this.defaultPropsForInput("state")}
                 label="State, Province, or Region"
                 placeholder="Add state, province, or region"
+                textContentType="addressState"
                 onSubmitEditing={() => this.postalCode.root.focus()}
                 inputRef={el => (this.stateProvinceRegion = el)}
                 onLayout={({ nativeEvent }) => (this.stateProvinceRegionLayout = nativeEvent.layout)}
@@ -248,6 +257,7 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
                 {...this.defaultPropsForInput("postalCode")}
                 label="Postal code"
                 placeholder="Add your postal code"
+                textContentType="postalCode"
                 onSubmitEditing={() => this.phoneNumber.root.focus()}
                 onLayout={({ nativeEvent }) => (this.postalCodeLayout = nativeEvent.layout)}
                 onFocus={() => this.scrollView.scrollTo({ x: 0, y: this.yPosition(this.postalCodeLayout) })}
@@ -257,6 +267,7 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
                 {...this.defaultPropsForInput("phoneNumber")}
                 label="Phone"
                 placeholder="Add your phone number"
+                textContentType="telephoneNumber"
                 onSubmitEditing={() => this.presentSelectCountry()}
                 onLayout={({ nativeEvent }) => (this.phoneNumberLayout = nativeEvent.layout)}
                 onFocus={() => this.scrollView.scrollTo({ x: 0, y: this.yPosition(this.phoneNumberLayout) })}
@@ -296,10 +307,10 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
     )
   }
 
-  private defaultPropsForInput(field: string) {
+  private defaultPropsForInput(field: string): Partial<StyledInputProps> {
     return {
       autoCapitalize: "words",
-      error: this.state.errors[field],
+      errorMessage: this.state.errors[field],
       inputRef: el => (this[field] = el),
       onBlur: () => this.validateField(field),
       onChangeText: value => this.setState({ values: { ...this.state.values, [field]: value } }),

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/BillingAddress-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/BillingAddress-tests.tsx.snap
@@ -154,6 +154,7 @@ exports[`renders properly 1`] = `
                 },
               ]
             }
+            textContentType="name"
             underlineColorAndroid="transparent"
           />
         </View>
@@ -222,6 +223,7 @@ exports[`renders properly 1`] = `
                 },
               ]
             }
+            textContentType="streetAddressLine1"
             underlineColorAndroid="transparent"
           />
         </View>
@@ -290,6 +292,7 @@ exports[`renders properly 1`] = `
                 },
               ]
             }
+            textContentType="streetAddressLine2"
             underlineColorAndroid="transparent"
           />
         </View>
@@ -358,6 +361,7 @@ exports[`renders properly 1`] = `
                 },
               ]
             }
+            textContentType="addressCity"
             underlineColorAndroid="transparent"
           />
         </View>
@@ -426,6 +430,7 @@ exports[`renders properly 1`] = `
                 },
               ]
             }
+            textContentType="addressState"
             underlineColorAndroid="transparent"
           />
         </View>
@@ -494,6 +499,7 @@ exports[`renders properly 1`] = `
                 },
               ]
             }
+            textContentType="postalCode"
             underlineColorAndroid="transparent"
           />
         </View>
@@ -562,6 +568,7 @@ exports[`renders properly 1`] = `
                 },
               ]
             }
+            textContentType="telephoneNumber"
             underlineColorAndroid="transparent"
           />
         </View>


### PR DESCRIPTION
During last week's Auctions QA session, I tried to register for a sale on an iPhone. I realized that the billing address inputs lacked `textContentType`, which is a property that tells iOS what data goes in each input field. This allows users to tap (for example) their name to get it input into the name field; this drastically improves the user experience of entering an address. 

Here's what it looks like in the simulator (`SIM-VALUE` would be replaced by the user's actual data, on-device): 

<img width="559" alt="Screen Shot 2019-08-01 at 10 16 19" src="https://user-images.githubusercontent.com/498212/62301935-7a5b6b00-b447-11e9-98e7-732dcb1dbf92.png">

During this work, I noticed that the `StyledInput` component was not well-typed, so I added some type annotations to get type-checking and autocomplete working:

<img width="924" alt="Screen Shot 2019-08-01 at 10 08 29" src="https://user-images.githubusercontent.com/498212/62301998-93641c00-b447-11e9-82ce-fd271183ad8f.png">
