### PR TITLE
PURCHASE-1309: Fixes mailto links rendered in markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### 1.12.13
 
 - Fix copy on registration pending view - yuki24
+- Fixes issue with mailto: links not opening - sweir27
 
 ### 1.12.12
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -287,7 +287,7 @@ SPEC CHECKSUMS:
   KSCrash: 4dc18329a90b516342809b9ca92fc4d199d712ea
   "NSURL+QueryDictionary": bae616404e2adf6409d3d5c02a093cbf44c8a236
   ORStackView: b9507271cb41fb9e0b3eecc6414d831201e7cf7c
-  Pulley: edc993fb57f7eb20541c8453d0fce10559f21dac
+  Pulley: 2679a2b5a9714c5eb760b1fbb535d15c60e50fb4
   React: 9d063e2f356c8cd2f54dd550d4507740037cbabe
   react-native-cameraroll: b1faef9f2ea27b07bdf818b8043909a93f797eca
   react-native-mapbox-gl: b7309e99290963cc7fe0e34db86c6e16890cfcee

--- a/src/lib/Components/Bidding/Screens/__tests__/RegistrationResult-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/RegistrationResult-tests.tsx
@@ -10,6 +10,9 @@ jest.mock("lib/NativeModules/SwitchBoard", () => ({
 }))
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 
+import { Linking } from "react-native"
+
+import { LinkText } from "lib/Components/Text/LinkText"
 import { BiddingThemeProvider } from "../../Components/BiddingThemeProvider"
 import { Icon20 } from "../../Components/Icon"
 
@@ -55,6 +58,19 @@ describe("Registration result component", () => {
       )
       .toJSON()
     expect(component).toMatchSnapshot()
+  })
+
+  it("renders registration error and mailto link properly", async () => {
+    Linking.canOpenURL = jest.fn().mockReturnValue(Promise.resolve(true))
+    Linking.openURL = jest.fn()
+
+    const component = renderer.create(
+      <BiddingThemeProvider>
+        <RegistrationResult status={RegistrationStatus.RegistrationStatusError} />
+      </BiddingThemeProvider>
+    )
+    await component.root.findByType(LinkText).props.onPress()
+    expect(Linking.openURL).toBeCalledWith("mailto:support@artsy.net")
   })
 
   it("dismisses the controller when the continue button is pressed", () => {

--- a/src/lib/Components/__tests__/Markdown-tests.tsx
+++ b/src/lib/Components/__tests__/Markdown-tests.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Text } from "react-native"
+import { Linking, Text } from "react-native"
 import * as renderer from "react-test-renderer"
 
 import { Theme } from "@artsy/palette"
@@ -56,7 +56,10 @@ describe("Markdown", () => {
     expect(SwitchBoardMock.presentModalViewController).toHaveBeenCalledWith(anything(), "http://www.artsy.net")
   })
 
-  it("renders mailto links as LinkText", () => {
+  it("renders mailto links as LinkText", async () => {
+    Linking.canOpenURL = jest.fn().mockReturnValue(Promise.resolve(true))
+    Linking.openURL = jest.fn()
+
     const markdown = renderer.create(
       <Theme>
         <Markdown>
@@ -72,9 +75,8 @@ describe("Markdown", () => {
     expect(markdown.root.findAllByType(LinkText).length).toEqual(1)
     expect(markdown.root.findAllByType(LinkText)[0].props.children[0]).toMatch("support@artsy.net")
 
-    markdown.root.findAllByType(LinkText)[0].props.onPress()
-
-    expect(SwitchBoardMock.presentModalViewController).toHaveBeenCalledWith(anything(), "mailto:support@artsy.net")
+    await markdown.root.findAllByType(LinkText)[0].props.onPress()
+    expect(Linking.openURL).toBeCalledWith("mailto:support@artsy.net")
   })
 
   it("accepts a rules prop", () => {

--- a/src/lib/utils/renderMarkdown.tsx
+++ b/src/lib/utils/renderMarkdown.tsx
@@ -3,7 +3,7 @@ import { LinkText } from "lib/Components/Text/LinkText"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import _ from "lodash"
 import React from "react"
-import { Text, View } from "react-native"
+import { Linking, Text, View } from "react-native"
 import SimpleMarkdown from "simple-markdown"
 
 // Rules for rendering parsed markdown. Currently only handles links and text. Add rules similar to
@@ -19,7 +19,17 @@ export function defaultRules(modal: boolean = false) {
         state.withinText = true
         let element
         const openUrl = url => {
-          if (modal) {
+          if (node.target.startsWith("mailto:")) {
+            Linking.canOpenURL(url)
+              .then(supported => {
+                if (!supported) {
+                  console.log("Unable to handle URL: " + url)
+                } else {
+                  return Linking.openURL(url)
+                }
+              })
+              .catch(err => console.error("An error occurred", err))
+          } else if (modal) {
             SwitchBoard.presentModalViewController(element, url)
           } else {
             SwitchBoard.presentNavigationViewController(element, url)


### PR DESCRIPTION
**Tested on-device!**

### Problem
We found that `mailto` links (included in markdown) were causing the app to crash when clicked into.

### Solution
`mailto` links need to be handled differently than normal links. This PR updates our `markdownRenderer` to correctly call the `Linking` react-native module when a mailto link is provided.
