### PR TITLE
[PURCHASE-1358] Attribution class FAQ is cut off

### DIFF
--- a/src/lib/Scenes/ArtworkAttributionClassFAQ/ArtworkAttributionClassFAQ.tsx
+++ b/src/lib/Scenes/ArtworkAttributionClassFAQ/ArtworkAttributionClassFAQ.tsx
@@ -39,7 +39,7 @@ export class ArtworkAttributionClassFAQ extends React.Component<Props> {
     return (
       <Theme>
         <ScrollView>
-          <Box pt={this.props.safeAreaInsets.top} pb={this.props.safeAreaInsets.top} px={2}>
+          <Box pt={this.props.safeAreaInsets.top + 3} pb={this.props.safeAreaInsets.top + 4} px={2}>
             <Spacer mt={3} />
             <Serif mb={2} size="8">
               Artwork classifications


### PR DESCRIPTION
[PURCHASE-1358]

Back button and bottom nav were overlapping the attribution class FAQ. I added more padding to its container.

__Before:__
<img width="382" alt="Screen Shot 2019-08-09 at 1 55 43 PM" src="https://user-images.githubusercontent.com/5643895/62799110-eb38fd80-baad-11e9-8539-dba211a5a61e.png">
<img width="382" alt="Screen Shot 2019-08-09 at 1 55 35 PM" src="https://user-images.githubusercontent.com/5643895/62799114-ed9b5780-baad-11e9-91c8-d288976d140a.png">

__After:__
<img width="386" alt="Screen Shot 2019-08-09 at 1 54 27 PM" src="https://user-images.githubusercontent.com/5643895/62799118-f4c26580-baad-11e9-8b18-fda0b9074f1c.png">
<img width="386" alt="Screen Shot 2019-08-09 at 1 54 45 PM" src="https://user-images.githubusercontent.com/5643895/62799124-f724bf80-baad-11e9-86d6-961f7d22ec58.png">


[PURCHASE-1358]: https://artsyproduct.atlassian.net/browse/PURCHASE-1358

#trivial