### PR TITLE
[PURCHASE-1143] Removes artwork set functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### 1.12.15
 
 - Replace usage of legacy filter artwork fields with new connection - alloy
+- Removes artwork set functionality - ash
 
 ### 1.12.14
 

--- a/Example/Emission/AppDelegate.m
+++ b/Example/Emission/AppDelegate.m
@@ -231,13 +231,6 @@ randomBOOL(void)
     [fromViewController.navigationController pushViewController:[self viewControllerForRoute:route] animated:YES];
   };
 
-  // Ignore the set attributes for now inside Emission, just load the artwork as a singleton
-  emission.switchBoardModule.presentArtworkSet = ^(UIViewController * _Nonnull fromViewController, NSArray<NSString *> * _Nonnull artworkIDs, NSNumber * _Nonnull index) {
-    NSString *artworkID = artworkIDs[index.integerValue];
-    NSString *route = [NSString stringWithFormat:@"/artwork/%@", artworkID];
-    [fromViewController.navigationController pushViewController:[self viewControllerForRoute:route] animated:YES];
-  };
-
   emission.switchBoardModule.presentModalViewController = ^(UIViewController * _Nonnull fromViewController,
                                                             NSString * _Nonnull route) {
     if ([fromViewController isKindOfClass:ARStorybookComponentViewController.class]) {

--- a/Pod/Classes/Core/ARSwitchBoardModule.h
+++ b/Pod/Classes/Core/ARSwitchBoardModule.h
@@ -3,10 +3,9 @@
 
 // Invoked on the main thread.
 typedef void(^ARSwitchBoardPresentViewController)(UIViewController * _Nonnull fromViewController, NSString * _Nonnull route);
-typedef void(^ARSwitchBoardHandleArtworkSet)(UIViewController * _Nonnull fromViewController, NSArray<NSString *> * _Nonnull artworkIDs, NSNumber * _Nonnull index);
 
 @interface ARSwitchBoardModule : NSObject <RCTBridgeModule>
 @property (nonatomic, copy, nullable, readwrite) ARSwitchBoardPresentViewController presentNavigationViewController;
 @property (nonatomic, copy, nullable, readwrite) ARSwitchBoardPresentViewController presentModalViewController;
-@property (nonatomic, copy, nullable, readwrite) ARSwitchBoardHandleArtworkSet presentArtworkSet;
+
 @end

--- a/Pod/Classes/Core/ARSwitchBoardModule.m
+++ b/Pod/Classes/Core/ARSwitchBoardModule.m
@@ -16,20 +16,6 @@ typedef void(^ARSwitchBoardPresentInternalViewController)(UIViewController * _No
 
 RCT_EXPORT_MODULE();
 
-RCT_EXPORT_METHOD(presentArtworksSet:(nonnull NSNumber *)reactTag artworkIDs:(nonnull NSArray<NSString *> *)artworkIDs initialIndex:(nonnull NSNumber *)index)
-{
-    UIView *originatingView = [self.bridge.uiManager viewForReactTag:reactTag];
-    UIView *rootView = originatingView;
-    while (rootView.superview && ![rootView isKindOfClass:RCTRootView.class]) {
-        rootView = rootView.superview;
-    }
-    UIViewController *viewController = rootView.reactViewController;
-    NSParameterAssert(viewController);
-
-    self.presentArtworkSet(viewController, artworkIDs, index);
-}
-
-
 RCT_EXPORT_METHOD(presentNavigationViewController:(nonnull NSNumber *)reactTag route:(nonnull NSString *)route)
 {
   [self invokeCallback:self.presentNavigationViewController reactTag:reactTag route:route];

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "emission",
   "version": "1.12.15",
-  "native-code-version": 32,
+  "native-code-version": 33,
   "description": "Artsy React(Native) components.",
   "engines": {
     "node": "10.x",

--- a/src/lib/Components/ArtworkGrids/ArtworkGridItem.tsx
+++ b/src/lib/Components/ArtworkGrids/ArtworkGridItem.tsx
@@ -28,10 +28,6 @@ const Badge = styled.View`
 
 interface Props {
   artwork: ArtworkGridItem_artwork
-  // Passes the Artwork ID back up to another component
-  // ideally, this would be used to send an array of Artworks
-  // through to Eigen where this item is the default selected one.
-  //
   // If it's not provided, then it will push just the one artwork
   // to the switchboard.
   onPress?: (artworkID: string) => void

--- a/src/lib/Components/ArtworkGrids/GenericGrid.tsx
+++ b/src/lib/Components/ArtworkGrids/GenericGrid.tsx
@@ -1,5 +1,4 @@
 import Spinner from "lib/Components/Spinner"
-import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import React from "react"
 import { LayoutChangeEvent, StyleSheet, View, ViewStyle } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -49,13 +48,6 @@ export class GenericArtworksGrid extends React.Component<Props, State> {
         context_module: props.contextModule,
       } as any)
   )
-  tappedOnArtwork(artworkID: string) {
-    // FIXME: Should this be internalID?
-    const allArtworkIDs = this.props.artworks.map(a => a.slug)
-    const index = allArtworkIDs.indexOf(artworkID)
-    SwitchBoard.presentArtworkSet(this, allArtworkIDs, index)
-  }
-
   layoutState(currentLayout): State {
     const width = currentLayout.width
     const isPad = width > 600
@@ -134,9 +126,7 @@ export class GenericArtworksGrid extends React.Component<Props, State> {
       const artworks = sectionedArtworks[i]
       for (let j = 0; j < artworks.length; j++) {
         const artwork = artworks[j]
-        artworkComponents.push(
-          <Artwork artwork={artwork} key={artwork.id + i + j} onPress={this.tappedOnArtwork.bind(this)} />
-        )
+        artworkComponents.push(<Artwork artwork={artwork} key={artwork.id + i + j} />)
         if (j < artworks.length - 1) {
           artworkComponents.push(<View style={spacerStyle} key={"spacer-" + j} accessibilityLabel="Spacer View" />)
         }

--- a/src/lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
+++ b/src/lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
@@ -13,7 +13,6 @@ import { createFragmentContainer, RelayPaginationProp } from "react-relay"
 import Spinner from "../Spinner"
 import Artwork from "./ArtworkGridItem"
 
-import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { isCloseToBottom } from "lib/utils/isCloseToBottom"
 
 import { PAGE_SIZE } from "lib/data/constants"
@@ -120,13 +119,6 @@ class InfiniteScrollArtworksGrid extends React.Component<Props & PrivateProps, S
     // tslint:enable:no-console
   }
 
-  tappedOnArtwork = (artworkID: string) => {
-    const artworks = this.props.connection.edges
-    const allArtworkIDs = artworks.map(a => a.node.slug)
-    const index = allArtworkIDs.indexOf(artworkID)
-    SwitchBoard.presentArtworkSet(this, allArtworkIDs, index)
-  }
-
   onLayout = (event: LayoutChangeEvent) => {
     const layout = event.nativeEvent.layout
     const { shouldAddPadding } = this.props
@@ -192,13 +184,7 @@ class InfiniteScrollArtworksGrid extends React.Component<Props & PrivateProps, S
       const artworkComponents: JSX.Element[] = []
       for (let j = 0; j < sectionedArtworks[i].length; j++) {
         const artwork = sectionedArtworks[i][j]
-        artworkComponents.push(
-          <Artwork
-            artwork={artwork}
-            key={"artwork-" + j + "-" + artwork.id}
-            onPress={this.tappedOnArtwork.bind(this)}
-          />
-        )
+        artworkComponents.push(<Artwork artwork={artwork} key={"artwork-" + j + "-" + artwork.id} />)
         // Setting a marginBottom on the artwork component didn’t work, so using a spacer view instead.
         if (j < artworks.length - 1) {
           artworkComponents.push(

--- a/src/lib/NativeModules/SwitchBoard.tsx
+++ b/src/lib/NativeModules/SwitchBoard.tsx
@@ -66,23 +66,10 @@ function dismissNavigationViewController(component: React.Component<any, any>) {
   ARSwitchBoardModule.dismissNavigationViewController(reactTag)
 }
 
-function presentArtworkSet(component: React.Component<any, any>, artworkIDs: string[], index: number) {
-  let reactTag
-  try {
-    reactTag = findNodeHandle(component)
-  } catch (err) {
-    console.error(`Unable to find tag in presentArtworkSet: ${err.message}`)
-    return
-  }
-
-  ARSwitchBoardModule.presentArtworksSet(reactTag, artworkIDs, index)
-}
-
 export default {
   presentNavigationViewController,
   presentMediaPreviewController,
   presentModalViewController,
   dismissModalViewController,
   dismissNavigationViewController,
-  presentArtworkSet,
 }


### PR DESCRIPTION
This PR removes the concept of an "artwork set", which is used by Eigen to provide left-to-right swiping between artworks in a grid. 

This is a companion PR to https://github.com/artsy/eigen/pull/2884, which it is blocking. 

#skip_new_tests