### PR TITLE
[PURCHASE-1316] Fixes intermittent crash on opening message attachment previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@
 //   * Major dev tool updates
 
 -->
+
 ### Master
 
+- Fixes intermittent crash on opening message attachment previews - ash
 - Fix consignments artist search and make it use relay - alloy
 
 ### 1.12.16

--- a/Pod/Classes/ViewControllers/ARMediaPreviewController.m
+++ b/Pod/Classes/ViewControllers/ARMediaPreviewController.m
@@ -82,7 +82,9 @@ static char kARMediaPreviewControllerAssociatedObject;
 
 - (UIViewController *)documentInteractionControllerViewControllerForPreview:(UIDocumentInteractionController *)controller;
 {
-    return self.hostViewController;
+    // We're seeing an intermittent crash with a nil hostViewController (UIKit is crashing, this method must never return nil).
+    // So in the case that hostViewController *is* nil, we fall back to the top-level controller.
+    return self.hostViewController ?: [[[UIApplication sharedApplication] keyWindow] rootViewController];
 }
 
 - (UIView *)documentInteractionControllerViewForPreview:(UIDocumentInteractionController *)controller;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "emission",
   "version": "1.12.16",
-  "native-code-version": 33,
+  "native-code-version": 34,
   "description": "Artsy React(Native) components.",
   "engines": {
     "node": "10.x",


### PR DESCRIPTION
I've included a comment here to explain what's up. Here's the Sentry crash: https://sentry.io/organizations/artsynet/issues/1025682704/?project=157493&query=is%3Aunresolved