### PR TITLE
PURCHASE-1409 - Fixes ContextCard with new MPv2 typename field

### DIFF
--- a/src/lib/Scenes/Artwork/Components/ContextCard.tsx
+++ b/src/lib/Scenes/Artwork/Components/ContextCard.tsx
@@ -133,7 +133,7 @@ export class ContextCard extends React.Component<ContextCardProps, ContextCardSt
 
     if (context) {
       const { __typename } = context
-      console.log("__typename", __typename)
+
       switch (__typename as any) {
         case "Sale":
           header = "In auction"

--- a/src/lib/Scenes/Artwork/Components/ContextCard.tsx
+++ b/src/lib/Scenes/Artwork/Components/ContextCard.tsx
@@ -133,8 +133,9 @@ export class ContextCard extends React.Component<ContextCardProps, ContextCardSt
 
     if (context) {
       const { __typename } = context
+      console.log("__typename", __typename)
       switch (__typename as any) {
-        case "ArtworkContextAuction":
+        case "Sale":
           header = "In auction"
           name = context.name
           href = context.href
@@ -142,7 +143,7 @@ export class ContextCard extends React.Component<ContextCardProps, ContextCardSt
           imageUrl = context.cover_image && context.cover_image.url ? context.cover_image.url : ""
           renderContextCard = true
           break
-        case "ArtworkContextFair":
+        case "Fair":
           header = "In fair"
           name = context.name
           href = context.href
@@ -150,8 +151,7 @@ export class ContextCard extends React.Component<ContextCardProps, ContextCardSt
           imageUrl = context.image && context.image.url ? context.image.url : ""
           renderContextCard = true
           break
-        case "ArtworkContextPartnerShow":
-          // TODO: Replace with ArtworkContextShow when MPv2 supports it
+        case "Show":
           const { shows } = artwork
           const show = shows[0]
           header = "In show"

--- a/src/lib/Scenes/Artwork/Components/__tests__/ContextCard-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/__tests__/ContextCard-tests.tsx
@@ -122,7 +122,7 @@ const fairContextArtwork = {
   gravityID: "candice-cmc-superman-donuts-1",
   internalID: "5d0a7485fc1f78001248b677",
   context: {
-    __typename: "ArtworkContextFair",
+    __typename: "Fair",
     id: "QXJ0d29ya0NvbnRleHRGYWlyOm1hcmtldC1hcnQtcGx1cy1kZXNpZ24tMjAxOQ==",
     name: "Market Art + Design 2019",
     href: "/market-art-plus-design-2019",
@@ -154,7 +154,7 @@ const auctionContextArtwork = {
   gravityID: "andy-warhol-mao-one-plate-3",
   internalID: "5bc13101c8d4326cc288ecb8",
   context: {
-    __typename: "ArtworkContextAuction",
+    __typename: "Sale",
     id: "QXJ0d29ya0NvbnRleHRBdWN0aW9uOmNocmlzdGllcy1wcmludHMtYW5kLW11bHRpcGxlcy02",
     name: "Christie’s: Prints & Multiples",
     href: "/auction/christies-prints-and-multiples-6",
@@ -174,7 +174,7 @@ const showContextArtwork = {
   gravityID: "abbas-kiarostami-untitled-7",
   internalID: "5b2b745e9c18db204fc32e11",
   context: {
-    __typename: "ArtworkContextPartnerShow",
+    __typename: "Show",
   },
   shows: [
     {


### PR DESCRIPTION
- https://artsyproduct.atlassian.net/browse/PURCHASE-1409
- Fixes context card with new `__typenames` which was creating empty space

#trivial