### PR TITLE
PURCHASE-1407: Artwork dimensions distorted in view in room

### DIFF
--- a/src/lib/Scenes/Artwork/Components/ArtworkActions.tsx
+++ b/src/lib/Scenes/Artwork/Components/ArtworkActions.tsx
@@ -92,7 +92,7 @@ export class ArtworkActions extends React.Component<ArtworkActionsProps> {
     const heightIn = heightCm / 2.54
     const widthIn = widthCm / 2.54
 
-    ApiModule.presentAugmentedRealityVIR(image.url, heightIn, widthIn, slug, id)
+    ApiModule.presentAugmentedRealityVIR(image.url, widthIn, heightIn, slug, id)
   }
 
   render() {


### PR DESCRIPTION
# [PURCHASE-1407]
https://www.notion.so/artsy/View-in-Room-shrink-image-551dd04f9efd4e4c8f58a20a6ebc795c

# Problem
Artworks appear stretched and distorted when using view in room

# Solution 
We were passing height and width to presentAugmentedRealityVIR in the wrong order. I switched them and corrected the problem.

__Before:__
![IMG_7283](https://user-images.githubusercontent.com/5643895/63786100-75130400-c8bf-11e9-8e91-c478c08e59de.jpeg)

__After:__
![IMG_7285](https://user-images.githubusercontent.com/5643895/63786274-befbea00-c8bf-11e9-8e40-64ce5a654f6c.jpeg)



[PURCHASE-1407]: https://artsyproduct.atlassian.net/browse/PURCHASE-1407
#trivial 