### PR TITLE
Carousel fixes

### DIFF
--- a/Pod/Classes/Core/ARDynamicScreenDimensions.m
+++ b/Pod/Classes/Core/ARDynamicScreenDimensions.m
@@ -64,17 +64,18 @@ RCT_EXPORT_MODULE()
 
 - (void)orientationChanged:(NSNotification *)note
 {
-  self.currentDimensions = getScreenDimensions();
   __weak ARDynamicScreenDimensions *wself = self;
 
-  if (self.isBeingObserved) {
-    dispatch_async(dispatch_get_main_queue(), ^{
-      __strong ARDynamicScreenDimensions *sself = wself;
-      if (sself && sself.isBeingObserved) {
-        [sself sendEventWithName:@"change" body:sself.currentDimensions];
-      }
-    });
-  }
+  dispatch_async(dispatch_get_main_queue(), ^{
+    __strong ARDynamicScreenDimensions *sself = wself;
+    if (!sself) {
+      return;
+    }
+    sself.currentDimensions = getScreenDimensions();
+    if (sself.isBeingObserved) {
+      [sself sendEventWithName:@"change" body:sself.currentDimensions];
+    }
+  });
 }
 
 - (void)startObserving

--- a/src/lib/Scenes/Artwork/Components/ImageCarousel/FullScreen/ImageZoomView.tsx
+++ b/src/lib/Scenes/Artwork/Components/ImageCarousel/FullScreen/ImageZoomView.tsx
@@ -125,7 +125,7 @@ export const ImageZoomView: React.RefForwardingComponent<ImageZoomView, ImageZoo
     const transition = useAnimatedValue(0)
     const transform = useMemo(() => createTransform(transition, imageTransitionOffset), [imageTransitionOffset])
 
-    const imageFittedWithinScreen = fitInside(screenDimensions, image)
+    const imageFittedWithinScreen = fitInside(screenDimensions, image.deepZoom.image.size)
     useEffect(() => {
       // animate image transition on mount
 

--- a/src/lib/Scenes/Artwork/Components/ImageCarousel/FullScreen/__tests__/ImageCarouselFullScreen-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/ImageCarousel/FullScreen/__tests__/ImageCarouselFullScreen-tests.tsx
@@ -7,7 +7,10 @@ import { ImageZoomView } from "../ImageZoomView"
 describe("ImageCarouselFullScreen", () => {
   function Mock() {
     const value = useNewImageCarouselContext({
-      images: [{ height: 5, width: 5, url: "a", deepZoom: null }, { height: 5, width: 5, url: "b", deepZoom: null }],
+      images: [
+        { height: 5, width: 5, url: "a", deepZoom: { image: { size: { width: 5, height: 5 } } as any } },
+        { height: 5, width: 5, url: "b", deepZoom: { image: { size: { width: 5, height: 5 } } as any } },
+      ],
     })
     return (
       <ImageCarouselContext.Provider value={value}>

--- a/src/lib/Scenes/Artwork/Components/ImageCarousel/geometry.ts
+++ b/src/lib/Scenes/Artwork/Components/ImageCarousel/geometry.ts
@@ -16,13 +16,13 @@ export function fitInside(container: Size, child: Size): Size & { marginHorizont
   const aspectRatio = child.width / child.height
 
   // start out assuming that we need to constrain the image by height
-  let height = container.height
-  let width = aspectRatio * container.height
+  let height = Math.min(container.height, child.height)
+  let width = aspectRatio * height
 
   // check whether we actually need to constrain the image by width
   if (width > container.width) {
     width = container.width
-    height = container.width / aspectRatio
+    height = width / aspectRatio
   }
 
   // calculate centering margins


### PR DESCRIPTION
Couple of small things

1. Screen dimensions updates seemed to be subject to a race condition on my iPad simulator at least. Calling `getScreenDimensions` synchronously with the `orientationChanged` callback was returning the pre-rotation values. So i moved the call onto the main thread right before the event is fired across the bridge.
2. Images whose maximum resolution is smaller than the viewport were being blown up to fill the screen in the full screen carousel. On iPad this could look *really* bad so I prevented it from happening.

#trivial
#skip_new_tests