### PR TITLE
Fixes edition set wrap

### DIFF
--- a/Example/Emission/ARRootViewController.m
+++ b/Example/Emission/ARRootViewController.m
@@ -264,7 +264,7 @@
 - (ARCellData *)jumpToArtworkWithBNMOWithEdition
 {
   return [self tappableCellDataWithTitle:@"Artwork With BNMO Edition Sets" selection:^{
-    id viewController = [[ARArtworkComponentViewController alloc] initWithArtworkID:@"david-yarrow-genesis-1"];
+    id viewController = [[ARArtworkComponentViewController alloc] initWithArtworkID:@"terry-oneill-faye-dunaway-the-beverly-hills-hilton-los-angeles-the-morning-after-her-network-oscar-1"];
     [self.navigationController pushViewController:viewController animated:YES];
   }];
 }

--- a/src/lib/Scenes/Artwork/Components/CommercialEditionSetInformation.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialEditionSetInformation.tsx
@@ -58,7 +58,7 @@ export class CommercialEditionSetInformation extends React.Component<Props, Stat
         <Sans size="3" weight="medium">
           Edition size
         </Sans>
-        <Flex flexDirection="row" alignContent="center">
+        <Flex flexDirection="row" alignContent="center" flexWrap="wrap">
           {editionSets.map(edition => {
             const { id, internalID, dimensions } = edition
             const selected = internalID === selectedEdition.internalID


### PR DESCRIPTION
- Edition set selection was rendering off page, adds wrap to the flex wrapper to allow the edition sets to wrap

<img width="439" alt="Screen Shot 2019-08-30 at 3 09 56 PM" src="https://user-images.githubusercontent.com/21182806/64046010-bc57f980-cb38-11e9-9e0c-e87cde03cd32.png">

#trivial
#skip_new_tests