### PR TITLE
[PURCHASE-1414] Removes errant tap events tracking on scroll layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fix Home artist rail following and switch to use Relay - alloy
 - Fix consignments and switch to use Relay - alloy
 - Adds BuyNowButton to artworks in auction with isBuyNowable true - kierangillen
+- Removes errant `tap` events tracking on scroll layout - ash
 
 ### 1.15.0
 

--- a/src/lib/Components/ArtworkGrids/ArtworkGridItem.tsx
+++ b/src/lib/Components/ArtworkGrids/ArtworkGridItem.tsx
@@ -7,6 +7,7 @@ import React from "react"
 import { StyleSheet, TouchableWithoutFeedback, View } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components/native"
+import { Schema, Track, track as _track } from "../../utils/track"
 import SerifText from "../Text/Serif"
 
 import { ArtworkGridItem_artwork } from "__generated__/ArtworkGridItem_artwork.graphql"
@@ -31,9 +32,20 @@ interface Props {
   // If it's not provided, then it will push just the one artwork
   // to the switchboard.
   onPress?: (artworkID: string) => void
+  trackingFlow?: string
+  contextModule?: string
 }
 
+const track: Track<Props, any> = _track
+
+@track()
 export class Artwork extends React.Component<Props, any> {
+  @track((props: Props) => ({
+    action_name: Schema.ActionNames.GridArtwork,
+    action_type: Schema.ActionTypes.Tap,
+    flow: props.trackingFlow,
+    context_module: props.contextModule,
+  }))
   handleTap() {
     // FIXME: Should this be internalID?
     this.props.onPress && this.props.artwork.slug

--- a/src/lib/Components/ArtworkGrids/GenericGrid.tsx
+++ b/src/lib/Components/ArtworkGrids/GenericGrid.tsx
@@ -2,7 +2,6 @@ import Spinner from "lib/Components/Spinner"
 import React from "react"
 import { LayoutChangeEvent, StyleSheet, View, ViewStyle } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
-import { Schema, Track, track as _track } from "../../utils/track"
 import Artwork from "./ArtworkGridItem"
 
 import { GenericGrid_artworks } from "__generated__/GenericGrid_artworks.graphql"
@@ -22,9 +21,6 @@ interface State {
   sectionCount: number
 }
 
-const track: Track<Props, State> = _track
-
-@track()
 export class GenericArtworksGrid extends React.Component<Props, State> {
   static defaultProps = {
     sectionDirection: "column" as "column",
@@ -39,12 +35,6 @@ export class GenericArtworksGrid extends React.Component<Props, State> {
 
   width = 0
 
-  @track((props: Props) => ({
-    action_name: Schema.ActionNames.GridArtwork,
-    action_type: Schema.ActionTypes.Tap,
-    flow: props.trackingFlow,
-    context_module: props.contextModule,
-  }))
   layoutState(currentLayout): State {
     const width = currentLayout.width
     const isPad = width > 600
@@ -118,12 +108,20 @@ export class GenericArtworksGrid extends React.Component<Props, State> {
     }
     const sectionedArtworks = this.sectionedArtworks()
     const sections = []
+    const { contextModule, trackingFlow } = this.props
     for (let i = 0; i < this.state.sectionCount; i++) {
       const artworkComponents = []
       const artworks = sectionedArtworks[i]
       for (let j = 0; j < artworks.length; j++) {
         const artwork = artworks[j]
-        artworkComponents.push(<Artwork artwork={artwork} key={artwork.id + i + j} />)
+        artworkComponents.push(
+          <Artwork
+            artwork={artwork}
+            key={artwork.id + i + j}
+            trackingFlow={trackingFlow}
+            contextModule={contextModule}
+          />
+        )
         if (j < artworks.length - 1) {
           artworkComponents.push(<View style={spacerStyle} key={"spacer-" + j} accessibilityLabel="Spacer View" />)
         }


### PR DESCRIPTION
Follow-up from https://github.com/artsy/eigen/pull/2896 We have been incorrectly tracking `tap` events on GenericGrid's layout events. This PR moves the tracking to the `ArtworkGridItem`, including passing down some props for tracking from `GenericGrid`. I've verified that this is working in Eigen, running these local Emission changes.