### PR TITLE
PURCHASE-1411 Prefetch images

### DIFF
--- a/Pod/Classes/OpaqueImageViewComponent/AROpaqueImageViewManager.m
+++ b/Pod/Classes/OpaqueImageViewComponent/AROpaqueImageViewManager.m
@@ -4,6 +4,7 @@
 
 #import <React/RCTConvert.h>
 
+#import <SDWebImage/SDWebImagePrefetcher.h>
 
 @interface AROpaqueImageViewComponent : AROpaqueImageView
 @property (nonatomic, strong, readwrite) RCTDirectEventBlock onLoad;
@@ -42,6 +43,12 @@ RCT_EXPORT_VIEW_PROPERTY(noAnimation, BOOL)
 // when the load fails
 RCT_EXPORT_VIEW_PROPERTY(failSilently, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(highPriority, BOOL)
+
+RCT_EXPORT_METHOD(prefetch:(nonnull NSArray *)urls)
+{
+  SDWebImagePrefetcher *fetcher = [SDWebImagePrefetcher sharedImagePrefetcher];
+  [fetcher prefetchURLs:urls];
+}
 
 - (UIView *)view;
 {

--- a/src/lib/Components/OpaqueImageView/OpaqueImageView.tsx
+++ b/src/lib/Components/OpaqueImageView/OpaqueImageView.tsx
@@ -4,6 +4,7 @@ import React from "react"
 import {
   ColorPropType,
   LayoutChangeEvent,
+  NativeModules,
   PixelRatio,
   processColor,
   requireNativeComponent,
@@ -12,6 +13,8 @@ import {
 
 import colors from "lib/data/colors"
 import { createGeminiUrl } from "./createGeminiUrl"
+
+const { AROpaqueImageViewManager } = NativeModules
 
 interface Props {
   /** The URL from where to fetch the image. */
@@ -75,6 +78,14 @@ export default class OpaqueImageView extends React.Component<Props, State> {
 
   static defaultProps: Props = {
     placeholderBackgroundColor: colors["gray-regular"],
+  }
+
+  /**
+   * Given a list of URLs, prefetches them in the background.
+   * @param urls
+   */
+  static prefetch(urls: string[]) {
+    AROpaqueImageViewManager.prefetch(urls)
   }
 
   constructor(props: Props) {

--- a/src/lib/Scenes/Artwork/Components/ImageCarousel/ImageCarouselEmbedded.tsx
+++ b/src/lib/Scenes/Artwork/Components/ImageCarousel/ImageCarouselEmbedded.tsx
@@ -1,6 +1,7 @@
+import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import { useScreenDimensions } from "lib/utils/useScreenDimensions"
 import { observer } from "mobx-react"
-import React, { useCallback, useContext } from "react"
+import React, { useCallback, useContext, useEffect } from "react"
 import { FlatList, NativeScrollEvent, NativeSyntheticEvent } from "react-native"
 import { findClosestIndex, getMeasurements } from "./geometry"
 import { ImageCarouselContext, ImageDescriptor } from "./ImageCarouselContext"
@@ -20,6 +21,13 @@ export const ImageCarouselEmbedded = observer(() => {
     dispatch,
     state,
   } = useContext(ImageCarouselContext)
+
+  useEffect(() => {
+    // Only the first two images are actually rendered to begin with so pre fetch the rest in the background
+    // Note that SDWebImage is smart enough to not download the same image twice so it's safe to pass the
+    // whole array in here rather than slicing off the first two.
+    OpaqueImageView.prefetch(images.map(i => i.url))
+  }, [])
 
   const measurements = getMeasurements({ images, boundingBox: embeddedCardBoundingBox })
   const offsets = measurements.map(m => m.cumulativeScrollOffset)

--- a/src/setupJest.ts
+++ b/src/setupJest.ts
@@ -72,7 +72,13 @@ console.error = (message?: any) => {
 
 mockedModule("./lib/Components/SwitchView.tsx", "SwitchView")
 mockedModule("./lib/Components/Spinner.tsx", "ARSpinner")
-mockedModule("./lib/Components/OpaqueImageView/OpaqueImageView.tsx", "AROpaqueImageView")
+jest.mock("./lib/Components/OpaqueImageView/OpaqueImageView.tsx", () =>
+  Object.assign(props => require("react").createElement("AROpaqueImageView", props), {
+    prefetch() {
+      // noop
+    },
+  })
+)
 // mockedModule("./lib/Components/ArtworkGrids/InfiniteScrollGrid.tsx", "ArtworksGrid")
 
 // Artist tests


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PURCHASE-1411

This is a potential fix for the issue where only the first two images were loading for people in certain situations.

## Rationale

Without being able to reliably reproduce the issue we need to make guesses about what's causing it.

The image carousel is implemented as a FlatList which initially only renders two items, and then is supposed to start rendering more items as the user starts scrolling.

One possible problem is that the FlatList is not rendering further items as the user scrolls.

<em>Note: given what I saw over zoom in the QA session I suspect this could have been the case, because the background remained completely white rather than showing a 'loading' placeholder as it would have done if the images were simply taking too long to download.</em>

Another cause might have been that the images were simply taking too long to download. This PR aims to address that by prefetching all thumbnail images before the user starts scrolling so that it's much more likely the images will be present and immediately renderable when scrolling.

Even if this wasn't the underlying problem that people were experiencing in the QA session, it should still be a UX win.

#trivial
#skip_new_tests 