### PR TITLE
Render all carousel images

### DIFF
--- a/Pod/Classes/OpaqueImageViewComponent/AROpaqueImageView.m
+++ b/Pod/Classes/OpaqueImageViewComponent/AROpaqueImageView.m
@@ -62,7 +62,7 @@ LoadImage(UIImage *image, CGSize destinationSize, CGFloat scaleFactor, UIColor *
 {
   // This will cancel an in-flight download operation, if one exists.
   self.imageURL = nil;
-  
+
   if (self.noAnimation) {
     [super setImage:image];
   } else {
@@ -104,14 +104,14 @@ LoadImage(UIImage *image, CGSize destinationSize, CGFloat scaleFactor, UIColor *
       self.backgroundColor = self.placeholderBackgroundColor;
     }
     self.downloadOperation = [manager downloadImageWithURL:self.imageURL
-                                                   options:0
+                                                   options:self.highPriority ? SDWebImageHighPriority : 0
                                                   progress:nil
                                                  completed:^(UIImage *image,
                                                              NSError *error,
                                                              SDImageCacheType __,
                                                              BOOL completed,
                                                              NSURL *imageURL) {
-                                                     
+
      __strong typeof(weakSelf) strongSelf = weakSelf;
      // Only really assign if the URL we downloaded still matches `self.imageURL`.
      if (strongSelf && [imageURL isEqual:strongSelf.imageURL]) {

--- a/Pod/Classes/OpaqueImageViewComponent/AROpaqueImageViewManager.m
+++ b/Pod/Classes/OpaqueImageViewComponent/AROpaqueImageViewManager.m
@@ -4,7 +4,6 @@
 
 #import <React/RCTConvert.h>
 
-#import <SDWebImage/SDWebImagePrefetcher.h>
 
 @interface AROpaqueImageViewComponent : AROpaqueImageView
 @property (nonatomic, strong, readwrite) RCTDirectEventBlock onLoad;
@@ -43,12 +42,6 @@ RCT_EXPORT_VIEW_PROPERTY(noAnimation, BOOL)
 // when the load fails
 RCT_EXPORT_VIEW_PROPERTY(failSilently, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(highPriority, BOOL)
-
-RCT_EXPORT_METHOD(prefetch:(nonnull NSArray *)urls)
-{
-  SDWebImagePrefetcher *fetcher = [SDWebImagePrefetcher sharedImagePrefetcher];
-  [fetcher prefetchURLs:urls];
-}
 
 - (UIView *)view;
 {

--- a/src/lib/Components/OpaqueImageView/OpaqueImageView.tsx
+++ b/src/lib/Components/OpaqueImageView/OpaqueImageView.tsx
@@ -55,7 +55,7 @@ interface Props {
   /**
    * renders the image at a higher threading priority level ('interactive')
    */
-  highPriorty?: boolean
+  highPriority?: boolean
 }
 
 interface State {

--- a/src/lib/Components/OpaqueImageView/OpaqueImageView.tsx
+++ b/src/lib/Components/OpaqueImageView/OpaqueImageView.tsx
@@ -4,7 +4,6 @@ import React from "react"
 import {
   ColorPropType,
   LayoutChangeEvent,
-  NativeModules,
   PixelRatio,
   processColor,
   requireNativeComponent,
@@ -13,8 +12,6 @@ import {
 
 import colors from "lib/data/colors"
 import { createGeminiUrl } from "./createGeminiUrl"
-
-const { AROpaqueImageViewManager } = NativeModules
 
 interface Props {
   /** The URL from where to fetch the image. */
@@ -78,14 +75,6 @@ export default class OpaqueImageView extends React.Component<Props, State> {
 
   static defaultProps: Props = {
     placeholderBackgroundColor: colors["gray-regular"],
-  }
-
-  /**
-   * Given a list of URLs, prefetches them in the background.
-   * @param urls
-   */
-  static prefetch(urls: string[]) {
-    AROpaqueImageViewManager.prefetch(urls)
   }
 
   constructor(props: Props) {

--- a/src/lib/Scenes/Artwork/Components/ImageCarousel/ImageCarouselEmbedded.tsx
+++ b/src/lib/Scenes/Artwork/Components/ImageCarousel/ImageCarouselEmbedded.tsx
@@ -87,7 +87,7 @@ export const ImageCarouselEmbedded = observer(() => {
       onScroll={onScroll}
       scrollEventThrottle={50}
       onResponderRelease={onResponderRelease}
-      initialNumToRender={2}
+      initialNumToRender={Math.min(images.length, 20)}
       renderItem={({ item, index }) => {
         const { cumulativeScrollOffset, ...styles } = measurements[index]
         return (
@@ -96,6 +96,8 @@ export const ImageCarouselEmbedded = observer(() => {
             width={styles.width}
             height={styles.height}
             onPress={goFullScreen}
+            // make sure first image loads first
+            highPriority={index === 0}
             ref={ref => {
               embeddedImageRefs[index] = ref
             }}

--- a/src/lib/Scenes/Artwork/Components/ImageCarousel/ImageCarouselEmbedded.tsx
+++ b/src/lib/Scenes/Artwork/Components/ImageCarousel/ImageCarouselEmbedded.tsx
@@ -1,7 +1,6 @@
-import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import { useScreenDimensions } from "lib/utils/useScreenDimensions"
 import { observer } from "mobx-react"
-import React, { useCallback, useContext, useEffect } from "react"
+import React, { useCallback, useContext } from "react"
 import { FlatList, NativeScrollEvent, NativeSyntheticEvent } from "react-native"
 import { findClosestIndex, getMeasurements } from "./geometry"
 import { ImageCarouselContext, ImageDescriptor } from "./ImageCarouselContext"
@@ -21,13 +20,6 @@ export const ImageCarouselEmbedded = observer(() => {
     dispatch,
     state,
   } = useContext(ImageCarouselContext)
-
-  useEffect(() => {
-    // Only the first two images are actually rendered to begin with so pre fetch the rest in the background
-    // Note that SDWebImage is smart enough to not download the same image twice so it's safe to pass the
-    // whole array in here rather than slicing off the first two.
-    OpaqueImageView.prefetch(images.map(i => i.url))
-  }, [])
 
   const measurements = getMeasurements({ images, boundingBox: embeddedCardBoundingBox })
   const offsets = measurements.map(m => m.cumulativeScrollOffset)

--- a/src/lib/Scenes/Artwork/Components/ImageCarousel/ImageWithLoadingState.tsx
+++ b/src/lib/Scenes/Artwork/Components/ImageCarousel/ImageWithLoadingState.tsx
@@ -12,6 +12,7 @@ interface ImageWithLoadingStateProps {
   onLoad?: () => void
   onPress?: () => void
   style?: ViewProps["style"]
+  highPriority?: boolean
 }
 /**
  * Renders an image with a 'fade in' transition when it has loaded.
@@ -20,7 +21,7 @@ interface ImageWithLoadingStateProps {
  *
  * @param param0 same as RN's Image props
  */
-export const ImageWithLoadingState = React.forwardRef<View, ImageWithLoadingStateProps>(({ ...props }, ref) => {
+export const ImageWithLoadingState = React.forwardRef<View, ImageWithLoadingStateProps>((props, ref) => {
   const [isLoading, setIsLoading] = useState(true)
 
   // When the image has loaded we want to fade it in, so we have a white overlay
@@ -52,6 +53,7 @@ export const ImageWithLoadingState = React.forwardRef<View, ImageWithLoadingStat
             imageURL={imageURL}
             aspectRatio={width / height}
             style={{ width, height }}
+            highPriority={props.highPriority}
           />
         </View>
         <Animated.View

--- a/src/setupJest.ts
+++ b/src/setupJest.ts
@@ -72,13 +72,7 @@ console.error = (message?: any) => {
 
 mockedModule("./lib/Components/SwitchView.tsx", "SwitchView")
 mockedModule("./lib/Components/Spinner.tsx", "ARSpinner")
-jest.mock("./lib/Components/OpaqueImageView/OpaqueImageView.tsx", () =>
-  Object.assign(props => require("react").createElement("AROpaqueImageView", props), {
-    prefetch() {
-      // noop
-    },
-  })
-)
+mockedModule("./lib/Components/OpaqueImageView/OpaqueImageView.tsx", "AROpaqueImageView")
 // mockedModule("./lib/Components/ArtworkGrids/InfiniteScrollGrid.tsx", "ArtworksGrid")
 
 // Artist tests


### PR DESCRIPTION
This reverts #1835 😬 That PR was fine, it's just that to really squash this bug I want to try a different approach. This PR achieves the same effect of preloading all carousel images, but while also _rendering_ all images.

After talking to @alloy I became convinced that preloading alone would not solve the issue we have seen, and that the problem is almost certainly `FlatList` which has been allegedly quite buggy historically, especially around whether or not lazily-rendered items appear.

The evidence I have for this is that both times when this kind of bug has appeared and I have seen it with my own eyes, the loading 'placeholder' background was not being show. It was just white. If this issue were caused by not prefetching images, we would expect to see a grey box with a loading spinner instead of a pure white background.

So it seems that `FlatList` is fine with rendering N items up-front, but occasionally chokes when pulling in more items as the user scrolls. It will be impossible for me to debug `FlatList` when I can't reproduce the issue locally and other people can't seem to reproduce it on-demand, so instead this PR introduces a workaround.

As already mentioned, that workaround is simply rendering all images up front. We have the luxury of being able to do that since the images are quite small, and we could get up to about 30 thumbnails before we need to even think about memory usage.

Network usage is a different thing. Here we set the first image to be a 'high pritority' download, which pushes it to the front of the `SDWebImage` download queue. That should help with the artwork page feeling snappy, but not as much as if we could force the images to download sequentially.

Another minor issue is that image downloads can't be cancelled with our current implementation of `OpaqueImageView` so if the user is on a bad connection and is navigating between pages faster than the thumbnails can load, they'll build up a queue of image downloads which will further hurt their network performance. This was an issue with the previous approach too. I'm not sure if `SDWebImage` supports cancelling downloads but if it does we should probably update `OpaqueImageView` to take advantage of it.

#skip_new_tests 
#trivial