### PR TITLE
PURCHASE-1355, PURCHASE-1356: Adjustments for Ipads

### DIFF
--- a/src/lib/Scenes/Artwork/Components/AboutArtist.tsx
+++ b/src/lib/Scenes/Artwork/Components/AboutArtist.tsx
@@ -4,6 +4,7 @@ import { ArtistListItemContainer as ArtistListItem } from "lib/Components/Artist
 import { ReadMore } from "lib/Components/ReadMore"
 import { Schema } from "lib/utils/track"
 import React from "react"
+import { Platform } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 
 interface AboutArtistProps {
@@ -20,6 +21,8 @@ export class AboutArtist extends React.Component<AboutArtistProps> {
       hasSingleArtist && artists[0].biography_blurb && artists[0].biography_blurb.text
         ? artists[0].biography_blurb.text
         : null
+
+    const textLimit = Platform.isPad ? 320 : 140
 
     return (
       <>
@@ -39,7 +42,7 @@ export class AboutArtist extends React.Component<AboutArtistProps> {
               <ReadMore
                 content={text}
                 trackingFlow={Schema.Flow.AboutTheArtist}
-                maxChars={140}
+                maxChars={textLimit}
                 contextModule={Schema.ContextModules.ArtistBiography}
               />
             </Box>

--- a/src/lib/Scenes/Artwork/Components/AboutArtist.tsx
+++ b/src/lib/Scenes/Artwork/Components/AboutArtist.tsx
@@ -4,7 +4,7 @@ import { ArtistListItemContainer as ArtistListItem } from "lib/Components/Artist
 import { ReadMore } from "lib/Components/ReadMore"
 import { Schema } from "lib/utils/track"
 import React from "react"
-import { Platform } from "react-native"
+import { Platform, PlatformIOSStatic } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 
 interface AboutArtistProps {
@@ -22,7 +22,8 @@ export class AboutArtist extends React.Component<AboutArtistProps> {
         ? artists[0].biography_blurb.text
         : null
 
-    const textLimit = Platform.isPad ? 320 : 140
+    const IOSPlatform = Platform as PlatformIOSStatic
+    const textLimit = IOSPlatform.isPad ? 320 : 140
 
     return (
       <>

--- a/src/lib/Scenes/Artwork/Components/AboutWork.tsx
+++ b/src/lib/Scenes/Artwork/Components/AboutWork.tsx
@@ -3,7 +3,7 @@ import { AboutWork_artwork } from "__generated__/AboutWork_artwork.graphql"
 import { ReadMore } from "lib/Components/ReadMore"
 import { Schema } from "lib/utils/track"
 import React from "react"
-import { Platform } from "react-native"
+import { Platform, PlatformIOSStatic } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 
 interface AboutWorkProps {
@@ -14,7 +14,10 @@ export class AboutWork extends React.Component<AboutWorkProps> {
   render() {
     const { additional_information, description } = this.props.artwork
     const hasArtworkInfo = additional_information || description
-    const textLimit = Platform.isPad ? 320 : 140
+
+    const IOSPlatform = Platform as PlatformIOSStatic
+    const textLimit = IOSPlatform.isPad ? 320 : 140
+
     return (
       hasArtworkInfo && (
         <Join separator={<Spacer mb={2} />}>

--- a/src/lib/Scenes/Artwork/Components/AboutWork.tsx
+++ b/src/lib/Scenes/Artwork/Components/AboutWork.tsx
@@ -3,6 +3,7 @@ import { AboutWork_artwork } from "__generated__/AboutWork_artwork.graphql"
 import { ReadMore } from "lib/Components/ReadMore"
 import { Schema } from "lib/utils/track"
 import React from "react"
+import { Platform } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 
 interface AboutWorkProps {
@@ -13,6 +14,7 @@ export class AboutWork extends React.Component<AboutWorkProps> {
   render() {
     const { additional_information, description } = this.props.artwork
     const hasArtworkInfo = additional_information || description
+    const textLimit = Platform.isPad ? 320 : 140
     return (
       hasArtworkInfo && (
         <Join separator={<Spacer mb={2} />}>
@@ -22,7 +24,7 @@ export class AboutWork extends React.Component<AboutWorkProps> {
           {additional_information && (
             <ReadMore
               content={additional_information}
-              maxChars={140}
+              maxChars={textLimit}
               trackingFlow={Schema.Flow.AboutTheWork}
               contextModule={Schema.ContextModules.AboutTheWork}
             />
@@ -34,7 +36,7 @@ export class AboutWork extends React.Component<AboutWorkProps> {
               </Sans>
               <ReadMore
                 content={description}
-                maxChars={140}
+                maxChars={textLimit}
                 trackingFlow={Schema.Flow.AboutTheWork}
                 contextModule={Schema.ContextModules.AboutTheWorkFromSpecialist}
               />

--- a/src/lib/Scenes/Artwork/Components/ArtworkHistory.tsx
+++ b/src/lib/Scenes/Artwork/Components/ArtworkHistory.tsx
@@ -3,6 +3,7 @@ import { ArtworkHistory_artwork } from "__generated__/ArtworkHistory_artwork.gra
 import { ReadMore } from "lib/Components/ReadMore"
 import { Schema } from "lib/utils/track"
 import React from "react"
+import { Platform } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 
 interface ArtworkHistoryProps {
@@ -24,6 +25,8 @@ export class ArtworkHistory extends React.Component<ArtworkHistoryProps> {
 
     const displaySections = sections.filter(i => i.value != null)
 
+    const textLimit = Platform.isPad ? 320 : 140
+
     return (
       <Join separator={<Spacer pb={3} />}>
         {displaySections.map(({ title, value, contextModule }, index) => (
@@ -33,7 +36,7 @@ export class ArtworkHistory extends React.Component<ArtworkHistoryProps> {
             </Sans>
             <ReadMore
               content={value}
-              maxChars={140}
+              maxChars={textLimit}
               trackingFlow={Schema.Flow.ArtworkDetails}
               contextModule={contextModule}
             />

--- a/src/lib/Scenes/Artwork/Components/ArtworkHistory.tsx
+++ b/src/lib/Scenes/Artwork/Components/ArtworkHistory.tsx
@@ -3,7 +3,7 @@ import { ArtworkHistory_artwork } from "__generated__/ArtworkHistory_artwork.gra
 import { ReadMore } from "lib/Components/ReadMore"
 import { Schema } from "lib/utils/track"
 import React from "react"
-import { Platform } from "react-native"
+import { Platform, PlatformIOSStatic } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 
 interface ArtworkHistoryProps {
@@ -25,7 +25,8 @@ export class ArtworkHistory extends React.Component<ArtworkHistoryProps> {
 
     const displaySections = sections.filter(i => i.value != null)
 
-    const textLimit = Platform.isPad ? 320 : 140
+    const IOSPlatform = Platform as PlatformIOSStatic
+    const textLimit = IOSPlatform.isPad ? 320 : 140
 
     return (
       <Join separator={<Spacer pb={3} />}>

--- a/src/lib/Scenes/Artwork/Components/ImageCarousel/ImageCarousel.tsx
+++ b/src/lib/Scenes/Artwork/Components/ImageCarousel/ImageCarousel.tsx
@@ -4,7 +4,7 @@ import { createGeminiUrl } from "lib/Components/OpaqueImageView/createGeminiUrl"
 import { useScreenDimensions } from "lib/utils/useScreenDimensions"
 import { observer } from "mobx-react"
 import React, { useContext, useMemo } from "react"
-import { Animated } from "react-native"
+import { Animated, Platform } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ImageCarouselFullScreen } from "./FullScreen/ImageCarouselFullScreen"
 import { fitInside } from "./geometry"
@@ -26,7 +26,8 @@ export const ImageCarousel = observer((props: ImageCarouselProps) => {
   const screenDimensions = useScreenDimensions()
   // The logic for cardHeight comes from the zeplin spec https://zpl.io/25JLX0Q
   const cardHeight = screenDimensions.width >= 375 ? 340 : 290
-  const embeddedCardBoundingBox = { width: screenDimensions.width, height: cardHeight }
+
+  const embeddedCardBoundingBox = { width: screenDimensions.width, height: Platform.isPad ? 460 : cardHeight }
 
   const images: ImageDescriptor[] = useMemo(
     () =>

--- a/src/lib/Scenes/Artwork/Components/ImageCarousel/ImageCarousel.tsx
+++ b/src/lib/Scenes/Artwork/Components/ImageCarousel/ImageCarousel.tsx
@@ -4,7 +4,7 @@ import { createGeminiUrl } from "lib/Components/OpaqueImageView/createGeminiUrl"
 import { useScreenDimensions } from "lib/utils/useScreenDimensions"
 import { observer } from "mobx-react"
 import React, { useContext, useMemo } from "react"
-import { Animated, Platform } from "react-native"
+import { Animated, Platform, PlatformIOSStatic } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ImageCarouselFullScreen } from "./FullScreen/ImageCarouselFullScreen"
 import { fitInside } from "./geometry"
@@ -27,7 +27,8 @@ export const ImageCarousel = observer((props: ImageCarouselProps) => {
   // The logic for cardHeight comes from the zeplin spec https://zpl.io/25JLX0Q
   const cardHeight = screenDimensions.width >= 375 ? 340 : 290
 
-  const embeddedCardBoundingBox = { width: screenDimensions.width, height: Platform.isPad ? 460 : cardHeight }
+  const IOSPlatform = Platform as PlatformIOSStatic
+  const embeddedCardBoundingBox = { width: screenDimensions.width, height: IOSPlatform.isPad ? 460 : cardHeight }
 
   const images: ImageDescriptor[] = useMemo(
     () =>

--- a/src/lib/Scenes/Artwork/Components/ImageCarousel/ImageCarouselEmbedded.tsx
+++ b/src/lib/Scenes/Artwork/Components/ImageCarousel/ImageCarouselEmbedded.tsx
@@ -1,7 +1,7 @@
 import { useScreenDimensions } from "lib/utils/useScreenDimensions"
 import { observer } from "mobx-react"
 import React, { useCallback, useContext } from "react"
-import { FlatList, NativeScrollEvent, NativeSyntheticEvent, Platform } from "react-native"
+import { FlatList, NativeScrollEvent, NativeSyntheticEvent, Platform, PlatformIOSStatic } from "react-native"
 import { findClosestIndex, getMeasurements } from "./geometry"
 import { ImageCarouselContext, ImageDescriptor } from "./ImageCarouselContext"
 import { ImageWithLoadingState } from "./ImageWithLoadingState"
@@ -12,7 +12,8 @@ export const ImageCarouselEmbedded = observer(() => {
   // The logic for cardHeight comes from the zeplin spec https://zpl.io/25JLX0Q
   const cardHeight = screenDimensions.width >= 375 ? 340 : 290
 
-  const embeddedCardBoundingBox = { width: screenDimensions.width, height: Platform.isPad ? 460 : cardHeight }
+  const IOSPlatform = Platform as PlatformIOSStatic
+  const embeddedCardBoundingBox = { width: screenDimensions.width, height: IOSPlatform.isPad ? 460 : cardHeight }
 
   const {
     images,

--- a/src/lib/Scenes/Artwork/Components/ImageCarousel/ImageCarouselEmbedded.tsx
+++ b/src/lib/Scenes/Artwork/Components/ImageCarousel/ImageCarouselEmbedded.tsx
@@ -1,7 +1,7 @@
 import { useScreenDimensions } from "lib/utils/useScreenDimensions"
 import { observer } from "mobx-react"
 import React, { useCallback, useContext } from "react"
-import { FlatList, NativeScrollEvent, NativeSyntheticEvent } from "react-native"
+import { FlatList, NativeScrollEvent, NativeSyntheticEvent, Platform } from "react-native"
 import { findClosestIndex, getMeasurements } from "./geometry"
 import { ImageCarouselContext, ImageDescriptor } from "./ImageCarouselContext"
 import { ImageWithLoadingState } from "./ImageWithLoadingState"
@@ -11,7 +11,8 @@ export const ImageCarouselEmbedded = observer(() => {
   const screenDimensions = useScreenDimensions()
   // The logic for cardHeight comes from the zeplin spec https://zpl.io/25JLX0Q
   const cardHeight = screenDimensions.width >= 375 ? 340 : 290
-  const embeddedCardBoundingBox = { width: screenDimensions.width, height: cardHeight }
+
+  const embeddedCardBoundingBox = { width: screenDimensions.width, height: Platform.isPad ? 460 : cardHeight }
 
   const {
     images,


### PR DESCRIPTION
# [PURCHASE-1355] Increase image height on iPad
Use 460px for the height for iPad

__Before:__
![IMG_0192](https://user-images.githubusercontent.com/5643895/64457624-1e78a780-d0c1-11e9-8b09-f2ae88505b79.jpg)

__After:__
![IMG_0194](https://user-images.githubusercontent.com/5643895/64457646-28020f80-d0c1-11e9-8b49-e830989715d5.jpg)

# [PURCHASE-1356] On iPad, increase text limit for "Read more" component
Use 320 characters instead of 140 for iPad

__Before:__
![IMG_0198](https://user-images.githubusercontent.com/5643895/64457553-e8d3be80-d0c0-11e9-8de4-ee68dc3de9d6.jpg)

__After:__
![IMG_0197](https://user-images.githubusercontent.com/5643895/64457575-fab56180-d0c0-11e9-9745-263022134523.jpg)
