### PR TITLE
Report all data load errors when not in tests

### DIFF
--- a/src/lib/utils/renderWithLoadProgress.tsx
+++ b/src/lib/utils/renderWithLoadProgress.tsx
@@ -18,15 +18,18 @@ export default function<T extends RelayContainer<any>>(
       // In tests we want errors to clearly bubble up.
       if (typeof jest !== "undefined") {
         throw error
+      } else {
+        console.error(error)
       }
+
       const networkError = error as any
       if (networkError.response && networkError.response._bodyInit) {
         let data = networkError.response._bodyInit || "{}"
         try {
           data = JSON.parse(data)
+          console.error("Error data", data)
           // tslint:disable-next-line:no-empty
         } catch (e) {}
-        console.error(`Metaphysics Error: ${error.message}\n`, data)
       }
 
       if (retrying) {

--- a/src/lib/utils/renderWithLoadProgress.tsx
+++ b/src/lib/utils/renderWithLoadProgress.tsx
@@ -27,9 +27,9 @@ export default function<T extends RelayContainer<any>>(
         let data = networkError.response._bodyInit || "{}"
         try {
           data = JSON.parse(data)
-          console.error("Error data", data)
           // tslint:disable-next-line:no-empty
         } catch (e) {}
+        console.error("Error data", data)
       }
 
       if (retrying) {


### PR DESCRIPTION
Follow up from artsy/metaphysics#1936

The above issue was tricky to debug because the error was being swallowed by `renderWithLoadProgress`.

`renderWithLoadProgress` does invoke `console.error` but only for errors with a specific shape. It turned out that our error yesterday didn't match that shape. So I moved the `console.error` invocation to make it more inclusive for _all_ errors 🌈 

#trivial 