### PR TITLE
PURCHASE-1464 [BidFlow] Fixes bug when clicking Next between fields in Billing Address form

### DIFF
--- a/src/lib/Components/Bidding/Screens/BillingAddress.tsx
+++ b/src/lib/Components/Bidding/Screens/BillingAddress.tsx
@@ -29,10 +29,8 @@ import { SelectCountry } from "./SelectCountry"
 
 interface StyledInputInterface {
   /** The object which styled components wraps */
-  root?: {
-    focus?: () => void
-    blur?: () => void
-  }
+  focus?: () => void
+  blur?: () => void
 }
 
 interface StyledInputProps extends InputProps {
@@ -202,7 +200,7 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
                 placeholder="Add your full name"
                 autoFocus={true}
                 textContentType="name"
-                onSubmitEditing={() => this.addressLine1.root.focus()}
+                onSubmitEditing={() => this.addressLine1.focus()}
                 onLayout={({ nativeEvent }) => (this.fullNameLayout = nativeEvent.layout)}
                 onFocus={() => this.scrollView.scrollTo({ x: 0, y: this.yPosition(this.fullNameLayout) })}
               />
@@ -212,7 +210,7 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
                 label="Address line 1"
                 placeholder="Add your street address"
                 textContentType="streetAddressLine1"
-                onSubmitEditing={() => this.addressLine2.root.focus()}
+                onSubmitEditing={() => this.addressLine2.focus()}
                 onLayout={({ nativeEvent }) => (this.addressLine1Layout = nativeEvent.layout)}
                 onFocus={() => this.scrollView.scrollTo({ x: 0, y: this.yPosition(this.addressLine1Layout) })}
               />
@@ -222,7 +220,7 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
                 label="Address line 2 (optional)"
                 placeholder="Add your apt, floor, suite, etc."
                 textContentType="streetAddressLine2"
-                onSubmitEditing={() => this.city.root.focus()}
+                onSubmitEditing={() => this.city.focus()}
                 onLayout={({ nativeEvent }) => (this.addressLine2Layout = nativeEvent.layout)}
                 onFocus={() => this.scrollView.scrollTo({ x: 0, y: this.yPosition(this.addressLine2Layout) })}
               />
@@ -232,7 +230,7 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
                 label="City"
                 placeholder="Add your city"
                 textContentType="addressCity"
-                onSubmitEditing={() => this.stateProvinceRegion.root.focus()}
+                onSubmitEditing={() => this.stateProvinceRegion.focus()}
                 onLayout={({ nativeEvent }) => (this.cityLayout = nativeEvent.layout)}
                 onFocus={() => this.scrollView.scrollTo({ x: 0, y: this.yPosition(this.cityLayout) })}
               />
@@ -242,7 +240,7 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
                 label="State, Province, or Region"
                 placeholder="Add state, province, or region"
                 textContentType="addressState"
-                onSubmitEditing={() => this.postalCode.root.focus()}
+                onSubmitEditing={() => this.postalCode.focus()}
                 inputRef={el => (this.stateProvinceRegion = el)}
                 onLayout={({ nativeEvent }) => (this.stateProvinceRegionLayout = nativeEvent.layout)}
                 onFocus={() =>
@@ -258,7 +256,7 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
                 label="Postal code"
                 placeholder="Add your postal code"
                 textContentType="postalCode"
-                onSubmitEditing={() => this.phoneNumber.root.focus()}
+                onSubmitEditing={() => this.phoneNumber.focus()}
                 onLayout={({ nativeEvent }) => (this.postalCodeLayout = nativeEvent.layout)}
                 onFocus={() => this.scrollView.scrollTo({ x: 0, y: this.yPosition(this.postalCodeLayout) })}
               />


### PR DESCRIPTION
Currently, clicking "Next" to navigate to the next field in the bid flow's billing address form causes the app to crash with the error `RCTFatalException: Unhandled JS Exception: undefined is not an object (evaluating 't.addressLine1.root.focus')`

Fixed it by removing the reference to `root`. This component hasn't been touched meaningfully in a while, so I'm not sure what made this break all of a sudden.

![next-bid-flow](https://user-images.githubusercontent.com/2081340/64653258-fd32f680-d3f3-11e9-9bf6-6e803acd762e.gif)

#trivial