### PR TITLE
Restricts git diff range on CI skip check

### DIFF
--- a/scripts/ci-skip-native-if-possible.js
+++ b/scripts/ci-skip-native-if-possible.js
@@ -29,7 +29,7 @@ if (branch === "master") {
 }
 
 /** @type {String[]} */
-const changedFiles = reverseSh(`git diff --name-only HEAD origin/master`).split("\n")
+const changedFiles = reverseSh(`git diff --name-only HEAD $(git merge-base HEAD origin/master)`).split("\n")
 if (changedFiles.filter(file => file.startsWith("Pod/") || file.startsWith("Example/")).length > 0) {
   throw new Error("Native files have been changed, not skipping.")
 }


### PR DESCRIPTION
I noticed that #1837 (which has only JS changes) was running native CI ([in this build](https://circleci.com/gh/artsy/emission/2823)). We have a yarn script to skip native CI on pull requests that have no native code changes, but it wasn't working. What was happening was, if native code got changed on master, that would "count" as a changed native file on every PR (unless they rebased). This change restricts the git diff to the most common ancestor commit of the PR's branch (ie: the commit it branched off of master from). #trivial