### PR TITLE
PURCHASE-1484 prevent crashes when staging image data is corrupt

### DIFF
--- a/src/lib/Scenes/Artwork/Components/ImageCarousel/ImageCarousel.tsx
+++ b/src/lib/Scenes/Artwork/Components/ImageCarousel/ImageCarousel.tsx
@@ -32,23 +32,33 @@ export const ImageCarousel = observer((props: ImageCarouselProps) => {
 
   const images: ImageDescriptor[] = useMemo(
     () =>
-      props.images.map(image => {
-        const { width, height } = fitInside(embeddedCardBoundingBox, image)
-        return {
-          width,
-          height,
-          url: createGeminiUrl({
-            imageURL: image.image_url.replace(":version", "normalized"),
+      props.images
+        .map(image => {
+          if (!image.height || !image.width || !image.image_url) {
+            // something is very wrong
+            return null
+          }
+          const { width, height } = fitInside(embeddedCardBoundingBox, image)
+          return {
             width,
             height,
-          }),
-          deepZoom: image.deepZoom,
-        }
-      }),
+            url: createGeminiUrl({
+              imageURL: image.image_url.replace(":version", "normalized"),
+              width,
+              height,
+            }),
+            deepZoom: image.deepZoom,
+          }
+        })
+        .filter(Boolean),
     [props.images]
   )
 
   const context = useNewImageCarouselContext({ images })
+
+  if (images.length === 0) {
+    return null
+  }
 
   return (
     <ImageCarouselContext.Provider value={context}>


### PR DESCRIPTION
@kierangillen saw some crashes in the app when staging was flaky that were related to certain artworks not having full image data. Here we add a fail-safe so the app will not crash if that happens again, it will just not render any images.

https://artsyproduct.atlassian.net/browse/PURCHASE-1484

#trivial