### PR TITLE
Use screen pixel density rather than constant

### DIFF
--- a/src/lib/Scenes/Artwork/Components/ImageCarousel/ImageCarousel.tsx
+++ b/src/lib/Scenes/Artwork/Components/ImageCarousel/ImageCarousel.tsx
@@ -4,7 +4,7 @@ import { createGeminiUrl } from "lib/Components/OpaqueImageView/createGeminiUrl"
 import { useScreenDimensions } from "lib/utils/useScreenDimensions"
 import { observer } from "mobx-react"
 import React, { useContext, useMemo } from "react"
-import { Animated } from "react-native"
+import { Animated, PixelRatio } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 import { isPad } from "../../hardware"
 import { ImageCarouselFullScreen } from "./FullScreen/ImageCarouselFullScreen"
@@ -16,8 +16,6 @@ import { useSpringValue } from "./useSpringValue"
 export interface ImageCarouselProps {
   images: ImageCarousel_images
 }
-
-const THUMBNAIL_PIXEL_DENSITY = 2
 
 /**
  * ImageCarousel
@@ -46,8 +44,9 @@ export const ImageCarousel = observer((props: ImageCarouselProps) => {
             height,
             url: createGeminiUrl({
               imageURL: image.image_url.replace(":version", "normalized"),
-              width: width * THUMBNAIL_PIXEL_DENSITY,
-              height: height * THUMBNAIL_PIXEL_DENSITY,
+              // upscale to match screen resolution
+              width: width * PixelRatio.get(),
+              height: height * PixelRatio.get(),
             }),
             deepZoom: image.deepZoom,
           }


### PR DESCRIPTION
As @alloy pointed out on slack, some iOS devices have a pixel ratio of 1:3 so we should ask the user's device how much to scale the image by.

#trivial