### PR TITLE
Adjust deep zoom levels for pixel ratio changes

### DIFF
--- a/src/lib/Scenes/Artwork/Components/ImageCarousel/FullScreen/DeepZoom/deepZoomGeometry.ts
+++ b/src/lib/Scenes/Artwork/Components/ImageCarousel/FullScreen/DeepZoom/deepZoomGeometry.ts
@@ -1,3 +1,4 @@
+import { PixelRatio } from "react-native"
 import { Rect, Size } from "../../geometry"
 import { ImageDescriptor } from "../../ImageCarouselContext"
 
@@ -36,7 +37,7 @@ export const calculateMinMaxDeepZoomLevels = (imageFittedWithinScreen: Size, zoo
   let minLevel = 0
   const maxLevel = zoomLevels.length - 1
   for (const { width } of zoomLevels) {
-    if (width >= imageFittedWithinScreen.width) {
+    if (width >= imageFittedWithinScreen.width * PixelRatio.get()) {
       break
     }
     minLevel++
@@ -63,7 +64,7 @@ export const getZoomScaleBoundaries = ({
   const result: ZoomScaleBoundaries[] = []
   for (const level of levels) {
     // This is the zoom scale at which the image will be at it's natural resolution
-    const perfectZoomScale = level.width / imageFittedWithinScreen.width
+    const perfectZoomScale = level.width / (imageFittedWithinScreen.width * PixelRatio.get())
     const startZoomScale = perfectZoomScale / 2
     const stopZoomScale = perfectZoomScale * 8
     result.push({ startZoomScale, stopZoomScale })


### PR DESCRIPTION
 in #1863 we updated the image carousel thumbnail to use the device's pixel ratio to decide image resolution, but forgot to update the deep zoom overlay to do the same. This PR basically makes it so that if you zoom in (either very slowly or with perfect network) you can't tell when one layer ends and the other begins. Whereas before there would be noticeable points while zooming when the image would become more detailed.

#trivial