### PR TITLE
Fixes empty space in Artwork view

### DIFF
--- a/src/lib/Scenes/Artwork/Components/CommercialInformation.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialInformation.tsx
@@ -87,7 +87,7 @@ export class CommercialInformation extends React.Component<CommercialInformation
               <AuctionCountDownTimer artwork={artwork} />
             </>
           )}
-          {(!!consignableArtistsCount || isAcquireable || isInquireable) && (
+          {(!!consignableArtistsCount || isAcquireable) && (
             <>
               <Spacer mb={2} />
               <ArtworkExtraLinks artwork={artwork} />


### PR DESCRIPTION
- We had not updated the logic in the parent component when to show `ExtraLinks` now that we're no longer showing if the artwork only has `isInquireable`

#trivial

## Before

<img width="440" alt="Screen Shot 2019-09-17 at 12 32 09 PM" src="https://user-images.githubusercontent.com/21182806/65061395-d3278a00-d947-11e9-9be9-d0439a49b12c.png">

## After

<img width="446" alt="Screen Shot 2019-09-17 at 12 31 54 PM" src="https://user-images.githubusercontent.com/21182806/65061408-dae72e80-d947-11e9-9ae6-2edb5b848c06.png">
