### PR TITLE
[Home] Stop scroll-to-top behaviour on Artists/Auctions tabs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### 1.17.0
 
 - Remove unused field selections from GraphQL documents - alloy, ds300, kierangillen, sweir27
+- Fix scroll-to-top behaviour on Home/Artists and Home/Auctions tabs - alloy
 - Add vscode-apollo-relay for better Relay DX with vscode-apollo extension - alloy
 - Adds pull to refresh to artwork view - kierangillen
 - Adds mailto to orders@artsy.net for Ask a Specialist - kierangillen

--- a/src/lib/Scenes/Home/index.tsx
+++ b/src/lib/Scenes/Home/index.tsx
@@ -17,6 +17,8 @@ import { ForYouRenderer, WorksForYouRenderer } from "lib/relay/QueryRenderers"
 import { SalesRenderer } from "lib/Scenes/Home/Components/Sales/Relay/SalesRenderer"
 import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
 
+import { QueryRenderersWorksForYouQueryResponse } from "__generated__/QueryRenderersWorksForYouQuery.graphql"
+import { SalesRendererQueryResponse } from "__generated__/SalesRendererQuery.graphql"
 import DarkNavigationButton from "lib/Components/Buttons/DarkNavigationButton"
 import TabBar, { Tab } from "lib/Components/TabBar"
 
@@ -52,6 +54,15 @@ const screenSchemaForCurrentTab = currentSelectedTab => {
 
   return screenType
 }
+
+/**
+ * These trampolines are to support the slightly awkward case where all of the props need to be captured as a single
+ * prop, which is because these forward the root Query type.
+ *
+ * TODO: See if it’s possible to refactor things such that this is no longer necessary.
+ */
+const WorksForYouTrampoline: React.FC<QueryRenderersWorksForYouQueryResponse> = query => <WorksForYou query={query} />
+const SalesTrampoline: React.FC<SalesRendererQueryResponse> = query => <Sales query={query} />
 
 // This kills two birds with one stone:
 // It's necessary to wrap all tracks nested in this component, so they dispatch properly
@@ -123,9 +134,7 @@ export default class Home extends React.Component<Props, State> {
       wider letter-spacing. Going forward, this would ideally be dealt with through letter indentation. */}
           <Tab tabLabel=" Artists">
             <WorksForYouRenderer
-              render={renderWithLoadProgress(query => (
-                <WorksForYou query={query as any} />
-              ))}
+              render={renderWithLoadProgress(WorksForYouTrampoline as any)}
               selectedArtist={this.props.selectedArtist}
             />
           </Tab>
@@ -133,11 +142,7 @@ export default class Home extends React.Component<Props, State> {
             <ForYouRenderer render={renderWithLoadProgress(ForYou)} />
           </Tab>
           <Tab tabLabel=" Auctions">
-            <SalesRenderer
-              render={renderWithLoadProgress(query => (
-                <Sales query={query as any} />
-              ))}
-            />
+            <SalesRenderer render={renderWithLoadProgress(SalesTrampoline as any)} />
           </Tab>
         </ScrollableTabView>
         {!!showConsignmentsSash && (


### PR DESCRIPTION
Fixes https://artsyproduct.atlassian.net/browse/PLATFORM-1781

Re-applies #1866, which was accidentally reverted here https://github.com/artsy/emission/commit/5b0ea4cf316a1ccd5d16c86444741db17d5309d8#r35129124