### PR TITLE
Track more auction events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### 1.17.2
 
 - Refetches Artwork page query on re-appear - ash & purchase team
+- Add more analytics around auction related actions - ashkan18
 
 ### 1.17.1
 

--- a/src/lib/Scenes/Artwork/Components/ArtworkExtraLinks.tsx
+++ b/src/lib/Scenes/Artwork/Components/ArtworkExtraLinks.tsx
@@ -30,12 +30,22 @@ export class ArtworkExtraLinks extends React.Component<ArtworkExtraLinksProps> {
     Linking.openURL(`mailto:orders@artsy.net?subject=${mailtoSubject}`)
   }
 
-  handleReadOurAuctionFAQsTap = () => {
+  @track({
+    action_name: Schema.ActionNames.AuctionsFAQ,
+    action_type: Schema.ActionTypes.Tap,
+    context_module: Schema.ContextModules.ArtworkExtraLinks,
+  })
+  handleReadOurAuctionFAQsTap() {
     // FIXME: Needs to link to the Force view
     return
   }
 
-  handleConditionsOfSaleTap = () => {
+  @track({
+    action_name: Schema.ActionNames.ConditionsOfSale,
+    action_type: Schema.ActionTypes.Tap,
+    context_module: Schema.ContextModules.ArtworkExtraLinks,
+  })
+  handleConditionsOfSaleTap() {
     SwitchBoard.presentNavigationViewController(this, `/conditions-of-sale`)
   }
 

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/BidButton.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/BidButton.tsx
@@ -1,8 +1,10 @@
 import { Button, color, Sans } from "@artsy/palette"
 import { BidButton_artwork } from "__generated__/BidButton_artwork.graphql"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
+import { Schema } from "lib/utils/track"
 import React from "react"
 import { createFragmentContainer, graphql, RelayProp } from "react-relay"
+import track from "react-tracking"
 
 export const PREDICTION_URL = "https://live.artsy.net"
 
@@ -11,28 +13,45 @@ export interface BidButtonProps {
   relay: RelayProp
 }
 
+@track()
 export class BidButton extends React.Component<BidButtonProps> {
-  setMaxBid = (newVal: number) => {
+  @track({
+    action_name: Schema.ActionNames.IncreaseMaxBid,
+    action_type: Schema.ActionTypes.Tap,
+  })
+  setMaxBid(newVal: number) {
     this.setState({ selectedMaxBidCents: newVal })
   }
 
-  handleBid = () => {
+  @track({
+    action_name: Schema.ActionNames.Bid,
+    action_type: Schema.ActionTypes.Tap,
+  })
+  handleBid() {
     const { sale } = this.props.artwork
     SwitchBoard.presentNavigationViewController(this, `/auction/${sale.slug}/bid/${this.props.artwork.slug}`)
   }
 
-  redirectToRegister = () => {
+  @track({
+    action_name: Schema.ActionNames.RegisterToBid,
+    action_type: Schema.ActionTypes.Tap,
+  })
+  redirectToRegister() {
     const { sale } = this.props.artwork
     SwitchBoard.presentNavigationViewController(this, `/auction-registration/${sale.slug}`)
   }
 
-  redirectToLiveBidding = () => {
+  @track({
+    action_name: Schema.ActionNames.EnterLiveBidding,
+    action_type: Schema.ActionTypes.Tap,
+  })
+  redirectToLiveBidding() {
     const { slug } = this.props.artwork.sale
     const liveUrl = `${PREDICTION_URL}/${slug}`
     SwitchBoard.presentNavigationViewController(this, liveUrl)
   }
 
-  redirectToBid = (firstIncrement: number) => {
+  redirectToBid(firstIncrement: number) {
     const { slug, sale } = this.props.artwork
     const bid = firstIncrement
 

--- a/src/lib/Scenes/Artwork/Components/__tests__/ArtworkExtraLinks-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/__tests__/ArtworkExtraLinks-tests.tsx
@@ -236,16 +236,27 @@ describe("ArtworkExtraLinks", () => {
 
     it("hides auction links when auction work has sold via buy now", () => {
       const notForSaleArtwork = {
-        ...artwork,
+        ...ArtworkFixture,
+        isInAuction: true,
         isForSale: false,
+        sale: {
+          isClosed: false,
+          internalID: "123",
+        },
+        artists: [
+          {
+            name: "Santa",
+            isConsignable: false,
+          },
+        ],
       }
 
-      const component = mount(
+      const componentWithNoLink = mount(
         <Theme>
           <ArtworkExtraLinks artwork={notForSaleArtwork} />
         </Theme>
       )
-      expect(component.find(Sans).length).toEqual(0)
+      expect(componentWithNoLink.find(Sans).length).toEqual(0)
     })
 
     it("posts proper event in when clicking Ask A Specialist", () => {

--- a/src/lib/Scenes/Artwork/Components/__tests__/ArtworkExtraLinks-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/__tests__/ArtworkExtraLinks-tests.tsx
@@ -1,6 +1,7 @@
 import { Sans, Theme } from "@artsy/palette"
 import { mount } from "enzyme"
 import { ArtworkFixture } from "lib/__fixtures__/ArtworkFixture"
+import Event from "lib/NativeModules/Events"
 import React from "react"
 import { Text } from "react-native"
 import { ArtworkExtraLinks } from "../ArtworkExtraLinks"
@@ -8,6 +9,10 @@ import { ArtworkExtraLinks } from "../ArtworkExtraLinks"
 jest.mock("lib/NativeModules/SwitchBoard", () => ({
   presentNavigationViewController: jest.fn(),
 }))
+
+jest.unmock("react-tracking")
+
+jest.mock("lib/NativeModules/Events", () => ({ postEvent: jest.fn() }))
 
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 
@@ -185,28 +190,28 @@ describe("ArtworkExtraLinks", () => {
     })
   })
   describe("FAQ and specialist Auction links", () => {
-    it("renders Auction specific text", () => {
-      const artwork = {
-        ...ArtworkFixture,
-        isInAuction: true,
-        isForSale: true,
-        sale: {
-          isClosed: false,
-          internalID: "123",
+    const artwork = {
+      ...ArtworkFixture,
+      isForSale: true,
+      isInAuction: true,
+      sale: {
+        isClosed: false,
+        internalID: "123",
+      },
+      artists: [
+        {
+          name: "Santa",
+          isConsignable: true,
         },
-        artists: [
-          {
-            name: "Santa",
-            isConsignable: true,
-          },
-        ],
-      }
+      ],
+    }
 
-      const component = mount(
-        <Theme>
-          <ArtworkExtraLinks artwork={artwork} />
-        </Theme>
-      )
+    const component = mount(
+      <Theme>
+        <ArtworkExtraLinks artwork={artwork} />
+      </Theme>
+    )
+    it("renders Auction specific text", () => {
       expect(
         component
           .find(Sans)
@@ -228,28 +233,27 @@ describe("ArtworkExtraLinks", () => {
     })
 
     it("hides auction links when auction work has sold via buy now", () => {
-      const artwork = {
-        ...ArtworkFixture,
+      const notForSaleArtwork = {
+        ...artwork,
         isForSale: false,
-        isInAuction: true,
-        sale: {
-          isClosed: false,
-          internalID: "123",
-        },
-        artists: [
-          {
-            name: "Santa",
-            isConsignable: false,
-          },
-        ],
       }
 
       const component = mount(
         <Theme>
-          <ArtworkExtraLinks artwork={artwork} />
+          <ArtworkExtraLinks artwork={notForSaleArtwork} />
         </Theme>
       )
       expect(component.find(Sans).length).toEqual(0)
+    })
+
+    it("calls the draft created event", () => {
+      component
+        .find("Text")
+        .findWhere(t => t.text() === "ask a specialist")
+        .first()
+        .props()
+        .onPress()
+      expect(Event.postEvent).toBeCalled()
     })
   })
 })

--- a/src/lib/Scenes/Artwork/Components/__tests__/ArtworkExtraLinks-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/__tests__/ArtworkExtraLinks-tests.tsx
@@ -15,6 +15,7 @@ jest.unmock("react-tracking")
 jest.mock("lib/NativeModules/Events", () => ({ postEvent: jest.fn() }))
 
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
+import { mockTracking } from "lib/tests/mockTracking"
 
 describe("ArtworkExtraLinks", () => {
   it("redirects to consignments flow when consignments link is clicked", () => {
@@ -206,11 +207,12 @@ describe("ArtworkExtraLinks", () => {
       ],
     }
 
-    const component = mount(
+    const Component = mockTracking(() => (
       <Theme>
         <ArtworkExtraLinks artwork={artwork} />
       </Theme>
-    )
+    ))
+    const component = mount(<Component />)
     it("renders Auction specific text", () => {
       expect(
         component
@@ -246,14 +248,46 @@ describe("ArtworkExtraLinks", () => {
       expect(component.find(Sans).length).toEqual(0)
     })
 
-    it("calls the draft created event", () => {
+    it("posts proper event in when clicking Ask A Specialist", () => {
       component
         .find("Text")
         .findWhere(t => t.text() === "ask a specialist")
         .first()
         .props()
         .onPress()
-      expect(Event.postEvent).toBeCalled()
+      expect(Event.postEvent).toBeCalledWith({
+        action_name: "askASpecialist",
+        action_type: "tap",
+        context_module: "ArtworkExtraLinks",
+      })
+    })
+
+    it("posts proper event in when clicking Read our auction FAQs", () => {
+      component
+        .find("Text")
+        .findWhere(t => t.text() === "Read our auction FAQs")
+        .first()
+        .props()
+        .onPress()
+      expect(Event.postEvent).toBeCalledWith({
+        action_name: "auctionsFAQ",
+        action_type: "tap",
+        context_module: "ArtworkExtraLinks",
+      })
+    })
+
+    it("posts proper event in when clicking Conditions of Sale", () => {
+      component
+        .find("Text")
+        .findWhere(t => t.text() === "Conditions of Sale")
+        .first()
+        .props()
+        .onPress()
+      expect(Event.postEvent).toBeCalledWith({
+        action_name: "conditionsOfSale",
+        action_type: "tap",
+        context_module: "ArtworkExtraLinks",
+      })
     })
   })
 })

--- a/src/lib/tests/mockTracking.ts
+++ b/src/lib/tests/mockTracking.ts
@@ -1,0 +1,17 @@
+import Event from "lib/NativeModules/Events"
+import track from "react-tracking"
+
+/**
+ * wrap components with this to inject react-tracking
+ * make sure to call
+ *   jest.unmock('react-tracking')
+ * and mock out Events
+ *   jest.mock("lib/NativeModules/Events", () => ({ postEvent: jest.fn() }))
+ * and then import Events
+ *   import Events from "lib/NativeModules/Events"
+ * and then make assertions like
+ *   expect(Events.postEvent).toHaveBeenCalledWith({myTrackingProperty: "whateve"})
+ */
+export function mockTracking<Props>(Component: React.ComponentType<Props>): React.ComponentType<Props> {
+  return track({}, { dispatch: data => Event.postEvent(data) })(Component)
+}

--- a/src/lib/utils/track/schema.ts
+++ b/src/lib/utils/track/schema.ts
@@ -169,20 +169,26 @@ export enum ActionNames {
   /**
    * Artwork Page Events
    */
+  ArtworkClassification = "artworkClassification",
   ArtworkImageSwipe = "artworkImageSwipe",
   ArtworkImageZoom = "artworkImageZoom",
   ArtworkSave = "artworkSave",
   ArtworkUnsave = "artworkUnsave",
-  ArtworkClassification = "artworkClassification",
   AskASpecialist = "askASpecialist",
+  AuctionsFAQ = "auctionsFAQ",
+  Bid = "bid",
+  ConditionsOfSale = "conditionsOfSale",
   ConsignWithArtsy = "consignWithArtsy",
+  EnterLiveBidding = "enterLiveBidding",
   FollowPartner = "followPartner",
   GridArtwork = "gridArtwork",
-  Share = "share",
-  ViewInRoom = "viewInRoom",
+  IncreaseMaxBid = "increaseMaxBid",
   ReadMore = "readMore",
+  RegisterToBid = "registerToBid",
+  Share = "share",
   ShowMoreArtworksDetails = "showMoreArtworksDetails",
   ViewAll = "viewAll",
+  ViewInRoom = "viewInRoom",
 
   /**
    * City and Map Page Events

--- a/src/lib/utils/track/schema.ts
+++ b/src/lib/utils/track/schema.ts
@@ -189,6 +189,7 @@ export enum ActionNames {
   ShowMoreArtworksDetails = "showMoreArtworksDetails",
   ViewAll = "viewAll",
   ViewInRoom = "viewInRoom",
+  WatchLiveBidding = "watchLiveBidding",
 
   /**
    * City and Map Page Events


### PR DESCRIPTION
# Change
https://artsyproduct.atlassian.net/browse/PURCHASE-1486
Added `@track` around few auction related actions based on ☝️ 

# Refactor?
`BidButton` logic was little complicated and hard to read, ended up consolidating some checks in one place and also tried to break `render` to call two other renders in `if` statement.

Let me know if there is a better way to make this more readable and if my changes don't help.

#skip_new_tests (for existing schema.ts file)