### PR TITLE
[Design Tweak] If no information on reserve or max bid (smaller text below 'starting bid') move the rest of the content up

### DIFF
--- a/src/lib/Scenes/Artwork/Components/AuctionPrice.tsx
+++ b/src/lib/Scenes/Artwork/Components/AuctionPrice.tsx
@@ -60,6 +60,7 @@ export class AuctionPrice extends React.Component<AuctionPriceProps> {
     const myMaxBid = get(myMostRecent, bid => bid.maxBid.display)
     const bidsCount = get(artwork, a => a.saleArtwork.counts.bidderPositions)
     const bidsPresent = bidsCount > 0
+    const bidText = this.bidText(bidsPresent, bidsCount) ? this.bidText(bidsPresent, bidsCount) : null
 
     return (
       <>
@@ -81,9 +82,12 @@ export class AuctionPrice extends React.Component<AuctionPriceProps> {
           </Sans>
         </Flex>
         <Flex flexDirection="row" flexWrap="nowrap" justifyContent="space-between">
-          <Sans size="2" pr={1} color="black60">
-            {this.bidText(bidsPresent, bidsCount)}
-          </Sans>
+          {bidText && (
+            <Sans size="2" pr={1} color="black60">
+              {bidText}
+            </Sans>
+          )}
+
           {myMaxBid && (
             <Sans size="2" color="black60" pl={1}>
               Your max: {myMaxBid}


### PR DESCRIPTION
__Before:__
<img width="341" alt="Screen Shot 2019-09-23 at 10 18 30 AM" src="https://user-images.githubusercontent.com/5643895/65551716-87995100-def0-11e9-9818-53ca93bb9037.png">

__After:__
<img width="344" alt="Screen Shot 2019-09-23 at 10 26 35 AM" src="https://user-images.githubusercontent.com/5643895/65551735-94b64000-def0-11e9-924e-945f68161504.png">

#trivial