### PR TITLE
[PURCHASE-1519] Fixes issue where the Artwork page would show a refresh animation on re-appear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Master
 
+- Fixes issue where the Artwork page would show a refresh animation on re-appear - ash
+
 ### 1.17.2
 
 - Refetches Artwork page query on re-appear - ash & purchase team

--- a/src/lib/Scenes/Artwork/Artwork.tsx
+++ b/src/lib/Scenes/Artwork/Artwork.tsx
@@ -82,7 +82,7 @@ export class Artwork extends React.Component<Props, State> {
   componentDidUpdate(prevProps) {
     // If we are visible, but weren't, then we are re-appearing (not called on first render).
     if (this.props.isVisible && !prevProps.isVisible) {
-      this.onRefresh()
+      this.forceRefetch()
     }
   }
 


### PR DESCRIPTION
Tracked here: https://www.notion.so/artsy/When-viewing-a-modal-i-e-the-Attribution-Class-one-going-back-to-the-artwork-page-triggers-a-ref-295d8c5c0d204f748ee1da194fa4c607