### PR TITLE
[PURCHASE-1520] Fixes submitting a consignment with a missing edition size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Master
 
+- Fixes submitting a consignment with a missing edition size - ash
+
 ### 1.17.2
 
 - Refetches Artwork page query on re-appear - ash & purchase team

--- a/src/lib/Components/Consignments/Submission/__tests__/consignmentSetupToSubmission-tests.ts
+++ b/src/lib/Components/Consignments/Submission/__tests__/consignmentSetupToSubmission-tests.ts
@@ -28,18 +28,47 @@ describe("consignment metadata -> submission", () => {
       },
       editionScreenViewed: true,
     }
-    const result = {
-      clientMutationId: "ID",
-      artistID: "danger",
-      category: "DESIGN_DECORATIVE_ART",
-      dimensionsMetric: "CM",
-      edition: false,
-      height: "100",
-      medium: "Wood",
-      title: "My Work",
-      width: "100",
-      year: "1983",
+    expect(consignmentSetupToMutationInput(setup)).toMatchInlineSnapshot(`
+      Object {
+        "artistID": "danger",
+        "category": "DESIGN_DECORATIVE_ART",
+        "clientMutationId": "ID",
+        "dimensionsMetric": "CM",
+        "edition": false,
+        "height": "100",
+        "medium": "Wood",
+        "title": "My Work",
+        "width": "100",
+        "year": "1983",
+      }
+    `)
+  })
+
+  it("handles a missing edition size", () => {
+    const setup: ConsignmentSetup = {
+      artist: {
+        internalID: "danger",
+        name: "Danger McShane",
+      },
+      editionInfo: {
+        size: undefined, // This is important, parseInt(undefined) returns NaN
+        number: "1",
+      },
+      metadata: {
+        title: "My Work",
+        year: "1983",
+        category: "DESIGN_DECORATIVE_ART",
+        categoryName: "Design",
+        medium: "Wood",
+        width: "100",
+        height: "100",
+        depth: null,
+        unit: "CM",
+        displayString: "5/5",
+      },
+      editionScreenViewed: true,
     }
-    expect(consignmentSetupToMutationInput(setup)).toEqual(result)
+    const result = consignmentSetupToMutationInput(setup)
+    expect(result.editionSize).not.toBeNaN()
   })
 })

--- a/src/lib/Components/Consignments/Submission/consignmentSetupToSubmission.ts
+++ b/src/lib/Components/Consignments/Submission/consignmentSetupToSubmission.ts
@@ -26,7 +26,7 @@ export const consignmentSetupToMutationInput = (submission: ConsignmentSetup) =>
       dimensionsMetric: submission.metadata && submission.metadata.unit,
       edition: !!submission.editionInfo,
       editionNumber: submission.editionInfo && submission.editionInfo.number,
-      editionSize: submission.editionInfo && parseInt(submission.editionInfo.size, 10),
+      editionSize: submission.editionInfo && (parseInt(submission.editionInfo.size, 10) || null), // parseInt(undefined) returns NaN, which errors on MP.
       height: submission.metadata && submission.metadata.height,
       locationCity: submission.location && submission.location.city,
       locationCountry: submission.location && submission.location.country,


### PR DESCRIPTION
Tracked here: https://www.notion.so/artsy/Consignments-that-specify-an-edition-without-an-edition-size-crash-the-app-206bd7177f654660a5f03208edf81839

I also updated the unit test to use Jest's new inline snapshot checking. 