### PR TITLE
PURCHASE-1540 -  Uses em dash between text in ReadMore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Master
 
 - Fixes crash with missing artist images - ash
+- Uses em dash between text in ReadMore component instead of line break - kierangillen
 
 ### 1.17.6
 

--- a/src/lib/Components/ReadMore.tsx
+++ b/src/lib/Components/ReadMore.tsx
@@ -27,8 +27,8 @@ export const ReadMore = React.memo(({ content, maxChars, presentLinksModally, tr
       react: (node, output, state) => {
         return (
           <Serif size="3t" color="black100" key={state.key}>
+            {!isExpanded && Number(state.key) > 0 ? "⁠ — " : null}
             {output(node.content, state)}
-            {isExpanded ? null : "⁠ — "}
           </Serif>
         )
       },

--- a/src/lib/Components/ReadMore.tsx
+++ b/src/lib/Components/ReadMore.tsx
@@ -28,6 +28,7 @@ export const ReadMore = React.memo(({ content, maxChars, presentLinksModally, tr
         return (
           <Serif size="3t" color="black100" key={state.key}>
             {output(node.content, state)}
+            {isExpanded ? null : "⁠ — "}
           </Serif>
         )
       },

--- a/src/lib/Components/__tests__/ReadMore-tests.tsx
+++ b/src/lib/Components/__tests__/ReadMore-tests.tsx
@@ -39,6 +39,17 @@ describe("ReadMore", () => {
     expect(component.find(Sans).length).toEqual(0)
   })
 
+  it("Renders an em dash if the text has line breaks when not expanded", () => {
+    const component = shallow(<ReadMore maxChars={30} content={"Line break\n\nWhich should render an em dash"} />)
+
+    expect(
+      component
+        .find(Serif)
+        .at(1)
+        .text()
+    ).toContain(" — Which should")
+  })
+
   it("Shows the 'Read more' link when the length of the text is > the number of characters allowed", () => {
     const component = mount(
       <Theme>


### PR DESCRIPTION
- Uses em dash between text instead in unexpanded text in `ReadMore` component
- https://artsyproduct.atlassian.net/browse/PURCHASE-1540

![2019-10-04 16 17 13](https://user-images.githubusercontent.com/21182806/66237346-dbf7ba00-e6c2-11e9-99a0-c38008b2cb95.gif)

