### PR TITLE
Fixes crash with missing artist images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Master
 
+- Fixes crash with missing artist images - ash
+
 ### 1.17.6
 
 ### 1.17.5

--- a/src/lib/Scenes/Favorites/Components/Artists/index.tsx
+++ b/src/lib/Scenes/Favorites/Components/Artists/index.tsx
@@ -71,13 +71,7 @@ class Artists extends React.Component<Props, State> {
       <FlatList<ArtistDetails>
         data={rows}
         keyExtractor={({ id }) => id}
-        renderItem={({
-          item: {
-            href,
-            image: { url },
-            name,
-          },
-        }) => <SavedItemRow href={href} image={{ url }} name={name} />}
+        renderItem={({ item: { href, image, name } }) => <SavedItemRow href={href} image={image} name={name} />}
         onEndReached={this.loadMore}
         onEndReachedThreshold={0.2}
         refreshControl={<RefreshControl refreshing={this.state.refreshingFromPull} onRefresh={this.handleRefresh} />}


### PR DESCRIPTION
#1901 added some safety to our use of image URLs (specifically, accessing `something.image.url` would crash if `image` was `null`). Looking closer at the [crash](https://sentry.io/organizations/artsynet/issues/1250975276/) [logs](https://sentry.io/organizations/artsynet/issues/1250975252/), we see that the query response that causes these crashes is `b108ebed90e257a8a29d53a085165670`, the `ArtistsMeQuery` query. The component uses a function that restructures its arguments in a way that causes a crash if `image` is `null`, so it seems like our likely source. The function was actually destructing more than it had to (and re-structuring to pass parameters into a child component) so the fix was simple:

```diff
renderItem={({
          item: {
            href,
-            image: { url },
+            image,
            name,
          },
-        }) => <SavedItemRow href={href} image={{ url }} name={name} />}
+        }) => <SavedItemRow href={href} image={image} name={name} />}
```

I checked the typing of `SavedItemRow` and it already supports `null` `image.url` 👍