### PR TITLE
ME-17 Send RetryErrorBoundary errors to sentry

### DIFF
--- a/src/lib/Components/RetryErrorBoundary.tsx
+++ b/src/lib/Components/RetryErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { Sentry } from "react-native-sentry"
 import LoadFailureView from "./LoadFailureView"
 
 enum ErrorState {
@@ -20,6 +21,7 @@ interface State {
 export class RetryErrorBoundary extends React.Component<Props, State> {
   static getDerivedStateFromError(error) {
     console.error(error)
+    Sentry.captureMessage(error.stack)
     return { errorState: ErrorState.Error }
   }
 

--- a/src/setupJest.ts
+++ b/src/setupJest.ts
@@ -35,8 +35,10 @@ jest.mock("./lib/NativeModules/NotificationsManager.tsx", () => ({
 }))
 
 jest.mock("react-native-sentry", () => ({
-  // tslint:disable-next-line:no-empty
-  captureMessage() {},
+  Sentry: {
+    // tslint:disable-next-line:no-empty
+    captureMessage() {},
+  },
 }))
 
 jest.mock("@mapbox/react-native-mapbox-gl", () => ({

--- a/src/setupJest.ts
+++ b/src/setupJest.ts
@@ -34,6 +34,11 @@ jest.mock("./lib/NativeModules/NotificationsManager.tsx", () => ({
   },
 }))
 
+jest.mock("react-native-sentry", () => ({
+  // tslint:disable-next-line:no-empty
+  captureMessage() {},
+}))
+
 jest.mock("@mapbox/react-native-mapbox-gl", () => ({
   MapView: () => null,
   StyleURL: {


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/ME-17

#trivial 
#skip_new_tests

There's a separate method for capturing `Error`s called `Sentry.captureException` but I found that the stack trace disappeared when using that method 🤔 So I decided to just capture the stack trace as a string. We'll need to figure out why the stack trace is disappearing if we ever want to set up symbolication for eigen (that's where you tell sentry about the source maps for your js bundle so it can replace bundled JS line numbers with source TS line numbers)
 