### PR TITLE
Fixes a few issues on the artwork view while auction is open for live bidding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 - Add graphql request duration reporting via volley - ds300
 - Fixes `Contact Gallery` button showing up when artwork auction is closed - sepans
+- Updates CommercialInformation component to properly handle live auctions - sweir27
 
 ### 1.17.8
 

--- a/src/lib/Scenes/Artwork/Components/AuctionCountDownTimer.tsx
+++ b/src/lib/Scenes/Artwork/Components/AuctionCountDownTimer.tsx
@@ -31,7 +31,7 @@ export class AuctionCountDownTimer extends React.Component<AuctionCountDownTimer
   countdownValue(sale, auctionState) {
     if (auctionState === "isPreview") {
       return sale.startAt
-    } else if (auctionState === "hasStarted" && sale.liveStartAt) {
+    } else if ((auctionState === "hasStarted" || auctionState === "isLive") && sale.liveStartAt) {
       return sale.liveStartAt
     } else {
       return sale.endAt

--- a/src/lib/Scenes/Artwork/Components/CommercialInformation.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialInformation.tsx
@@ -78,9 +78,12 @@ export class CommercialInformation extends React.Component<CommercialInformation
     const { artwork } = this.props
     const { auctionState } = this.state
     const { isInAuction, isForSale } = artwork
-
-    if (isInAuction && isForSale && auctionState !== "isLive") {
-      return <AuctionPrice artwork={artwork} auctionState={auctionState as AuctionState} />
+    if (isInAuction && isForSale) {
+      if (auctionState === "isLive") {
+        return null
+      } else {
+        return <AuctionPrice artwork={artwork} auctionState={auctionState as AuctionState} />
+      }
     } else if (artwork.editionSets && artwork.editionSets.length > 1) {
       return this.renderEditionSetArtwork()
     } else {
@@ -157,6 +160,7 @@ export class CommercialInformation extends React.Component<CommercialInformation
     const isInClosedAuction = isInAuction && sale && auctionState === "hasEnded"
     const canTakeCommercialAction = isAcquireable || isOfferable || isInquireable || isBiddableInAuction
     const artistIsConsignable = artwork.artists.filter(artist => artist.isConsignable).length
+    const hidesPriceInformation = isInAuction && isForSale && auctionState === "isLive"
 
     return (
       <>
@@ -165,7 +169,7 @@ export class CommercialInformation extends React.Component<CommercialInformation
           {canTakeCommercialAction &&
             !isInClosedAuction && (
               <>
-                <Spacer mb={2} />
+                {!hidesPriceInformation && <Spacer mb={2} />}
                 <CommercialButtons artwork={artwork} auctionState={auctionState} editionSetID={editionSetID} />
               </>
             )}

--- a/src/lib/Scenes/Artwork/Components/__tests__/AuctionCountDownTimer-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/__tests__/AuctionCountDownTimer-tests.tsx
@@ -70,6 +70,7 @@ describe("AuctionCountDownTimer", () => {
       const date = timeUntil(startAt, liveStartAt, endAt, auctionState)
       expect(date).toEqual("Starts Aug 16, 8:00am EDT")
     })
+
     it("returns 'Live' string when auction has started but live sale has not", () => {
       const startAt = oneDayAgo
       const liveStartAt = oneDayFromNow
@@ -88,6 +89,7 @@ describe("AuctionCountDownTimer", () => {
       expect(date).toEqual("In progress")
     })
   })
+
   it("renders the correct countdown time and label using endAt if auctionState hasStarted", () => {
     const artwork = {
       ...ArtworkFixture,
@@ -114,7 +116,7 @@ describe("AuctionCountDownTimer", () => {
         sale: {
           startAt: "2019-08-14T19:22:00+00:00",
           liveStartAt: "2019-09-15T19:22:00+00:00",
-          endAt: "2019-10-16T20:20:00+00:00",
+          endAt: null,
         },
       },
     }
@@ -125,6 +127,26 @@ describe("AuctionCountDownTimer", () => {
     )
 
     expect(component.find(TimeRemaining).text()).toContain("31d 07h 22m 00sLive Sep 15, 3:22pm")
+  })
+
+  it("renders the correct countdown time and label when the live portion of the sale has started", () => {
+    const artwork = {
+      ...ArtworkFixture,
+      ...{
+        sale: {
+          startAt: oneYearAgo,
+          liveStartAt: oneDayAgo,
+          endAt: null,
+        },
+      },
+    }
+    const component = mount(
+      <Theme>
+        <AuctionCountDownTimer artwork={artwork} auctionState="isLive" />
+      </Theme>
+    )
+
+    expect(component.find(TimeRemaining).text()).toContain("00d 00h 00m 00sIn progress")
   })
 
   it("doesn't render if sale is null", () => {

--- a/src/lib/Scenes/Artwork/__tests__/Artwork-tests.tsx
+++ b/src/lib/Scenes/Artwork/__tests__/Artwork-tests.tsx
@@ -1,10 +1,21 @@
+import { Button, Sans, TimeRemaining } from "@artsy/palette"
 import { mount } from "enzyme"
+import {
+  ArtworkFromLiveAuctionRegistrationClosed,
+  ArtworkFromLiveAuctionRegistrationOpen,
+  NotRegisteredToBid,
+  RegisteredBidder,
+} from "lib/__fixtures__/ArtworkBidAction"
 import { ArtworkFixture } from "lib/__fixtures__/ArtworkFixture"
+import { merge } from "lodash"
 import React from "react"
 import { RelayRefetchProp } from "react-relay"
 import { useTracking } from "react-tracking"
 import { Artwork } from "../Artwork"
 import { ArtworkHeader } from "../Components/ArtworkHeader"
+import { AuctionCountDownTimer } from "../Components/AuctionCountDownTimer"
+import { BidButton } from "../Components/CommercialButtons/BidButton"
+import { CommercialPartnerInformation } from "../Components/CommercialPartnerInformation"
 import { ContextCard } from "../Components/ContextCard"
 
 const trackEvent = jest.fn()
@@ -63,5 +74,52 @@ describe("Artwork", () => {
       <Artwork artwork={auctionSaleArtwork as any} relay={{ environment: {} } as RelayRefetchProp} isVisible />
     )
     expect(component.find(ContextCard).length).toEqual(1)
+  })
+
+  describe("Live Auction States", () => {
+    it("has the correct state for a work that is in an auction that is currently live, for which I am registered", () => {
+      const liveAuctionArtwork = merge({}, ArtworkFixture, ArtworkFromLiveAuctionRegistrationClosed, RegisteredBidder)
+      const component = mount(
+        <Artwork artwork={liveAuctionArtwork as any} relay={{ environment: {} } as RelayRefetchProp} isVisible />
+      )
+      expect(component.find(CommercialPartnerInformation).length).toEqual(0)
+      expect(component.find(AuctionCountDownTimer).length).toEqual(1)
+      expect(component.find(TimeRemaining).text()).toContain("00d 00h 00m 00sIn progress")
+      expect(component.find(BidButton).text()).toContain("Enter live bidding")
+    })
+
+    it("has the correct state for a work that is in an auction that is currently live, for which I am not registered and registration is open", () => {
+      const liveAuctionArtwork = merge({}, ArtworkFixture, ArtworkFromLiveAuctionRegistrationClosed, NotRegisteredToBid)
+      const component = mount(
+        <Artwork artwork={liveAuctionArtwork as any} relay={{ environment: {} } as RelayRefetchProp} isVisible />
+      )
+      expect(component.find(CommercialPartnerInformation).length).toEqual(0)
+      expect(component.find(AuctionCountDownTimer).length).toEqual(1)
+      expect(component.find(TimeRemaining).text()).toContain("00d 00h 00m 00sIn progress")
+      expect(
+        component
+          .find(BidButton)
+          .find(Button)
+          .text()
+      ).toContain("Watch live bidding")
+      expect(
+        component
+          .find(BidButton)
+          .find(Sans)
+          .at(0)
+          .text()
+      ).toContain("Registration closed")
+    })
+
+    it("has the correct state for a work that is in an auction that is currently live, for which I am not registered and registration is closed", () => {
+      const liveAuctionArtwork = merge({}, ArtworkFixture, ArtworkFromLiveAuctionRegistrationOpen, NotRegisteredToBid)
+      const component = mount(
+        <Artwork artwork={liveAuctionArtwork as any} relay={{ environment: {} } as RelayRefetchProp} isVisible />
+      )
+      expect(component.find(CommercialPartnerInformation).length).toEqual(0)
+      expect(component.find(AuctionCountDownTimer).length).toEqual(1)
+      expect(component.find(TimeRemaining).text()).toContain("00d 00h 00m 00sIn progress")
+      expect(component.find(BidButton).text()).toContain("Enter live bidding")
+    })
   })
 })

--- a/src/lib/__fixtures__/ArtworkBidAction.ts
+++ b/src/lib/__fixtures__/ArtworkBidAction.ts
@@ -1,6 +1,15 @@
+import { DateTime } from "luxon"
+
+const InAuctionForSale = {
+  isInAuction: true,
+  isForSale: true,
+}
+
 export const ArtworkFromAuctionPreview = {
+  ...InAuctionForSale,
   internalID: "artwork_from_preview_auction",
   sale: {
+    isAuction: true,
     registrationStatus: null,
     isPreview: true,
     isOpen: false,
@@ -20,8 +29,10 @@ export const ArtworkFromAuctionPreview = {
 }
 
 export const ArtworkFromTimedAuctionRegistrationOpen = {
+  ...InAuctionForSale,
   internalID: "artwork_from_open_non_live_auction",
   sale: {
+    isAuction: true,
     registrationStatus: null,
     isPreview: false,
     isOpen: true,
@@ -41,8 +52,10 @@ export const ArtworkFromTimedAuctionRegistrationOpen = {
 }
 
 export const ArtworkFromTimedAuctionRegistrationClosed = {
+  ...InAuctionForSale,
   internalID: "artwork_from_open_non_live_auction",
   sale: {
+    isAuction: true,
     registrationStatus: null,
     isPreview: false,
     isOpen: true,
@@ -62,14 +75,23 @@ export const ArtworkFromTimedAuctionRegistrationClosed = {
 }
 
 export const ArtworkFromLiveAuctionRegistrationOpen = {
+  ...InAuctionForSale,
   internalID: "artwork_from_open_live_auction_open_registration",
   sale: {
+    isAuction: true,
     registrationStatus: null,
     isPreview: false,
     isOpen: true,
     isLiveOpen: true,
     isClosed: false,
     isRegistrationClosed: false,
+    liveStartAt: DateTime.fromMillis(Date.now())
+      .minus({ minutes: 1 })
+      .toISO(),
+    startAt: DateTime.fromMillis(Date.now())
+      .minus({ minutes: 10 })
+      .toISO(),
+    endAt: null,
   },
   saleArtwork: {
     increments: [
@@ -83,14 +105,22 @@ export const ArtworkFromLiveAuctionRegistrationOpen = {
 }
 
 export const ArtworkFromLiveAuctionRegistrationClosed = {
+  ...InAuctionForSale,
   internalID: "artwork_from_open_live_auction_closed_registration",
   sale: {
+    isAuction: true,
     registrationStatus: null,
     isPreview: false,
     isOpen: true,
     isLiveOpen: true,
     isClosed: false,
     isRegistrationClosed: true,
+    liveStartAt: DateTime.fromMillis(Date.now())
+      .minus({ minutes: 1 })
+      .toISO(),
+    startAt: DateTime.fromMillis(Date.now())
+      .minus({ minutes: 10 })
+      .toISO(),
   },
   saleArtwork: {
     increments: [
@@ -104,8 +134,10 @@ export const ArtworkFromLiveAuctionRegistrationClosed = {
 }
 
 export const ArtworkFromClosedAuction = {
+  ...InAuctionForSale,
   internalID: "artwork_from_closed_auction",
   sale: {
+    isAuction: true,
     registrationStatus: null,
     isPreview: false,
     isOpen: false,


### PR DESCRIPTION
Addresses: https://artsyproduct.atlassian.net/browse/PURCHASE-1597

Before:
![image](https://user-images.githubusercontent.com/2081340/67037731-1bbf9800-f0ec-11e9-92e5-8685a94c2d77.png)

There are a few issues with the above image:
- We should not be showing the "availability" message and corresponding partner information for this case.
- We should be showing the timer (at 0, with `In progress` as the label)
- We should be correctly showing `Enter live bidding` vs. `Watch live bidding`

I confirmed that out logic for when to show `Enter` vs. `Watch` is correct, so I suspect the original bug report was due to weirdness around auction state transitions. 

When I am able to register OR already registered:
<img width="380" alt="Screen Shot 2019-10-17 at 2 38 50 PM" src="https://user-images.githubusercontent.com/2081340/67037629-e1ee9180-f0eb-11e9-846a-e67e9fcc8e56.png">

When I am not able to register:
<img width="383" alt="Screen Shot 2019-10-17 at 2 18 26 PM" src="https://user-images.githubusercontent.com/2081340/67037642-e87d0900-f0eb-11e9-936d-81ba753df328.png">
