### PR TITLE
[PURCHASE-1600] Hide 'contact gallery' button when artwork sale is closed

### DIFF
--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/CommercialButtons.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/CommercialButtons.tsx
@@ -35,6 +35,8 @@ export class CommercialButtons extends React.Component<CommercialButtonProps> {
     const { isBuyNowable, isAcquireable, isOfferable, isInquireable, isInAuction, editionSets, isForSale } = artwork
     const noEditions = (editionSets && editionSets.length === 0) || !editionSets
 
+    const artworkSaleEnded = artwork.sale && artwork.sale.isClosed
+
     if (isInAuction && artwork.sale && auctionState !== "hasEnded" && isForSale) {
       return (
         <>
@@ -61,7 +63,7 @@ export class CommercialButtons extends React.Component<CommercialButtonProps> {
       return <BuyNowButton artwork={artwork} editionSetID={this.props.editionSetID} />
     } else if (isOfferable) {
       return <MakeOfferButton artwork={artwork} editionSetID={this.props.editionSetID} />
-    } else if (isInquireable) {
+    } else if (isInquireable && !artworkSaleEnded) {
       return (
         <Button onPress={() => this.handleInquiry()} size="large" block width={100}>
           Contact gallery

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/__tests__/CommercialButtons-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/__tests__/CommercialButtons-tests.tsx
@@ -65,6 +65,23 @@ describe("CommercialButtons", () => {
     expect(commercialButtons.text()).toContain("Contact gallery")
   })
 
+  it("doesn't render button for Contact Gallery button if isInquireable but sale is closed", async () => {
+    const artwork = {
+      ...ArtworkFixture,
+      isAcquireable: false,
+      isOfferable: false,
+      isInquireable: true,
+      isForSale: true,
+      sale: {
+        isClosed: true,
+      },
+    }
+    const commercialButtons = await relayComponent({
+      artwork,
+    })
+    expect(commercialButtons.text()).not.toContain("Contact gallery")
+  })
+
   it("renders Make Offer button if isOfferable", async () => {
     const artwork = {
       ...ArtworkFixture,


### PR DESCRIPTION
Fixes [PURCHASE-1600](https://artsyproduct.atlassian.net/browse/PURCHASE-1600)

Before:

<img width="459" alt="Screen Shot 2019-10-17 at 2 50 19 PM" src="https://user-images.githubusercontent.com/687513/67038508-858c7180-f0ed-11e9-8160-b26235f61bd5.png">

After:

<img width="461" alt="Screen Shot 2019-10-17 at 2 49 31 PM" src="https://user-images.githubusercontent.com/687513/67038513-87eecb80-f0ed-11e9-9173-80411744b345.png">
