### PR TITLE
No 'Contact Gallery' Button for artwork in closed auction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Master
 
 - Add graphql request duration reporting via volley - ds300
+- Fixes `Contact Gallery` button showing up when artwork auction is closed - sepans
 
 ### 1.17.8
 

--- a/src/lib/Scenes/Artwork/Components/CommercialInformation.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialInformation.tsx
@@ -154,6 +154,7 @@ export class CommercialInformation extends React.Component<CommercialInformation
     const { isAcquireable, isOfferable, isInquireable, isInAuction, sale, isForSale } = artwork
 
     const isBiddableInAuction = isInAuction && sale && auctionState !== "hasEnded" && isForSale
+    const isInClosedAuction = isInAuction && sale && auctionState === "hasEnded"
     const canTakeCommercialAction = isAcquireable || isOfferable || isInquireable || isBiddableInAuction
     const artistIsConsignable = artwork.artists.filter(artist => artist.isConsignable).length
 
@@ -161,12 +162,13 @@ export class CommercialInformation extends React.Component<CommercialInformation
       <>
         {this.renderPriceInformation()}
         <Box>
-          {canTakeCommercialAction && (
-            <>
-              <Spacer mb={2} />
-              <CommercialButtons artwork={artwork} auctionState={auctionState} editionSetID={editionSetID} />
-            </>
-          )}
+          {canTakeCommercialAction &&
+            !isInClosedAuction && (
+              <>
+                <Spacer mb={2} />
+                <CommercialButtons artwork={artwork} auctionState={auctionState} editionSetID={editionSetID} />
+              </>
+            )}
           {isBiddableInAuction && (
             <>
               <Spacer mb={2} />

--- a/src/lib/Scenes/Artwork/Components/__tests__/CommercialInformation-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/__tests__/CommercialInformation-tests.tsx
@@ -28,10 +28,11 @@ describe("CommercialInformation", () => {
     expect(component.find(ArtworkExtraLinks).text()).toContain("Consign with Artsy.")
   })
 
-  it("renders Bidding Closed for auction works when the auction has ended", () => {
+  it("renders Bidding Closed and no CommercialButtons for auction works when the auction has ended", () => {
     const workInEndedAuction = {
       ...CommercialInformationArtwork,
       isInAuction: true,
+      isInquireable: true,
       sale: {
         isAuction: true,
         isClosed: true,
@@ -44,6 +45,7 @@ describe("CommercialInformation", () => {
     )
 
     expect(component.text()).toContain("Bidding closed")
+    expect(component.find("CommercialButtons").length).toBe(0)
   })
 
   it("hides seller info for works from closed auctions", () => {


### PR DESCRIPTION
Fixes [PURCHASE-1600](https://artsyproduct.atlassian.net/browse/PURCHASE-1600)

Before:

<img width="459" alt="Screen Shot 2019-10-17 at 2 50 19 PM" src="https://user-images.githubusercontent.com/687513/67044407-38fb6300-f0fa-11e9-90da-157a85875308.png">

After:

<img width="464" alt="Screen Shot 2019-10-17 at 4 04 24 PM" src="https://user-images.githubusercontent.com/687513/67044451-49abd900-f0fa-11e9-9406-cac265da3b33.png">


The spacing between the sections were complex so for the sake of not breaking the layout for other variations of the screen lifted the logic up to the parent component.