### PR TITLE
Rename enablePriceTransparency to AROptionsPriceTransparency for consistency

### DIFF
--- a/Example/Emission/ARLabOptions.m
+++ b/Example/Emission/ARLabOptions.m
@@ -22,7 +22,7 @@ static NSDictionary *options = nil;
     // object.
     //
     options = @{
-       @"enablePriceTransparency": @"Price transparency"
+       @"AROptionsPriceTransparency": @"Price transparency"
     };
   });
 

--- a/src/lib/Components/Bidding/Screens/ConfirmBid/index.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmBid/index.tsx
@@ -417,7 +417,9 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
     const { requiresPaymentInformation, requiresCheckbox, isLoading } = this.state
     const artworkImage = artwork.image
     const enablePriceTransparency =
-      NativeModules.Emission && NativeModules.Emission.options && NativeModules.Emission.options.enablePriceTransparency
+      NativeModules.Emission &&
+      NativeModules.Emission.options &&
+      NativeModules.Emission.options.AROptionsPriceTransparency
 
     return (
       <BiddingThemeProvider>

--- a/src/lib/Components/Bidding/Screens/__tests__/ConfirmBid-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/ConfirmBid-tests.tsx
@@ -78,7 +78,7 @@ beforeEach(() => {
   NativeModules.ARNotificationsManager = { postNotificationName: mockPostNotificationName }
   NativeModules.Emission = {
     options: {
-      enablePriceTransparency: true,
+      AROptionsPriceTransparency: true,
     },
   }
 })
@@ -155,7 +155,7 @@ it("can load and display price summary", () => {
 })
 
 it("does not display price summary when the feature flag is off", () => {
-  NativeModules.Emission.options.enablePriceTransparency = false
+  NativeModules.Emission.options.AROptionsPriceTransparency = false
 
   const component = mountConfirmBidComponent(initialProps)
 


### PR DESCRIPTION
Just to get aligned with https://github.com/artsy/eigen/pull/2934 so we don't have to do extra key conversion for feature flagging in multiple platforms.

#trivial #skip_new_tests