### PR TITLE
[PURCHASE-1545] All artwork details subfields have a ReadMore link

### DIFF
--- a/src/lib/Scenes/Artwork/Components/ArtworkDetails.tsx
+++ b/src/lib/Scenes/Artwork/Components/ArtworkDetails.tsx
@@ -1,32 +1,23 @@
 import { Box, Join, Sans, Spacer } from "@artsy/palette"
 import { ArtworkDetails_artwork } from "__generated__/ArtworkDetails_artwork.graphql"
+import { ReadMore } from "lib/Components/ReadMore"
 import { Schema, track } from "lib/utils/track"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
-import { LinkText } from "../../../Components/Text/LinkText"
+import { truncatedTextLimit } from "../hardware"
 
 interface ArtworkDetailsProps {
   artwork: ArtworkDetails_artwork
 }
 
-interface ArtworkDetailsState {
-  showAll: boolean
-}
-
 @track()
-export class ArtworkDetails extends React.Component<ArtworkDetailsProps, ArtworkDetailsState> {
-  state = { showAll: false }
-
+export class ArtworkDetails extends React.Component<ArtworkDetailsProps> {
   @track(() => ({
     action_name: Schema.ActionNames.ShowMoreArtworksDetails,
     action_type: Schema.ActionTypes.Tap,
     flow: Schema.Flow.ArtworkDetails,
     context_module: Schema.ContextModules.ArtworkDetails,
   }))
-  showAllArtworks() {
-    this.setState({ showAll: true })
-  }
-
   render() {
     const listItems = [
       { title: "Medium", value: this.props.artwork.category },
@@ -48,40 +39,27 @@ export class ArtworkDetails extends React.Component<ArtworkDetailsProps, Artwork
 
     const displayItems = listItems.filter(i => i.value != null && i.value !== "")
 
-    let truncatedDisplayItems = displayItems
-
-    if (!this.state.showAll && displayItems.length > 3) {
-      truncatedDisplayItems = displayItems.slice(0, 3)
-    }
-
     return (
       <Box>
         <Join separator={<Spacer my={1} />}>
           <Sans size="3t" weight="medium">
             Artwork details
           </Sans>
-          {truncatedDisplayItems.map(({ title, value }, index) => (
+          {displayItems.map(({ title, value }, index) => (
             <React.Fragment key={index}>
               <Sans size="3t" weight="regular">
                 {title}
               </Sans>
-              <Sans size="3t" weight="regular" color="gray">
-                {value}
-              </Sans>
+              <ReadMore
+                content={value}
+                color="black60"
+                sans
+                maxChars={truncatedTextLimit()}
+                trackingFlow={Schema.Flow.ArtworkDetails}
+                contextModule={Schema.ContextModules.ArtworkDetails}
+              />
             </React.Fragment>
           ))}
-          {!this.state.showAll &&
-            (displayItems.length > 3 && (
-              <LinkText
-                onPress={() => {
-                  this.showAllArtworks()
-                }}
-              >
-                <Sans size="3t" weight="regular">
-                  Show more artwork details
-                </Sans>
-              </LinkText>
-            ))}
         </Join>
       </Box>
     )

--- a/src/lib/Scenes/Artwork/Components/__tests__/ArtworkDetails-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/__tests__/ArtworkDetails-tests.tsx
@@ -1,3 +1,4 @@
+import { Theme } from "@artsy/palette"
 import { mount } from "enzyme"
 import React from "react"
 import { ArtworkDetails } from "../ArtworkDetails"
@@ -5,13 +6,20 @@ import { ArtworkDetails } from "../ArtworkDetails"
 jest.unmock("react-relay")
 
 describe("Artwork Details", () => {
-  it("shows 3 or less fields inline", () => {
+  const mountArtworkDetails = (artwork: any) =>
+    mount(
+      <Theme>
+        <ArtworkDetails artwork={artwork} />
+      </Theme>
+    )
+
+  it("renders the data if available", () => {
     const artworkDetailsInfo = {
       artwork: {
         " $refType": null,
         category: "Oil on canvas",
         conditionDescription: null,
-        signatureInfo: null,
+        signatureInfo: { label: "Signature", details: "Signed by artist" },
         certificateOfAuthenticity: { label: "Certificate of Authenticity", details: "Not included" },
         framed: { label: "Framed", details: "Included" },
         series: null,
@@ -21,79 +29,12 @@ describe("Artwork Details", () => {
       },
     }
 
-    const component = mount(<ArtworkDetails artwork={artworkDetailsInfo.artwork} />)
+    const component = mountArtworkDetails(artworkDetailsInfo.artwork)
     expect(component.text()).toContain("Artwork details")
-    expect(component.text()).toContain("MediumOil")
-    expect(component.text()).toContain("Certificate of AuthenticityNot included")
-    expect(component.text()).toContain("FrameIncluded")
-  })
-
-  it("truncated fields when there are more than 3", () => {
-    const artworkDetailsInfo = {
-      artwork: {
-        " $refType": null,
-        category: "Oil on canvas",
-        conditionDescription: { label: "Condition details", details: "Excellent" },
-        signatureInfo: null,
-        certificateOfAuthenticity: { label: "Certificate of Authenticity", details: "Not included" },
-        framed: { label: "Framed", details: "Included" },
-        series: null,
-        publisher: null,
-        manufacturer: null,
-        image_rights: "Scala / Art Resource, NY / Picasso, Pablo (1881-1973) © ARS, NY",
-      },
-    }
-
-    const component = mount(<ArtworkDetails artwork={artworkDetailsInfo.artwork} />)
-    expect(component.text()).toContain("Artwork details")
-    expect(component.text()).toContain("MediumOil")
-    expect(component.text()).toContain("ConditionExcellent")
-    expect(component.text()).toContain("Certificate of AuthenticityNot included")
-    expect(component.text()).not.toContain("FrameIncluded")
-    expect(component.text()).not.toContain("Image Rights")
-    expect(component.text()).toContain("Show more artwork details")
-  })
-
-  it("shows top 3 fields if >3 and show more button to reveal the rest", () => {
-    const artworkDetailsInfo = {
-      artwork: {
-        " $refType": null,
-        category: "Oil on canvas",
-        conditionDescription: { label: "Condition details", details: "Excellent" },
-        signatureInfo: { label: "Signature", details: "Signed by artist" },
-        certificateOfAuthenticity: { label: "Certificate of Authenticity", details: "Not included" },
-        framed: { label: "Framed", details: "Included" },
-        series: null,
-        publisher: "steve",
-        manufacturer: null,
-        image_rights: "Scala / Art Resource, NY / Picasso, Pablo (1881-1973) © ARS, NY",
-      },
-    }
-
-    const component = mount(<ArtworkDetails artwork={artworkDetailsInfo.artwork} />)
-    expect(component.text()).toContain("Artwork details")
-    expect(component.text()).toContain("MediumOil")
-    expect(component.text()).toContain("ConditionExcellent")
     expect(component.text()).toContain("SignatureSigned by artist")
-    expect(component.text()).not.toContain("Certificate of AuthenticityNot included")
-    expect(component.text()).not.toContain("FrameIncluded")
-
-    expect(
-      component
-        .find("Sans")
-        .last()
-        .text()
-    ).toEqual("Show more artwork details")
-
-    component
-      .findWhere(c => c.props().onPress !== undefined)
-      .last()
-      .props()
-      .onPress()
-
+    expect(component.text()).toContain("MediumOil")
     expect(component.text()).toContain("Certificate of AuthenticityNot included")
     expect(component.text()).toContain("FrameIncluded")
-    expect(component.text()).not.toContain("Show more artwork details")
   })
 
   it("hides certificate of authenticity, framed, and signature fields if null", () => {
@@ -112,36 +53,9 @@ describe("Artwork Details", () => {
       },
     }
 
-    const component = mount(<ArtworkDetails artwork={artworkDetailsInfo.artwork} />)
+    const component = mountArtworkDetails(artworkDetailsInfo.artwork)
     expect(component.text()).not.toContain("Certificate of Authenticity")
     expect(component.text()).not.toContain("Frame")
     expect(component.text()).not.toContain("Signature")
-  })
-
-  it("shows certificate of authenticity, framed, and signature fields if data is present", () => {
-    const artworkDetailsInfo = {
-      artwork: {
-        " $refType": null,
-        category: "Oil on canvas",
-        conditionDescription: null,
-        signatureInfo: { label: "Signature", details: "Signed by artist" },
-        certificateOfAuthenticity: { label: "Certificate of Authenticity", details: "Included" },
-        framed: { label: "Framed", details: "Not included" },
-        series: null,
-        publisher: null,
-        manufacturer: null,
-        image_rights: "Scala / Art Resource, NY / Picasso, Pablo (1881-1973) © ARS, NY",
-      },
-    }
-
-    const component = mount(<ArtworkDetails artwork={artworkDetailsInfo.artwork} />)
-    component
-      .findWhere(c => c.props().onPress !== undefined)
-      .last()
-      .props()
-      .onPress()
-    expect(component.text()).toContain("SignatureSigned by artist")
-    expect(component.text()).toContain("Certificate of AuthenticityIncluded")
-    expect(component.text()).toContain("FrameNot included")
   })
 })


### PR DESCRIPTION
| Before  | After  |
|---|---|
| ![Screen Shot 2019-10-30 at 10 48 13](https://user-images.githubusercontent.com/498212/67871526-dd23d780-fb06-11e9-8412-cdbbe0d8c9e4.png) | ![Screen Shot 2019-10-30 at 10 47 57](https://user-images.githubusercontent.com/498212/67871515-d9905080-fb06-11e9-8b21-95ca1df9370d.png) |