### PR TITLE
[ME-37] Fixes iOS Share Sheet invocation

### DIFF
--- a/src/lib/Scenes/Artwork/Components/ArtworkActions.tsx
+++ b/src/lib/Scenes/Artwork/Components/ArtworkActions.tsx
@@ -30,7 +30,7 @@ interface ArtworkActionsProps {
 export const shareContent = (title, href, artists: ArtworkActions_artwork["artists"]) => {
   let computedTitle: string | null
   if (artists && artists.length) {
-    const names = take(artists, 3).map(arist => arist.name)
+    const names = take(artists, 3).map(artist => artist.name)
     computedTitle = `${title} by ${names.join(", ")} on Artsy`
   } else if (title) {
     computedTitle = `${title} on Artsy`

--- a/src/lib/Scenes/Artwork/Components/ArtworkActions.tsx
+++ b/src/lib/Scenes/Artwork/Components/ArtworkActions.tsx
@@ -13,6 +13,7 @@ import {
 import { ArtworkActions_artwork } from "__generated__/ArtworkActions_artwork.graphql"
 import { ArtworkActionsSaveMutation } from "__generated__/ArtworkActionsSaveMutation.graphql"
 import { Schema, track } from "lib/utils/track"
+import { take } from "lodash"
 import React from "react"
 import { NativeModules, Share, TouchableWithoutFeedback, View } from "react-native"
 import { commitMutation, createFragmentContainer, graphql, RelayProp } from "react-relay"
@@ -26,22 +27,19 @@ interface ArtworkActionsProps {
   relay?: RelayProp
 }
 
-export const shareMessage = (title, href, artists) => {
-  let message
+export const shareContent = (title, href, artists: ArtworkActions_artwork["artists"]) => {
+  let computedTitle: string | null
   if (artists && artists.length) {
-    const names = []
-    artists.forEach((artist, i) => {
-      if (i < 3) {
-        names.push(artist.name)
-      }
-    })
-    message = `${title} by ${names.join(", ")} on Artsy https://artsy.net${href}`
+    const names = take(artists, 3).map(arist => arist.name)
+    computedTitle = `${title} by ${names.join(", ")} on Artsy`
   } else if (title) {
-    message = `${title} on Artsy https://artsy.net${href}`
-  } else {
-    message = `https://artsy.net${href}`
+    computedTitle = `${title} on Artsy`
   }
-  return message
+  return {
+    title: computedTitle,
+    message: computedTitle,
+    url: `https://artsy.net${href}`,
+  }
 }
 
 @track()
@@ -79,9 +77,7 @@ export class ArtworkActions extends React.Component<ArtworkActionsProps> {
   async handleArtworkShare() {
     const { title, href, artists } = this.props.artwork
     try {
-      await Share.share({
-        message: shareMessage(title, href, artists),
-      })
+      await Share.share(shareContent(title, href, artists))
     } catch (error) {
       console.error("ArtworkActions.tsx", error)
     }

--- a/src/lib/Scenes/Artwork/Components/__tests__/ArtworkActions-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/__tests__/ArtworkActions-tests.tsx
@@ -6,35 +6,51 @@ import { renderRelayTree } from "lib/tests/renderRelayTree"
 import React from "react"
 import { NativeModules, TouchableWithoutFeedback } from "react-native"
 import { graphql } from "react-relay"
-import { ArtworkActions, ArtworkActionsFragmentContainer, shareMessage } from "../ArtworkActions"
+import { ArtworkActions, ArtworkActionsFragmentContainer, shareContent } from "../ArtworkActions"
 
 jest.unmock("react-relay")
 
 describe("ArtworkActions", () => {
   describe("share button message", () => {
     it("displays only 3 artists when there are more than 3 artist", async () => {
-      const message = shareMessage("Title 1", "/artwork/title-1", [
+      const content = shareContent("Title 1", "/artwork/title-1", [
         { name: "Artist 1" },
         { name: "Artist 2" },
         { name: "Artist 3" },
         { name: "Artist 4" },
       ])
-      expect(message).toEqual("Title 1 by Artist 1, Artist 2, Artist 3 on Artsy https://artsy.net/artwork/title-1")
+      expect(content).toMatchObject({
+        title: "Title 1 by Artist 1, Artist 2, Artist 3 on Artsy",
+        url: "https://artsy.net/artwork/title-1",
+        message: "Title 1 by Artist 1, Artist 2, Artist 3 on Artsy",
+      })
     })
 
     it("displays 1 artists", async () => {
-      const message = shareMessage("Title 1", "/artwork/title-1", [{ name: "Artist 1" }])
-      expect(message).toEqual("Title 1 by Artist 1 on Artsy https://artsy.net/artwork/title-1")
+      const content = shareContent("Title 1", "/artwork/title-1", [{ name: "Artist 1" }])
+      expect(content).toMatchObject({
+        title: "Title 1 by Artist 1 on Artsy",
+        url: "https://artsy.net/artwork/title-1",
+        message: "Title 1 by Artist 1 on Artsy",
+      })
     })
 
     it("displays only the title if there's no artists", async () => {
-      const message = shareMessage("Title 1", "/artwork/title-1", null)
-      expect(message).toEqual("Title 1 on Artsy https://artsy.net/artwork/title-1")
+      const content = shareContent("Title 1", "/artwork/title-1", null)
+      expect(content).toMatchObject({
+        title: "Title 1 on Artsy",
+        url: "https://artsy.net/artwork/title-1",
+        message: "Title 1 on Artsy",
+      })
     })
 
     it("displays only the URL if no artists or title", async () => {
-      const message = shareMessage(null, "/artwork/title-1", null)
-      expect(message).toEqual("https://artsy.net/artwork/title-1")
+      const content = shareContent(null, "/artwork/title-1", null)
+      expect(content).toMatchObject({
+        url: "https://artsy.net/artwork/title-1",
+      })
+      expect(content.message).not.toBeDefined()
+      expect(content.title).not.toBeDefined()
     })
   })
 


### PR DESCRIPTION
Couldn't help myself, my curiosity got the better of me.

This bug runs deeper than Airdrop, but that's where we saw it first. Users sharing artworks to other iOS or macOS devices were sending a _text file_, which is *not* QWoA at all. So what was going on?

Our previous work on sharing had us doing a lot of semantic construction before passing the content on to iOS to actually share. This is an anti-pattern; the iOS share API is designed to be given a URL, title, and message so that the OS can massage that data into whatever semantic representation makes sense for the share destination the user picks.

That is to say, instead of computing a string `title` with the artwork title, artist names, and URL all in that string, we should be sending an object with that data to let the OS render however it makes sense.

I've verified this works on-device.