### PR TITLE
Adjust the loader position for <PriceSummary>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### 🐛  Bug Fix
 
 - [ME-77] Marks artworks as recently viewed [#1949](https://github.com/artsy/emission/pull/1949) ([@ashfurrow](https://github.com/ashfurrow))
+- [AUCT-692] Adds margin top to position the loader at a more appropriate location in `<PriceSummary>` [#1952](https://github.com/artsy/emission/pull/1952) ([@yuki24](https://github.com/yuki2))
 
 #### Authors: 1
 

--- a/src/lib/Components/Bidding/Screens/ConfirmBid/PriceSummary.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmBid/PriceSummary.tsx
@@ -15,7 +15,7 @@ interface PriceSummaryViewProps {
 }
 
 const _PriceSummary = ({ bid, calculatedCost }: PriceSummaryViewProps) => (
-  <Box mt={4} mx={4}>
+  <Box mx={4}>
     <Serif mb={1} size="4" weight="semibold" color="black100">
       Summary
     </Serif>

--- a/src/lib/Components/Bidding/Screens/ConfirmBid/index.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmBid/index.tsx
@@ -470,7 +470,11 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
                 <Divider mb={2} />
               )}
 
-              {enablePriceTransparency && <PriceSummary saleArtworkId={id} bid={this.selectedBid()} />}
+              {enablePriceTransparency && (
+                <Box mt={4}>
+                  <PriceSummary saleArtworkId={id} bid={this.selectedBid()} />
+                </Box>
+              )}
 
               <Modal
                 visible={this.state.errorModalVisible}

--- a/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmBid-tests.tsx.snap
+++ b/src/lib/Components/Bidding/Screens/__tests__/__snapshots__/ConfirmBid-tests.tsx.snap
@@ -378,14 +378,25 @@ exports[`renders properly 1`] = `
           }
           width="100%"
         />
-        <ARSpinner
+        <View
+          mt={4}
           style={
-            Object {
-              "flex": 1,
-            }
+            Array [
+              Object {
+                "marginTop": 20,
+              },
+            ]
           }
-          testID="relay-loading"
-        />
+        >
+          <ARSpinner
+            style={
+              Object {
+                "flex": 1,
+              }
+            }
+            testID="relay-loading"
+          />
+        </View>
         <View
           style={
             Object {


### PR DESCRIPTION
(sort of) addresses https://artsyproduct.atlassian.net/browse/AUCT-692

For some reason the loader started working fine... I just needed to add a bit of `margin-top` to make it look a little nicer. I didn't know what else to do so I just added some typos to the branch name `loaoeader`.

#skip_new_tests

## Screenshot

![loader](https://user-images.githubusercontent.com/386234/68064600-0eadc600-fcf4-11e9-8601-e098889d3361.gif)

