### PR TITLE
Fixes an issue where the feature flag of '0' causes a crash

### DIFF
--- a/src/lib/Components/Bidding/Screens/ConfirmBid/index.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmBid/index.tsx
@@ -470,11 +470,11 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
                 <Divider mb={2} />
               )}
 
-              {enablePriceTransparency && (
+              {enablePriceTransparency ? (
                 <Box mt={4}>
                   <PriceSummary saleArtworkId={id} bid={this.selectedBid()} />
                 </Box>
-              )}
+              ) : null}
 
               <Modal
                 visible={this.state.errorModalVisible}


### PR DESCRIPTION
addresses https://sentry.io/organizations/artsynet/issues/1351246099/\?project\=166818\&query\=is%3Aunresolved

In the TestFlight version  6.1.0 (2019.11.22.8) I noticed that updating a feature flag to `false` on https://echo-web-production.herokuapp.com/accounts/1/features/14 would cause a crash on the Confirm Bid screen in Emission. After some digging I noticed that the boolean `false` value in Echo would end up being `0` in the iOS world (which is understandable given that some languages treat `0` as a falsy value).

Normally this wouldn't cause any problems, but because of the way the conditional is written, this was causing a crash:

```tsx
enablePriceTransparency && <Component>
```

this one-liner was returning `0` and React tried to render the `0` as a text anyway, but in React Native any text needs to be wrapped with a `<Text>` component, so RN just threw an error saying that you can't render `0` without wrapping it.

The intention of this code was to not render anything, so I just changed this line to the form of `flag ? <Component> : null` to fix it.

#skip_new_tests I tried to write a test but this isn't replicable because there is a platform difference jest and RN. React (the one that generates in-memory VDOM) doesn't care about text being present anywhere else while React Native (the one that maps VDOM to native views in iOS/Android) doesn't like them.