### PR TITLE
MX-116 - Fixes markdown bug causing Artwork crash

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -79,11 +79,6 @@ PODS:
   - Folly (2018.10.22.00):
     - boost-for-react-native
     - DoubleConversion
-    - Folly/Default (= 2018.10.22.00)
-    - glog
-  - Folly/Default (2018.10.22.00):
-    - boost-for-react-native
-    - DoubleConversion
     - glog
   - glog (0.3.5)
   - INTUAnimationEngine (1.4.2):
@@ -517,7 +512,7 @@ SPEC CHECKSUMS:
   "Artsy+UIFonts": 597c44f264aead6bdc21898b690addd90e14edbd
   Artsy-UIButtons: 3c396f0fad352a7b0332100e0ffcb0ca577e0082
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
-  DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
+  DoubleConversion: bb338842f62ab1d708ceb63ec3d999f0f3d98ecd
   Emission: 7b0b25bc89124cbed2aecfebd6726e4dbd88217b
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   Extraction: 2be993a17f8f8c4fac988ebecaed93a409181faf
@@ -525,8 +520,8 @@ SPEC CHECKSUMS:
   FBReactNativeSpec: 51477b84b1bf7ab6f9ef307c24e3dd675391be44
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
   FLKAutoLayout: 37e1e09de6411dbee5526860d9f55d9063323ea8
-  Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
-  glog: 1f3da668190260b06b429bb211bfbee5cd790c28
+  Folly: de497beb10f102453a1afa9edbf8cf8a251890de
+  glog: aefd1eb5dda2ab95ba0938556f34b98e2da3a60d
   INTUAnimationEngine: 3a7d63738cd51af573d16848a771feedea7cc9f2
   ISO8601DateFormatter: 4551b6ce4f83185425f583b0b3feb3c7b59b942c
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9

--- a/src/lib/utils/renderMarkdown.tsx
+++ b/src/lib/utils/renderMarkdown.tsx
@@ -124,7 +124,9 @@ export function defaultRules(modal: boolean = false) {
           )
           return (
             <View key={i} style={{ flexDirection: "row" }}>
-              {bullet} {listItemText}
+              <Text>
+                {bullet} {listItemText}
+              </Text>
             </View>
           )
         })


### PR DESCRIPTION
- https://artsyproduct.atlassian.net/browse/MX-116

- Wraps the returned markdown in a `Text` element. In some edge cases React-native would crash due to text not being in a text component. 