### PR TITLE
Updates emission VC to expose artworkID

### DIFF
--- a/Pod/Classes/ViewControllers/ARArtworkComponentViewController.h
+++ b/Pod/Classes/ViewControllers/ARArtworkComponentViewController.h
@@ -12,6 +12,8 @@ NS_ASSUME_NONNULL_BEGIN
                       moduleName:(NSString *)moduleName
                initialProperties:(nullable NSDictionary *)initialProperties NS_UNAVAILABLE;
 
+@property (nonatomic, readonly) NSString *artworkID;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Pod/Classes/ViewControllers/ARArtworkComponentViewController.m
+++ b/Pod/Classes/ViewControllers/ARArtworkComponentViewController.m
@@ -13,9 +13,12 @@
 - (instancetype)initWithArtworkID:(NSString *)artworkID
                          emission:(nullable AREmission *)emission;
 {
-    return [super initWithEmission:emission
+    if ((self = [super initWithEmission:emission
                         moduleName:@"Artwork"
-                 initialProperties:@{ @"artworkID": artworkID }];
+                      initialProperties:@{ @"artworkID": artworkID }])) {
+        _artworkID = artworkID;
+    }
+    return self;
 }
 
 @end


### PR DESCRIPTION
- Exposes `artworkID` for Eigen #native_no_changes