### PR TITLE
Points to our fork of tipsi-stripe #trivial

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -79,11 +79,6 @@ PODS:
   - Folly (2018.10.22.00):
     - boost-for-react-native
     - DoubleConversion
-    - Folly/Default (= 2018.10.22.00)
-    - glog
-  - Folly/Default (2018.10.22.00):
-    - boost-for-react-native
-    - DoubleConversion
     - glog
   - glog (0.3.5)
   - INTUAnimationEngine (1.4.2):
@@ -507,8 +502,8 @@ CHECKOUT OPTIONS:
     :commit: 23f1c0e8cad5a72d03176fe33535c14726e7a160
     :git: https://github.com/l2succes/Pulley.git
   tipsi-stripe:
-    :commit: efcbc49dc7cf472099d8aa8c3fb2b64441fc5ea1
-    :git: https://github.com/erikdstock/tipsi-stripe.git
+    :commit: aeb742baf1a8329ba371d9c94c7650104a112807
+    :git: https://github.com/ashfurrow/tipsi-stripe
 
 SPEC CHECKSUMS:
   ARGenericTableViewController: 61a0897ba66c35111b5d1cc3b44884282bd3c1a5
@@ -517,7 +512,7 @@ SPEC CHECKSUMS:
   "Artsy+UIFonts": 597c44f264aead6bdc21898b690addd90e14edbd
   Artsy-UIButtons: 3c396f0fad352a7b0332100e0ffcb0ca577e0082
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
-  DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
+  DoubleConversion: bb338842f62ab1d708ceb63ec3d999f0f3d98ecd
   Emission: 5c1236d844ea3107f7af6d9eae055ac472dd2b36
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   Extraction: 2be993a17f8f8c4fac988ebecaed93a409181faf
@@ -525,8 +520,8 @@ SPEC CHECKSUMS:
   FBReactNativeSpec: 51477b84b1bf7ab6f9ef307c24e3dd675391be44
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
   FLKAutoLayout: 37e1e09de6411dbee5526860d9f55d9063323ea8
-  Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
-  glog: 1f3da668190260b06b429bb211bfbee5cd790c28
+  Folly: de497beb10f102453a1afa9edbf8cf8a251890de
+  glog: aefd1eb5dda2ab95ba0938556f34b98e2da3a60d
   INTUAnimationEngine: 3a7d63738cd51af573d16848a771feedea7cc9f2
   ISO8601DateFormatter: 4551b6ce4f83185425f583b0b3feb3c7b59b942c
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
@@ -567,7 +562,7 @@ SPEC CHECKSUMS:
   SentryReactNative: 3dff4e9bd82aa581dc64ff8d2524d7007cea076b
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
   Stripe: db29ad197c74aca6fb981e4e8355cf7ebd0fca5a
-  tipsi-stripe: 2d0e33b5bb62168cd1f1777a904781725c5baf8a
+  tipsi-stripe: 8aaaa6f5e4cfea5c35be3affbb616c4e6cfafa5f
   "UIView+BooleanAnimations": a760be9a066036e55f298b7b7350a6cb14cfcd97
   Yoga: ba3d99dbee6c15ea6bbe3783d1f0cb1ffb79af0f
 

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "simple-markdown": "0.4.4",
     "styled-components": "4.2.0",
     "supercluster": "6.0.1",
-    "tipsi-stripe": "7.5.0"
+    "tipsi-stripe": "https://github.com/ashfurrow/tipsi-stripe.git#fix-infinite-loop"
   },
   "devDependencies": {
     "@artsy/auto-config": "1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15161,10 +15161,9 @@ tinycolor2@^1.4.1:
   resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.1.tgz#f4fad333447bc0b07d4dc8e9209d8f39a8ac77e8"
   integrity sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g=
 
-tipsi-stripe@7.5.0:
+"tipsi-stripe@https://github.com/ashfurrow/tipsi-stripe.git#fix-infinite-loop":
   version "7.5.0"
-  resolved "https://registry.yarnpkg.com/tipsi-stripe/-/tipsi-stripe-7.5.0.tgz#6004564463559092fe2164b00c35b707ce084e4c"
-  integrity sha512-+p/55DF3pOuI0arv0DcsZxBowcTKU5n5V7JFe4m+jubpATbx2W2aaShoP/AYWluBJw2BGcHvAow+7OhCQ3BbIw==
+  resolved "https://github.com/ashfurrow/tipsi-stripe.git#aeb742baf1a8329ba371d9c94c7650104a112807"
 
 tmp@0.1.0:
   version "0.1.0"


### PR DESCRIPTION
We need to point to point to our fork of `tipsi-stripe` because we pulled in [this fix](https://github.com/tipsi/tipsi-stripe/pull/508) for [this issue](https://github.com/tipsi/tipsi-stripe/issues/408) (it'll be included in an upcoming release of `tipsi-stripe`, so I'm fine still pointing to my own fork). Previously, we did this in Eigen, but was removed in the RN upgrade infrastructure PR:

https://github.com/artsy/eigen/pull/2962/files#diff-4a25b996826623c4a3a4910f47f10c30L101

This was causing the bug (app crashes when entering credit card number) to re-occur.

This adds it back, using that new infrastructure mechanism. I took a look at the other RN pods that we were pointing to forks on, and it appears all the changes we'd made are now included in their upstreams, so we're good to go 🙌 