### PR TITLE
Updates Danger rule for adding tests for new files

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -25,9 +25,13 @@ const filesOnly = (file: string) => fs.existsSync(file) && fs.lstatSync(file).is
 const modifiedAppFiles = modified.filter(p => includes(p, "lib/")).filter(p => filesOnly(p) && typescriptOnly(p))
 
 // Modified or Created can be treated the same a lot of the time
-const touchedFiles = modified.concat(danger.git.created_files).filter(p => filesOnly(p))
+const touchedFiles = modified.concat(danger.git.created_files).filter(filesOnly)
+const createdFiles = danger.git.created_files.filter(filesOnly)
 
 const touchedAppOnlyFiles = touchedFiles.filter(
+  p => includes(p, "src/lib/") && !includes(p, "__tests__") && typescriptOnly(p)
+)
+const createdAppOnlyFiles = createdFiles.filter(
   p => includes(p, "src/lib/") && !includes(p, "__tests__") && typescriptOnly(p)
 )
 
@@ -40,8 +44,8 @@ if (pr.base.repo.full_name !== pr.head.repo.full_name) {
   warn("This PR comes from a fork, and won't get JS generated for QA testing this PR inside the Emission Example app.")
 }
 
-// Check that every file touched has a corresponding test file
-const correspondingTestsForAppFiles = touchedAppOnlyFiles.map(f => {
+// Check that every file created has a corresponding test file
+const correspondingTestsForAppFiles = createdAppOnlyFiles.map(f => {
   const newPath = path.dirname(f)
   const name = path.basename(f).replace(".ts", "-tests.ts")
   return `${newPath}/__tests__/${name}`


### PR DESCRIPTION
I was reviewing #1999 and noticed the "skip new tests" hashtag to avoid the Danger rule. We've been doing that a lot, and it got me thinking about the purpose of the rule itself.

According to the comments in the Dangerfile, the rule is really intended only for _new files_, but _modified files_ were being included in the check too. A comment above alludes to the fact that they're most interchangeable – but in my opinion, the check for new tests is not one of those times.

I've changed the Dangerfile to only check for new files, while leaving existing variables so that future rules can use them.

After merging this PR, the new-tests rule won't triggered spuriously, so we will all need to adjust our barometers for when it makes sense to add "skip new tests" to our PR descriptions 👍 