### PR TITLE
Fix artist header when `bylineRequired` field is an empty string.

### DIFF
--- a/src/lib/Components/Artist/ArtistHeader.tsx
+++ b/src/lib/Components/Artist/ArtistHeader.tsx
@@ -42,16 +42,15 @@ class Header extends React.Component<Props, State> {
           {artist.name}
         </Serif>
         <Spacer mb={0.5} />
-        {(!!count || bylineRequired) && (
+        {Boolean(count || bylineRequired) && (
           <>
             <TextWrapper style={{ textAlign: "center" }}>
               {bylineRequired && <Sans size="2">{this.descriptiveString()}</Sans>}
-              {!!count &&
-                bylineRequired && (
-                  <Sans size="2">
-                    {"  "}•{"  "}
-                  </Sans>
-                )}
+              {!!count && bylineRequired && (
+                <Sans size="2">
+                  {"  "}•{"  "}
+                </Sans>
+              )}
               {!!count && (
                 <>
                   <Sans size="2" weight="medium">


### PR DESCRIPTION
https://artsy.slack.com/archives/CN8S32FJR/p1576238196078900