### PR TITLE
Removes bundler installation from deploy job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,10 +121,6 @@ jobs:
           fingerprints:
             - "23:11:82:24:bb:cb:a8:1e:7a:eb:b1:f3:d6:e1:55:32"
 
-      - run:
-          name: Install Bundler 2.0.2
-          command: gem update --system && gem install bundler -v 2.0.2
-
       - restore_cache:
           keys:
             - v3-gems-{{ checksum "Example/Gemfile.lock" }}


### PR DESCRIPTION
Matches the change made here: https://github.com/artsy/emission/commit/5187b967414872b82fd525c1a51503172c967d1e

I think this was caused when we upgraded Circle CI machines a few weeks ago (though I'm not sure why it only started failing today). The issue was we were installing a specific version of Bundler to get around [a bug](https://bundler.io/blog/2019/01/04/an-update-on-the-bundler-2-release.html) with Bundler. Since we're on a new enough version by default on the CI machines, I took out the explicit installation step (which was failing while waiting for user input to confirm replacing the already-installed version).