### PR TITLE
[MX-70] - Guard against S3 upload crash

### DIFF
--- a/src/lib/Components/Consignments/Screens/Overview.tsx
+++ b/src/lib/Components/Consignments/Screens/Overview.tsx
@@ -124,7 +124,7 @@ export default class Overview extends React.Component<Props, State> {
   }
 
   showUploadFailureAlert(error: Error) {
-    Alert.alert("Sorry, we couldn't process the request.", "Please try again or contact orders@artsy.net for help.", [
+    Alert.alert("Sorry, we couldn't upload your image(s).", "Please try again or contact support@artsy.net for help.", [
       {
         text: "Cancel",
         style: "cancel",
@@ -206,6 +206,7 @@ export default class Overview extends React.Component<Props, State> {
         photo.uploading = false
         this.setState({ photos: this.state.photos }, this.uploadPhotosIfNeeded)
       } catch (e) {
+        // Reset photos to enable upload retry, propogate exception upward
         photo.uploaded = false
         photo.uploading = false
         throw e

--- a/src/lib/Components/Consignments/Screens/Overview.tsx
+++ b/src/lib/Components/Consignments/Screens/Overview.tsx
@@ -124,7 +124,7 @@ export default class Overview extends React.Component<Props, State> {
   }
 
   showUploadFailureAlert(error: Error) {
-    Alert.alert("Sorry, we couldn't upload your image(s).", "Please try again or contact consign@artsy.net for help.", [
+    Alert.alert("Sorry, we couldn't upload your images.", "Please try again or contact consign@artsy.net for help.", [
       {
         text: "Cancel",
         style: "cancel",

--- a/src/lib/Components/Consignments/Screens/Overview.tsx
+++ b/src/lib/Components/Consignments/Screens/Overview.tsx
@@ -1,5 +1,6 @@
 import { Schema, screenTrack, Track, track as _track } from "lib/utils/track"
 import React from "react"
+import { Alert } from "react-native"
 
 import { AsyncStorage, Dimensions, Route, ScrollView, View, ViewProperties } from "react-native"
 import NavigatorIOS from "react-native-navigator-ios"
@@ -108,16 +109,34 @@ export default class Overview extends React.Component<Props, State> {
     this.saveStateToLocalStorage()
 
     if (this.state.submissionID) {
-      // This is async, but we don't need the synchronous behavior from await.
-      this.uploadPhotosIfNeeded()
-
-      updateConsignmentSubmission(this.state)
+      try {
+        await this.uploadPhotosIfNeeded()
+        updateConsignmentSubmission(this.state)
+      } catch (error) {
+        this.showUploadFailureAlert(error)
+      }
     } else if (this.state.artist) {
       const submissionID = await createConsignmentSubmission(this.state)
       this.setState({ submissionID }, () => {
         this.submissionDraftCreated()
       })
     }
+  }
+
+  showUploadFailureAlert(error: Error) {
+    Alert.alert("Sorry, we couldn't process the request.", "Please try again or contact orders@artsy.net for help.", [
+      {
+        text: "Cancel",
+        style: "cancel",
+      },
+      {
+        text: "Retry",
+        onPress: () => {
+          this.updateLocalStateAndMetaphysics()
+        },
+      },
+    ])
+    console.log("src/lib/Components/Consignments/Screens/Overview.tsx", error)
   }
 
   @track((_props, state) => ({
@@ -174,18 +193,23 @@ export default class Overview extends React.Component<Props, State> {
     if (!uploading && toUpload && toUpload.length) {
       // Pull out the first in the queue and upload it
       const photo = toUpload[0]
+      try {
+        // Set this one photo to upload, so that if you go in and out
+        // quickly it doesn't upload duplicates
+        photo.uploading = true
+        this.setState({ photos: this.state.photos })
+        await uploadImageAndPassToGemini(photo.file, "private", this.state.submissionID)
 
-      // Set this one photo to upload, so that if you go in and out
-      // quickly it doesn't upload duplicates
-      photo.uploading = true
-      this.setState({ photos: this.state.photos })
-      await uploadImageAndPassToGemini(photo.file, "private", this.state.submissionID)
-
-      // Mutate state 'unexpectedly', then send it back through "setState" to trigger the next
-      // in the queue
-      photo.uploaded = true
-      photo.uploading = false
-      this.setState({ photos: this.state.photos }, this.uploadPhotosIfNeeded)
+        // Mutate state 'unexpectedly', then send it back through "setState" to trigger the next
+        // in the queue
+        photo.uploaded = true
+        photo.uploading = false
+        this.setState({ photos: this.state.photos }, this.uploadPhotosIfNeeded)
+      } catch (e) {
+        photo.uploaded = false
+        photo.uploading = false
+        throw e
+      }
     }
   }
 

--- a/src/lib/Components/Consignments/Screens/Overview.tsx
+++ b/src/lib/Components/Consignments/Screens/Overview.tsx
@@ -124,7 +124,7 @@ export default class Overview extends React.Component<Props, State> {
   }
 
   showUploadFailureAlert(error: Error) {
-    Alert.alert("Sorry, we couldn't upload your image(s).", "Please try again or contact support@artsy.net for help.", [
+    Alert.alert("Sorry, we couldn't upload your image(s).", "Please try again or contact consign@artsy.net for help.", [
       {
         text: "Cancel",
         style: "cancel",

--- a/src/lib/Components/Consignments/Submission/geminiUploadToS3.ts
+++ b/src/lib/Components/Consignments/Submission/geminiUploadToS3.ts
@@ -15,7 +15,7 @@ declare var FormData: any
 declare var XMLHttpRequest: any
 
 export const uploadFileToS3 = (file: string, acl: string, asset: AssetCredentials) =>
-  new Promise<S3UploadResponse>(resolve => {
+  new Promise<S3UploadResponse>((resolve, reject) => {
     const formData = new FormData()
     const geminiKey = asset.policyDocument.conditions.geminiKey
     const bucket = asset.policyDocument.conditions.bucket
@@ -59,7 +59,7 @@ export const uploadFileToS3 = (file: string, acl: string, asset: AssetCredential
             .replace("%2F", "/"),
         })
       } else {
-        throw new Error("S3 upload failed")
+        reject(new Error("S3 upload failed"))
       }
     }
 


### PR DESCRIPTION
Show an error alert and allow retry rather than crash on unhandled JS Exception.
Copy in screenshot is out of date - updated copy is:
"Sorry, we couldn't upload your images."  - (Removed optional s)
"Please try again or contact consign@artsy.net for help."

The error alert looks like this:
![s3UploadErrorAlert](https://user-images.githubusercontent.com/49686530/71285416-1cb2b700-2333-11ea-83b1-6eeddb261b06.png)


