### PR TITLE
Adds full bleed to collections header

### DIFF
--- a/Pod/Classes/ViewControllers/ARCollectionComponentViewController.m
+++ b/Pod/Classes/ViewControllers/ARCollectionComponentViewController.m
@@ -18,6 +18,8 @@
                              moduleName:@"Collection"
                       initialProperties:@{ @"collectionID": collectionID }])) {
         _collectionID = collectionID;
+
+        self.fullBleed = YES;
     }
     return self;
 }


### PR DESCRIPTION
Update the full-bleed method to return `true` enabling the collection header image to extend to the top of the iOS devices' viewport rather than being cut off by the status bar.

Screenshots with various collection headers below:

<img width="404" alt="Screen Shot 2020-01-02 at 3 58 27 PM" src="https://user-images.githubusercontent.com/10385964/71674158-d15cc780-2d7a-11ea-9f07-791575e7e2f4.png">
<img width="385" alt="Screen Shot 2020-01-02 at 4 01 10 PM" src="https://user-images.githubusercontent.com/10385964/71674159-d1f55e00-2d7a-11ea-9f3e-797a69fbf6f8.png">
<img width="384" alt="Screen Shot 2020-01-02 at 4 03 16 PM" src="https://user-images.githubusercontent.com/10385964/71674160-d1f55e00-2d7a-11ea-9576-339bc9a9b6e8.png">
<img width="394" alt="Screen Shot 2020-01-02 at 4 04 49 PM" src="https://user-images.githubusercontent.com/10385964/71674163-d1f55e00-2d7a-11ea-9fed-9655f8ccb0c0.png">
