### PR TITLE
Excludes mocks from requiring their own unit tests

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -28,12 +28,14 @@ const modifiedAppFiles = modified.filter(p => includes(p, "lib/")).filter(p => f
 const touchedFiles = modified.concat(danger.git.created_files).filter(filesOnly)
 const createdFiles = danger.git.created_files.filter(filesOnly)
 
-const touchedAppOnlyFiles = touchedFiles.filter(
-  p => includes(p, "src/lib/") && !includes(p, "__tests__") && typescriptOnly(p)
-)
-const createdAppOnlyFiles = createdFiles.filter(
-  p => includes(p, "src/lib/") && !includes(p, "__tests__") && typescriptOnly(p)
-)
+const appOnlyFilter = (filename: string) =>
+  includes(filename, "src/lib/") &&
+  !includes(filename, "__tests__") &&
+  !includes(filename, "__mocks__") &&
+  typescriptOnly(filename)
+
+const touchedAppOnlyFiles = touchedFiles.filter(appOnlyFilter)
+const createdAppOnlyFiles = createdFiles.filter(appOnlyFilter)
 
 const touchedComponents = touchedFiles.filter(p => includes(p, "src/lib/components") && !includes(p, "__tests__"))
 


### PR DESCRIPTION
We're seeing a Danger failure in this PR because I added a new mock, and Danger is insisting we write a unit test _for that mock_: https://github.com/artsy/emission/pull/2027

It's expecting that `src/lib/Scenes/Settings/__mocks__/LoggedInUserInfo.tsx` has a corresponding `src/lib/Scenes/Settings/__mocks__/__tests__/LoggedInUserInfo-tests.tsx` test file. This update excludes mocks from the Danger rule.

EDIT: Forgot to say that I tested this change locally using `DANGER_GITHUB_API_TOKEN=MY_PERSONAL_ACCESS_TOKEN yarn danger pr https://github.com/artsy/emission/pull/2027` and it works 👍 