### PR TITLE
[MX-135] - Null checks for optional show.kind metadata

### DIFF
--- a/src/lib/Components/Artist/ArtistShows/Metadata.tsx
+++ b/src/lib/Components/Artist/ArtistShows/Metadata.tsx
@@ -16,10 +16,11 @@ interface Props extends ViewProperties {
 class Metadata extends React.Component<Props> {
   render() {
     const partnerName = this.props.show.partner && this.props.show.partner.name
+    const showType = this.showTypeString()
     return (
       <View style={styles.container}>
         {!!partnerName && <Text style={styles.sansSerifText}>{partnerName.toUpperCase()}</Text>}
-        {!!this.showTypeString() && <Text style={styles.sansSerifText}>{this.showTypeString()}</Text>}
+        {!!showType && <Text style={styles.sansSerifText}>{showType}</Text>}
         <SerifText style={styles.serifText}>{this.props.show.name}</SerifText>
         {this.dateAndLocationString()}
         {this.statusText()}

--- a/src/lib/Components/Artist/ArtistShows/Metadata.tsx
+++ b/src/lib/Components/Artist/ArtistShows/Metadata.tsx
@@ -19,7 +19,7 @@ class Metadata extends React.Component<Props> {
     return (
       <View style={styles.container}>
         {!!partnerName && <Text style={styles.sansSerifText}>{partnerName.toUpperCase()}</Text>}
-        <Text style={styles.sansSerifText}>{this.showTypeString()}</Text>
+        {!!this.showTypeString() && <Text style={styles.sansSerifText}>{this.showTypeString()}</Text>}
         <SerifText style={styles.serifText}>{this.props.show.name}</SerifText>
         {this.dateAndLocationString()}
         {this.statusText()}
@@ -28,8 +28,11 @@ class Metadata extends React.Component<Props> {
   }
 
   showTypeString() {
-    const message = this.props.show.kind.toUpperCase() + (this.props.show.kind === "fair" ? " BOOTH" : " SHOW")
-    return message
+    if (this.props.show.kind) {
+      const message = this.props.show.kind.toUpperCase() + (this.props.show.kind === "fair" ? " BOOTH" : " SHOW")
+      return message
+    }
+    return null
   }
 
   dateAndLocationString() {

--- a/src/lib/Components/Artist/ArtistShows/__tests__/ArtistShow-tests.tsx
+++ b/src/lib/Components/Artist/ArtistShows/__tests__/ArtistShow-tests.tsx
@@ -46,4 +46,30 @@ it("renders properly", () => {
     )
     .toJSON()
   expect(show).toMatchSnapshot()
+
+  const showPropsNullKind = {
+    href: "artsy.net/show",
+    cover_image: {
+      url: "artsy.net/image-url",
+    },
+    name: "Expansive Exhibition",
+    exhibition_period: "Jan 1 - March 1",
+    status_update: "Closing in 2 days",
+    status: "running",
+    partner: {
+      name: "Gallery",
+    },
+    location: {
+      city: "Berlin",
+    },
+  }
+
+  const showNullKind = renderer
+    .create(
+      <Theme>
+        <ArtistShow show={showPropsNullKind as any} styles={showStyles} />
+      </Theme>
+    )
+    .toJSON()
+  expect(showNullKind).toMatchSnapshot()
 })

--- a/src/lib/Components/Artist/ArtistShows/__tests__/ArtistShow-tests.tsx
+++ b/src/lib/Components/Artist/ArtistShows/__tests__/ArtistShow-tests.tsx
@@ -7,37 +7,37 @@ import ArtistShow from "../ArtistShow"
 
 import { Theme } from "@artsy/palette"
 
-it("renders properly", () => {
-  const showProps = {
-    href: "artsy.net/show",
-    cover_image: {
-      url: "artsy.net/image-url",
-    },
-    kind: "solo",
-    name: "Expansive Exhibition",
-    exhibition_period: "Jan 1 - March 1",
-    status_update: "Closing in 2 days",
-    status: "running",
-    partner: {
-      name: "Gallery",
-    },
-    location: {
-      city: "Berlin",
-    },
-  }
+const showProps = {
+  href: "artsy.net/show",
+  cover_image: {
+    url: "artsy.net/image-url",
+  },
+  kind: "solo",
+  name: "Expansive Exhibition",
+  exhibition_period: "Jan 1 - March 1",
+  status_update: "Closing in 2 days",
+  status: "running",
+  partner: {
+    name: "Gallery",
+  },
+  location: {
+    city: "Berlin",
+  },
+}
 
-  const showStyles = {
-    container: {
-      margin: 10,
-      marginBottom: 30,
-      width: 100,
-    },
-    image: {
-      width: 50,
-      height: 50,
-    },
-  }
+const showStyles = {
+  container: {
+    margin: 10,
+    marginBottom: 30,
+    width: 100,
+  },
+  image: {
+    width: 50,
+    height: 50,
+  },
+}
 
+it("renders properly with all props", () => {
   const show = renderer
     .create(
       <Theme>
@@ -46,22 +46,12 @@ it("renders properly", () => {
     )
     .toJSON()
   expect(show).toMatchSnapshot()
+})
 
+it("renders properly with null show kind", () => {
   const showPropsNullKind = {
-    href: "artsy.net/show",
-    cover_image: {
-      url: "artsy.net/image-url",
-    },
-    name: "Expansive Exhibition",
-    exhibition_period: "Jan 1 - March 1",
-    status_update: "Closing in 2 days",
-    status: "running",
-    partner: {
-      name: "Gallery",
-    },
-    location: {
-      city: "Berlin",
-    },
+    ...showProps,
+    kind: null,
   }
 
   const showNullKind = renderer

--- a/src/lib/Components/Artist/ArtistShows/__tests__/__snapshots__/ArtistShow-tests.tsx.snap
+++ b/src/lib/Components/Artist/ArtistShows/__tests__/__snapshots__/ArtistShow-tests.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders properly 1`] = `
+exports[`renders properly with all props 1`] = `
 <View
   accessible={true}
   focusable={true}
@@ -127,7 +127,7 @@ exports[`renders properly 1`] = `
 </View>
 `;
 
-exports[`renders properly 2`] = `
+exports[`renders properly with null show kind 1`] = `
 <View
   accessible={true}
   focusable={true}

--- a/src/lib/Components/Artist/ArtistShows/__tests__/__snapshots__/ArtistShow-tests.tsx.snap
+++ b/src/lib/Components/Artist/ArtistShows/__tests__/__snapshots__/ArtistShow-tests.tsx.snap
@@ -126,3 +126,117 @@ exports[`renders properly 1`] = `
   </View>
 </View>
 `;
+
+exports[`renders properly 2`] = `
+<View
+  accessible={true}
+  focusable={true}
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Object {
+      "margin": 10,
+      "marginBottom": 30,
+      "width": 100,
+    }
+  }
+>
+  <AROpaqueImageView
+    imageURL="artsy.net/image-url"
+    style={
+      Object {
+        "height": 50,
+        "width": 50,
+      }
+    }
+  />
+  <View
+    style={
+      Object {
+        "justifyContent": "flex-start",
+        "marginTop": 10,
+      }
+    }
+  >
+    <Text
+      style={
+        Object {
+          "fontFamily": "AvantGardeGothicITC",
+          "fontSize": 12,
+          "margin": 2,
+          "marginLeft": 0,
+          "textAlign": "left",
+        }
+      }
+    >
+      GALLERY
+    </Text>
+    <Text
+      numberOfLines={1}
+      style={
+        Array [
+          Object {
+            "fontSize": 17,
+          },
+          Object {
+            "margin": 2,
+            "marginLeft": 0,
+          },
+          Object {
+            "fontFamily": "AGaramondPro-Regular",
+          },
+        ]
+      }
+    >
+      Expansive Exhibition
+    </Text>
+    <Text
+      numberOfLines={1}
+      style={
+        Array [
+          Object {
+            "fontSize": 17,
+          },
+          Array [
+            Object {
+              "margin": 2,
+              "marginLeft": 0,
+            },
+            Object {
+              "color": "grey",
+            },
+          ],
+          Object {
+            "fontFamily": "AGaramondPro-Regular",
+          },
+        ]
+      }
+    >
+      Berlin, Jan 1 - March 1
+    </Text>
+    <Text
+      numberOfLines={1}
+      style={
+        Array [
+          Object {
+            "fontSize": 17,
+          },
+          Object {
+            "color": "#f7625a",
+          },
+          Object {
+            "fontFamily": "AGaramondPro-Regular",
+          },
+        ]
+      }
+    >
+      Closing in 2 days
+    </Text>
+  </View>
+</View>
+`;


### PR DESCRIPTION
Added a null check similar to partner name check to prevent crash. 
This is what component looks like with showTypeString:
<img width="400" alt="showComponentWith" src="https://user-images.githubusercontent.com/49686530/72260672-5b115e00-35e1-11ea-948e-d370f43282cd.png">

and without:
<img width="395" alt="showComponentWithout" src="https://user-images.githubusercontent.com/49686530/72260697-695f7a00-35e1-11ea-92d0-7935e376401e.png">


