### PR TITLE
Installs Node 12 on deploy build #trivial

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,6 +126,17 @@ jobs:
       BUNDLER_VERSION: 2.0.2
 
     steps:
+      - run:
+        name: Install Node 12 (Required for Yarn)
+        command: |
+          set +e
+          touch $BASH_ENV
+          curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh | bash
+          echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
+          echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
+          echo 'nvm install v12.13.1' >> $BASH_ENV
+          echo 'nvm alias default v12.13.1' >> $BASH_ENV
+
       - checkout
 
       - add_ssh_keys:


### PR DESCRIPTION
#2026 upgraded Xcode 11, which required Circle to install Node 12. I forgot to include this installation in the deploy job. Since the other PR was already reviewed, I'm marking this as #mergeongreen right away to unblock deploys.