### PR TITLE
Fixes bug causing image to fail to render in collection header

### DIFF
--- a/src/lib/Scenes/Collection/Screens/CollectionHeader.tsx
+++ b/src/lib/Scenes/Collection/Screens/CollectionHeader.tsx
@@ -24,7 +24,7 @@ export const CollectionHeader: React.SFC<CollectionHeaderProps> = props => {
   return (
     <>
       <Box mb={2}>
-        <OpaqueImageView imageURL={url} height={HEADER_IMAGE_HEIGHT} width={screenWidth} />
+        <OpaqueImageView imageURL={url} height={HEADER_IMAGE_HEIGHT} width={screenWidth} useRawURL />
       </Box>
       <Box mb={collectionDescription ? 0 : 2}>
         <Serif size="8" color={color("black100")} ml={2}>

--- a/src/lib/Scenes/Collection/__tests__/__snapshots__/Collection-tests.tsx.snap
+++ b/src/lib/Scenes/Collection/__tests__/__snapshots__/Collection-tests.tsx.snap
@@ -1232,6 +1232,7 @@ exports[`Collection renders a snapshot 1`] = `
           <AROpaqueImageView
             height={204}
             imageURL="<mock-value-for-field-\\"headerImage\\">"
+            useRawURL={true}
             width={750}
           />
         </View>


### PR DESCRIPTION
This PR fixes a bug where the collection header image URL was being reformated in Gemini both on the server and the client, thus creating an invalid URL.

[Links to FX-1742](https://artsyproduct.atlassian.net/browse/FX-1742)

<img width="360" alt="Screen Shot 2020-01-17 at 3 23 03 PM" src="https://user-images.githubusercontent.com/10385964/72643935-c5a5ff00-393d-11ea-966c-f9d583b486d5.png">
