### PR TITLE
Removes CocoaPods Specs repo setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,12 +76,10 @@ jobs:
             - v9-pods-{{ checksum "package.json" }}
 
       - run:
-          name: Install CocoaPods Specs If Necessary
-          command: yarn ci:skip-native-if-possible || { cd Example ; bundle exec pod check --ignore-dev-pods || { curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf ; } ; }
-
-      - run:
           name: Install CocoaPods If Necessary
-          command: yarn ci:skip-native-if-possible || { cd Example ; bundle exec pod check --ignore-dev-pods || bundle exec pod install ; }
+          command:
+            yarn ci:skip-native-if-possible || { cd Example ; bundle exec pod check --ignore-dev-pods || bundle exec pod
+            install ; }
 
       - save_cache:
           key: v9-pods-{{ checksum "package.json" }}
@@ -98,7 +96,12 @@ jobs:
 
       - run:
           name: Run Unit Tests
-          command: yarn ci:skip-native-if-possible || { cd Example ; set -o pipefail && xcodebuild -workspace Emission.xcworkspace -scheme "Emission Example" -configuration Debug test -sdk iphonesimulator -destination "platform=iOS Simulator,OS=12.4,name=iPhone X" GCC_PREPROCESSOR_DEFINITIONS="\$GCC_PREPROCESSOR_DEFINITIONS RUNNING_ON_CI=1" | tee /tmp/xcode_test_raw.log | xcpretty -c --test --report junit --output /tmp/test_results/xcode/results.xml ; }
+          command:
+            yarn ci:skip-native-if-possible || { cd Example ; set -o pipefail && xcodebuild -workspace
+            Emission.xcworkspace -scheme "Emission Example" -configuration Debug test -sdk iphonesimulator -destination
+            "platform=iOS Simulator,OS=12.4,name=iPhone X" GCC_PREPROCESSOR_DEFINITIONS="\$GCC_PREPROCESSOR_DEFINITIONS
+            RUNNING_ON_CI=1" | tee /tmp/xcode_test_raw.log | xcpretty -c --test --report junit --output
+            /tmp/test_results/xcode/results.xml ; }
 
       - store_test_results:
           path: /tmp/test_results/


### PR DESCRIPTION
Since #1781, we have been downloading CocoaPods specs from the CDN instead of using the Specs repo. That means that this setup step is no longer required, but is still taking up CI time.

Also, Prettier made some changes to the yaml file, so, sure!