### PR TITLE
Fixes issue with Artist tracking components #trivial

### DIFF
--- a/src/lib/Containers/Artist.tsx
+++ b/src/lib/Containers/Artist.tsx
@@ -5,6 +5,7 @@ import ArtistArtworks from "lib/Components/Artist/ArtistArtworks"
 import ArtistHeader from "lib/Components/Artist/ArtistHeader"
 import ArtistShows from "lib/Components/Artist/ArtistShows"
 import { StickyTabPage } from "lib/Components/StickyTabPage/StickyTabPage"
+import { track } from "lib/utils/track"
 import { ProvideScreenDimensions } from "lib/utils/useScreenDimensions"
 import React from "react"
 import { ViewProperties } from "react-native"
@@ -19,6 +20,7 @@ interface State {
 }
 
 // screen views are tracked in eigen
+@track()
 export class Artist extends React.Component<Props, State> {
   state = {
     tabs: [],


### PR DESCRIPTION
This is a follow-up to https://github.com/artsy/emission/pull/2058 . Without decorating the top-level component with either `@screenTrack()` (which generates tracking events itself) or `@track()` (which exposes the tracking capabilities to the component tree, but doesn't itself track events), then the component tree will fail to render. I've verified this still keeps fixes the duplicate artist screen tracks 👍 

Going to self-merge so we have a workable beta for the weekend.