### PR TITLE
reduce volley client error message noise in sentry

### DIFF
--- a/src/lib/utils/volleyClient.ts
+++ b/src/lib/utils/volleyClient.ts
@@ -85,14 +85,14 @@ class VolleyClient {
         }),
       })
         .then(e => {
-          if (e.status >= 400) {
-            throw e
+          if (!__DEV__ && e.status >= 400) {
+            Sentry.captureMessage(`Failed to post metrics to volley (status ${e.status})`)
           }
         })
-        .catch(e => {
-          console.error("Failed to post metrics to volley")
-          console.error(e)
-          Sentry.captureMessage(e.stack)
+        .catch(() => {
+          if (!__DEV__) {
+            Sentry.captureMessage("Failed to post metrics to volley")
+          }
         })
     },
     1000,


### PR DESCRIPTION
Was going through sentry and noticed a lot of noise from these volley client errors. i don't know why volley is failing so often, but the noise is due to the stack trace being included in the error message rather than as metadata. Sentry identifies errors by the message so different messages means different errors. This PR should group them by http status.