### PR TITLE
Add missing event type for Collections' view-more-artists interaction

### DIFF
--- a/src/lib/Scenes/Collection/Components/FeaturedArtists.tsx
+++ b/src/lib/Scenes/Collection/Components/FeaturedArtists.tsx
@@ -104,6 +104,7 @@ export class FeaturedArtists extends React.Component<FeaturedArtistsProps, Featu
                 onPress={() => {
                   this.setState({ showMore: true })
                   tracking.trackEvent({
+                    action_type: Schema.ActionTypes.Tap,
                     action_name: Schema.ActionNames.ViewMore,
                     context_screen: Schema.PageNames.Collection,
                     context_module: Schema.ContextModules.FeaturedArtists,

--- a/src/lib/Scenes/Collection/Components/__tests__/FeaturedArtists-tests.tsx
+++ b/src/lib/Scenes/Collection/Components/__tests__/FeaturedArtists-tests.tsx
@@ -184,6 +184,7 @@ describe("FeaturedArtists", () => {
       viewMore.simulate("click")
 
       expect(Events.postEvent).toHaveBeenCalledWith({
+        action_type: "tap",
         action_name: "viewMore",
         context_module: "FeaturedArtists",
         context_screen: "Collection",


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-1729

QA fix: adds a missing bit of the tracking payload, as noted in the ticket discussion.