### PR TITLE
[WIP] Adds toggling filter button for iOS Collections

### DIFF
--- a/src/lib/Scenes/Collection/__tests__/__snapshots__/Collection-tests.tsx.snap
+++ b/src/lib/Scenes/Collection/__tests__/__snapshots__/Collection-tests.tsx.snap
@@ -3,9 +3,9 @@
 exports[`Collection renders a snapshot 1`] = `
 <View
   style={
-    Array [
-      Object {},
-    ]
+    Object {
+      "flex": 1,
+    }
   }
 >
   <RCTScrollView
@@ -1197,12 +1197,27 @@ exports[`Collection renders a snapshot 1`] = `
     onScroll={[Function]}
     onScrollBeginDrag={[Function]}
     onScrollEndDrag={[Function]}
+    onViewableItemsChanged={[Function]}
     removeClippedSubviews={false}
     renderItem={[Function]}
     scrollEventThrottle={50}
     stickyHeaderIndices={Array []}
     updateCellsBatchingPeriod={50}
-    viewabilityConfigCallbackPairs={Array []}
+    viewabilityConfig={
+      Object {
+        "viewAreaCoveragePercentThreshold": 5,
+      }
+    }
+    viewabilityConfigCallbackPairs={
+      Array [
+        Object {
+          "onViewableItemsChanged": [Function],
+          "viewabilityConfig": Object {
+            "viewAreaCoveragePercentThreshold": 5,
+          },
+        },
+      ]
+    }
     windowSize={21}
   >
     <View>


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-1765

Adds an unstyled filter button for opening filter artworks modal that only renders when collection artworks grid is within the viewport.

![Kapture 2020-01-30 at 18 23 04](https://user-images.githubusercontent.com/10385964/73499254-9eafea00-438d-11ea-82b5-e40e7c8473e7.gif)

