### PR TITLE
[MX-126] highlight diacritics in search results

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@react-native-community/cameraroll": "1.3.0",
     "@react-native-community/geolocation": "2.0.2",
     "@react-native-community/netinfo": "4.6.1",
+    "grapheme-splitter": "^1.0.4",
     "lodash": "4.17.15",
     "moment": "2.24.0",
     "moment-timezone": "0.5.25",

--- a/src/lib/Scenes/Search/SearchResult.tsx
+++ b/src/lib/Scenes/Search/SearchResult.tsx
@@ -1,4 +1,5 @@
 import { CloseIcon, Flex, Sans, Serif, Spacer } from "@artsy/palette"
+import GraphemeSplitter from "grapheme-splitter"
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { Schema } from "lib/utils/track"
@@ -72,9 +73,50 @@ export const SearchResult: React.FC<{
   )
 }
 
+function removeDiracritics(text: string) {
+  // https://stackoverflow.com/a/37511463
+  return text.normalize("NFD").replace(/[\u0300-\u036f]/g, "")
+}
+
+const splitter = new GraphemeSplitter()
+
 function applyHighlight(displayLabel: string, highlight: string | undefined) {
-  const i = highlight ? displayLabel.toLowerCase().indexOf(highlight.toLowerCase()) : -1
-  if (i === -1) {
+  if (!highlight?.trim()) {
+    return (
+      <Serif size="3" weight="regular">
+        {displayLabel}
+      </Serif>
+    )
+  }
+  // search for `highlight` in `displayLabel` but ignore diacritics in `displayLabel`
+  // so that a user can type, e.g. `Miro` and see `Miró` highlighted
+  const labelGraphemes = splitter.splitGraphemes(displayLabel)
+  const highlightGraphemes = splitter.splitGraphemes(highlight)
+  let result: [string, string, string] | null = null
+  outerLoop: for (let i = 0; i < labelGraphemes.length; i++) {
+    innerLoop: for (let j = 0; j < highlightGraphemes.length; j++) {
+      if (i + j >= labelGraphemes.length) {
+        continue outerLoop
+      }
+      const labelGrapheme = removeDiracritics(labelGraphemes[i + j]).toLowerCase()
+      const highlightGrapheme = highlightGraphemes[j].toLowerCase()
+      if (labelGrapheme === highlightGrapheme) {
+        // might be a match, continue to see for sure
+        continue innerLoop
+      } else {
+        // not a match so go on to the next grapheme in the label
+        continue outerLoop
+      }
+    }
+    // innerloop eneded naturally so there was a match
+    result = [
+      labelGraphemes.slice(0, i).join(""),
+      labelGraphemes.slice(i, i + highlightGraphemes.length).join(""),
+      labelGraphemes.slice(i + highlightGraphemes.length).join(""),
+    ]
+    break outerLoop
+  }
+  if (!result) {
     return (
       <Serif size="3" weight="regular">
         {displayLabel}
@@ -83,11 +125,11 @@ function applyHighlight(displayLabel: string, highlight: string | undefined) {
   }
   return (
     <Serif size="3" weight="regular">
-      {displayLabel.slice(0, i)}
+      {result[0]}
       <Serif size="3" weight="semibold">
-        {displayLabel.slice(i, i + highlight.length)}
+        {result[1]}
       </Serif>
-      {displayLabel.slice(i + highlight.length)}
+      {result[2]}
     </Serif>
   )
 }

--- a/src/lib/Scenes/Search/__tests__/SearchResult-tests.tsx
+++ b/src/lib/Scenes/Search/__tests__/SearchResult-tests.tsx
@@ -81,6 +81,32 @@ describe(SearchResult, () => {
     expect(extractText(tree.root.findByProps({ weight: "semibold" }))).toBe("an")
   })
 
+  it(`highlights a part of the string even when the string has diacritics but the highlight doesn't`, async () => {
+    const tree = create(
+      <TestWrapper
+        result={{
+          ...result,
+          displayLabel: "Joãn Miró",
+        }}
+        highlight="an"
+      />
+    )
+
+    expect(extractText(tree.root.findByProps({ weight: "semibold" }))).toBe("ãn")
+
+    tree.update(
+      <TestWrapper
+        result={{
+          ...result,
+          displayLabel: "Joãn Miró",
+        }}
+        highlight="Miro"
+      />
+    )
+
+    expect(extractText(tree.root.findByProps({ weight: "semibold" }))).toBe("Miró")
+  })
+
   it(`updates recent searches by default`, async () => {
     const tree = create(<TestWrapper result={result} />)
     expect(SwitchBoard.presentNavigationViewController).not.toHaveBeenCalled()

--- a/yarn.lock
+++ b/yarn.lock
@@ -7499,6 +7499,11 @@ graceful-fs@^4.1.3, graceful-fs@^4.1.9:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
   integrity sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=
 
+grapheme-splitter@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz#9cf3a665c6247479896834af35cf1dbb4400767e"
+  integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
+
 graphql-tag@^2.9.2:
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.10.1.tgz#10aa41f1cd8fae5373eaf11f1f67260a3cad5e02"


### PR DESCRIPTION
# Before

![image](https://user-images.githubusercontent.com/1242537/73675256-f8742500-46a9-11ea-9bcd-1dfbd5520aaf.png)


# After

![image](https://user-images.githubusercontent.com/1242537/73675318-15105d00-46aa-11ea-90fb-817944fce4f9.png)

https://artsyproduct.atlassian.net/browse/MX-126

~On hold while we have a RFC for this new dependency, `grapheme-splitter` #2072~