### PR TITLE
Collections Artwork Filter Container

### DIFF
--- a/Example/Emission/ARLabOptions.m
+++ b/Example/Emission/ARLabOptions.m
@@ -24,6 +24,8 @@ static NSDictionary *options = nil;
     options = @{
        @"AROptionsPriceTransparency": @"Price transparency",
        @"AROptionsLotConditionReport": @"Lot Condition Report"
+       @"AROptionsFilterCollectionsArtworks": @"Filter Collections Artworks"
+
     };
   });
 

--- a/Example/Emission/ARLabOptions.m
+++ b/Example/Emission/ARLabOptions.m
@@ -23,9 +23,8 @@ static NSDictionary *options = nil;
     //
     options = @{
        @"AROptionsPriceTransparency": @"Price transparency",
-       @"AROptionsLotConditionReport": @"Lot Condition Report"
+       @"AROptionsLotConditionReport": @"Lot Condition Report",
        @"AROptionsFilterCollectionsArtworks": @"Filter Collections Artworks"
-
     };
   });
 

--- a/src/lib/Components/FilterModal.tsx
+++ b/src/lib/Components/FilterModal.tsx
@@ -1,0 +1,78 @@
+import { Button, Sans } from "@artsy/palette"
+import { theme } from "lib/Components/Bidding/Elements/Theme"
+import React from "react"
+import { Modal as RNModal, TouchableWithoutFeedback, View, ViewProperties } from "react-native"
+import styled from "styled-components/native"
+
+interface ModalProps extends ViewProperties {
+  visible?: boolean
+  closeModal?: () => void
+}
+
+const ModalBackgroundView = styled.View`
+  background-color: #00000099;
+  flex: 1;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`
+
+const ModalInnerView = styled.View`
+  flex-direction: column;
+  width: 100%;
+  background-color: white;
+  padding: 20px;
+  opacity: 1;
+`
+
+export class FilterModal extends React.Component<ModalProps, any> {
+  constructor(props) {
+    super(props)
+
+    this.state = { modalVisible: props.visible || false }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.visible !== prevProps.visible) {
+      this.setState({ modalVisible: this.props.visible })
+    }
+  }
+
+  closeModal() {
+    if (this.props.closeModal) {
+      this.props.closeModal()
+    }
+    this.setState({ modalVisible: false })
+  }
+
+  render() {
+    return (
+      <View style={{ marginTop: 22 }}>
+        <RNModal animationType="fade" transparent={true} visible={this.state.modalVisible}>
+          <TouchableWithoutFeedback onPress={() => this.closeModal()}>
+            <ModalBackgroundView>
+              <TouchableWithoutFeedback onPress={null}>
+                <>
+                  <View style={{ flexGrow: 1 }} />
+                  <ModalInnerView>
+                    {this.props.children}
+                    <Button
+                      onPress={() => {
+                        this.closeModal()
+                      }}
+                      block
+                      width={100}
+                      variant="secondaryOutline"
+                    >
+                      Ok
+                    </Button>
+                  </ModalInnerView>
+                </>
+              </TouchableWithoutFeedback>
+            </ModalBackgroundView>
+          </TouchableWithoutFeedback>
+        </RNModal>
+      </View>
+    )
+  }
+}

--- a/src/lib/Components/FilterModal.tsx
+++ b/src/lib/Components/FilterModal.tsx
@@ -1,7 +1,6 @@
-import { Button, Sans } from "@artsy/palette"
-import { theme } from "lib/Components/Bidding/Elements/Theme"
+import { Button } from "@artsy/palette"
 import React from "react"
-import { Modal as RNModal, TouchableWithoutFeedback, View, ViewProperties } from "react-native"
+import { LayoutAnimation, Modal as RNModal, TouchableWithoutFeedback, View, ViewProperties } from "react-native"
 import styled from "styled-components/native"
 
 interface ModalProps extends ViewProperties {
@@ -9,70 +8,87 @@ interface ModalProps extends ViewProperties {
   closeModal?: () => void
 }
 
+interface State {
+  isComponentMounted: boolean
+}
+
 const ModalBackgroundView = styled.View`
   background-color: #00000099;
   flex: 1;
   flex-direction: column;
-  justify-content: center;
-  align-items: center;
 `
 
-const ModalInnerView = styled.View`
+const ModalInnerView = styled.View<{ visible: boolean }>`
   flex-direction: column;
   width: 100%;
   background-color: white;
-  padding: 20px;
-  opacity: 1;
+  height: ${({ visible }) => (visible ? "auto" : "0")};
+  padding: ${({ visible }) => (visible ? "20px" : "0")};
+  border-top-left-radius: 10px;
+  border-top-right-radius: 10px;
 `
 
-export class FilterModal extends React.Component<ModalProps, any> {
+export class FilterModal extends React.Component<ModalProps, State> {
   constructor(props) {
     super(props)
 
-    this.state = { modalVisible: props.visible || false }
+    this.state = { isComponentMounted: false }
   }
 
-  componentDidUpdate(prevProps) {
-    if (this.props.visible !== prevProps.visible) {
-      this.setState({ modalVisible: this.props.visible })
-    }
+  componentDidMount() {
+    setTimeout(() => {
+      LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)
+      this.setState({ isComponentMounted: true })
+    }, 100)
   }
 
   closeModal() {
     if (this.props.closeModal) {
       this.props.closeModal()
     }
-    this.setState({ modalVisible: false })
   }
 
   render() {
+    /*
+    https://app.zeplin.io/project/5aabc5e0786bbb29b6e3dc7f/screen/5dba03df09bf3f5547162ac9
+
+    Next steps:
+
+    - Add a Navigator
+      - Configure left button to be x close
+      - Configure right button for "clear all"
+    - Define a TypeScript interface to represent possible filter states (take a look at the Pick TypeScript generic)
+    - Implement the rest of the UI
+    - Add callbacks for when filter has been cleared / reset / applied
+
+    Let's start with a single filter (sort, or medium maybe) and get it working end-to-end in Collections
+    Look at Reactions' ArtworkFilter implementation, which does something similar ^
+    */
     return (
-      <View style={{ marginTop: 22 }}>
-        <RNModal animationType="fade" transparent={true} visible={this.state.modalVisible}>
-          <TouchableWithoutFeedback onPress={() => this.closeModal()}>
-            <ModalBackgroundView>
-              <TouchableWithoutFeedback onPress={null}>
-                <>
-                  <View style={{ flexGrow: 1 }} />
-                  <ModalInnerView>
-                    {this.props.children}
-                    <Button
-                      onPress={() => {
-                        this.closeModal()
-                      }}
-                      block
-                      width={100}
-                      variant="secondaryOutline"
-                    >
-                      Ok
-                    </Button>
-                  </ModalInnerView>
-                </>
-              </TouchableWithoutFeedback>
-            </ModalBackgroundView>
-          </TouchableWithoutFeedback>
-        </RNModal>
-      </View>
+      <RNModal animationType="fade" transparent={true} visible={this.props.visible}>
+        <TouchableWithoutFeedback onPress={() => this.closeModal()}>
+          <ModalBackgroundView>
+            <TouchableWithoutFeedback onPress={null}>
+              <>
+                <View style={{ flexGrow: 1 }} />
+                <ModalInnerView visible={this.state.isComponentMounted}>
+                  {this.props.children}
+                  <Button
+                    onPress={() => {
+                      this.closeModal()
+                    }}
+                    block
+                    width={100}
+                    variant="secondaryOutline"
+                  >
+                    Ok
+                  </Button>
+                </ModalInnerView>
+              </>
+            </TouchableWithoutFeedback>
+          </ModalBackgroundView>
+        </TouchableWithoutFeedback>
+      </RNModal>
     )
   }
 }

--- a/src/lib/Components/FilterModal.tsx
+++ b/src/lib/Components/FilterModal.tsx
@@ -8,6 +8,7 @@ interface ModalProps extends ViewProperties {
   closeModal?: () => void
 }
 
+// TODO:  Define a TypeScript interface to represent possible filter states (take a look at the Pick TypeScript generic)
 interface State {
   isComponentMounted: boolean
 }
@@ -49,21 +50,6 @@ export class FilterModal extends React.Component<ModalProps, State> {
   }
 
   render() {
-    /*
-    https://app.zeplin.io/project/5aabc5e0786bbb29b6e3dc7f/screen/5dba03df09bf3f5547162ac9
-
-    Next steps:
-
-    - Add a Navigator
-      - Configure left button to be x close
-      - Configure right button for "clear all"
-    - Define a TypeScript interface to represent possible filter states (take a look at the Pick TypeScript generic)
-    - Implement the rest of the UI
-    - Add callbacks for when filter has been cleared / reset / applied
-
-    Let's start with a single filter (sort, or medium maybe) and get it working end-to-end in Collections
-    Look at Reactions' ArtworkFilter implementation, which does something similar ^
-    */
     return (
       <RNModal animationType="fade" transparent={true} visible={this.props.visible}>
         <TouchableWithoutFeedback>
@@ -74,7 +60,7 @@ export class FilterModal extends React.Component<ModalProps, State> {
                 <ModalInnerView visible={this.state.isComponentMounted}>
                   <Flex flexDirection="row" justifyContent="space-between">
                     <Flex alignItems="flex-end" mt={0.5} mb={2}>
-                      <Box onTouchEnd={() => this.closeModal()}>
+                      <Box onTouchStart={() => this.closeModal()}>
                         <CloseIcon fill="black100" />
                       </Box>
                     </Flex>

--- a/src/lib/Components/FilterModal.tsx
+++ b/src/lib/Components/FilterModal.tsx
@@ -1,6 +1,6 @@
-import { Button } from "@artsy/palette"
+import { Box, Button, CloseIcon, Flex, Sans } from "@artsy/palette"
 import React from "react"
-import { LayoutAnimation, Modal as RNModal, TouchableWithoutFeedback, View, ViewProperties } from "react-native"
+import { LayoutAnimation, Modal as RNModal, TouchableWithoutFeedback, ViewProperties } from "react-native"
 import styled from "styled-components/native"
 
 interface ModalProps extends ViewProperties {
@@ -66,12 +66,23 @@ export class FilterModal extends React.Component<ModalProps, State> {
     */
     return (
       <RNModal animationType="fade" transparent={true} visible={this.props.visible}>
-        <TouchableWithoutFeedback onPress={() => this.closeModal()}>
+        <TouchableWithoutFeedback>
           <ModalBackgroundView>
             <TouchableWithoutFeedback onPress={null}>
               <>
-                <View style={{ flexGrow: 1 }} />
+                <Flex onTouchStart={() => this.closeModal()} style={{ flexGrow: 1 }} />
                 <ModalInnerView visible={this.state.isComponentMounted}>
+                  <Flex flexDirection="row" justifyContent="space-between">
+                    <Flex alignItems="flex-end" mt={0.5} mb={2}>
+                      <Box onTouchEnd={() => this.closeModal()}>
+                        <CloseIcon fill="black100" />
+                      </Box>
+                    </Flex>
+                    <Sans weight="medium" size="4">
+                      Filter
+                    </Sans>
+                    <Sans size="4">Clear all</Sans>
+                  </Flex>
                   {this.props.children}
                   <Button
                     onPress={() => {

--- a/src/lib/Components/__tests__/FilterModal-tests.tsx
+++ b/src/lib/Components/__tests__/FilterModal-tests.tsx
@@ -1,0 +1,22 @@
+import { Theme } from "@artsy/palette"
+import { FilterModal } from "lib/Components/FilterModal"
+import React from "react"
+import "react-native"
+import * as renderer from "react-test-renderer"
+
+it("renders a snapshot of the filter artworks modal", () => {
+  let props
+
+  props = {
+    visible: true,
+  }
+
+  const tree = renderer
+    .create(
+      <Theme>
+        <FilterModal {...props} />
+      </Theme>
+    )
+    .toJSON()
+  expect(tree).toMatchSnapshot()
+})

--- a/src/lib/Components/__tests__/__snapshots__/FilterModal-tests.tsx.snap
+++ b/src/lib/Components/__tests__/__snapshots__/FilterModal-tests.tsx.snap
@@ -1,0 +1,596 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders a snapshot of the filter artworks modal 1`] = `
+<Modal
+  animationType="fade"
+  hardwareAccelerated={false}
+  transparent={true}
+  visible={true}
+>
+  <View
+    accessible={true}
+    focusable={false}
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "backgroundColor": "#00000099",
+          "flexBasis": 0,
+          "flexDirection": "column",
+          "flexGrow": 1,
+          "flexShrink": 1,
+        },
+      ]
+    }
+  >
+    <View
+      onTouchStart={[Function]}
+      style={
+        Array [
+          Object {
+            "display": "flex",
+          },
+          Object {
+            "flexGrow": 1,
+          },
+        ]
+      }
+    />
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "white",
+            "borderTopLeftRadius": 10,
+            "borderTopRightRadius": 10,
+            "flexDirection": "column",
+            "height": 0,
+            "paddingBottom": 0,
+            "paddingLeft": 0,
+            "paddingRight": 0,
+            "paddingTop": 0,
+            "width": "100%",
+          },
+        ]
+      }
+      visible={false}
+    >
+      <View
+        flexDirection="row"
+        justifyContent="space-between"
+        style={
+          Array [
+            Object {
+              "display": "flex",
+              "flexDirection": "row",
+              "justifyContent": "space-between",
+            },
+          ]
+        }
+      >
+        <View
+          alignItems="flex-end"
+          mb={2}
+          mt={0.5}
+          style={
+            Array [
+              Object {
+                "alignItems": "flex-end",
+                "display": "flex",
+                "marginBottom": 20,
+                "marginTop": 5,
+              },
+            ]
+          }
+        >
+          <View
+            onTouchStart={[Function]}
+            style={
+              Array [
+                Object {},
+              ]
+            }
+          >
+            <RNSVGSvgView
+              align="xMidYMid"
+              bbHeight="18px"
+              bbWidth="18px"
+              className="Iconios__Icon-z4d8jr-0 cjvLsm"
+              fill="black100"
+              focusable={false}
+              height="18px"
+              meetOrSlice={0}
+              minX={0}
+              minY={0}
+              style={
+                Array [
+                  Object {
+                    "backgroundColor": "transparent",
+                    "borderWidth": 0,
+                  },
+                  undefined,
+                  Object {
+                    "opacity": 1,
+                  },
+                  Object {
+                    "flex": 0,
+                    "height": 18,
+                    "width": 18,
+                  },
+                ]
+              }
+              vbHeight={18}
+              vbWidth={18}
+              width="18px"
+            >
+              <RNSVGGroup
+                fill={
+                  Array [
+                    0,
+                    4278190080,
+                  ]
+                }
+                fillOpacity={1}
+                fillRule={1}
+                font={Object {}}
+                matrix={
+                  Array [
+                    1,
+                    0,
+                    0,
+                    1,
+                    0,
+                    0,
+                  ]
+                }
+                opacity={1}
+                originX={0}
+                originY={0}
+                propList={
+                  Array [
+                    "fill",
+                  ]
+                }
+                rotation={0}
+                scaleX={1}
+                scaleY={1}
+                skewX={0}
+                skewY={0}
+                stroke={null}
+                strokeDasharray={null}
+                strokeDashoffset={null}
+                strokeLinecap={0}
+                strokeLinejoin={0}
+                strokeMiterlimit={4}
+                strokeOpacity={1}
+                strokeWidth={1}
+                vectorEffect={0}
+                x={0}
+                y={0}
+              >
+                <RNSVGPath
+                  d="M9.88 9l4.56 4.56-.88.88L9 9.88l-4.56 4.56-.88-.88L8.12 9 3.56 4.44l.88-.88L9 8.12l4.56-4.56.88.88z"
+                  fill={
+                    Array [
+                      0,
+                      4278190080,
+                    ]
+                  }
+                  fillOpacity={1}
+                  fillRule={0}
+                  matrix={
+                    Array [
+                      1,
+                      0,
+                      0,
+                      1,
+                      0,
+                      0,
+                    ]
+                  }
+                  opacity={1}
+                  originX={0}
+                  originY={0}
+                  propList={
+                    Array [
+                      "fill",
+                      "fillRule",
+                    ]
+                  }
+                  rotation={0}
+                  scaleX={1}
+                  scaleY={1}
+                  skewX={0}
+                  skewY={0}
+                  stroke={null}
+                  strokeDasharray={null}
+                  strokeDashoffset={null}
+                  strokeLinecap={0}
+                  strokeLinejoin={0}
+                  strokeMiterlimit={4}
+                  strokeOpacity={1}
+                  strokeWidth={1}
+                  vectorEffect={0}
+                  x={0}
+                  y={0}
+                />
+              </RNSVGGroup>
+            </RNSVGSvgView>
+          </View>
+        </View>
+        <Text
+          fontFamily="Unica77LL-Medium"
+          fontSize="16px"
+          lineHeight="26px"
+          style={
+            Array [
+              Object {
+                "fontFamily": "Unica77LL-Medium",
+                "fontSize": 16,
+                "lineHeight": 26,
+              },
+              Object {},
+            ]
+          }
+        >
+          Filter
+        </Text>
+        <Text
+          fontFamily="Unica77LL-Regular"
+          fontSize="16px"
+          lineHeight="26px"
+          style={
+            Array [
+              Object {
+                "fontFamily": "Unica77LL-Regular",
+                "fontSize": 16,
+                "lineHeight": 26,
+              },
+              Object {},
+            ]
+          }
+        >
+          Clear all
+        </Text>
+      </View>
+      <View
+        accessible={true}
+        flexDirection="row"
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Array [
+            Object {
+              "display": "flex",
+              "flexDirection": "row",
+            },
+          ]
+        }
+      >
+        <View
+          block={true}
+          onPress={[Function]}
+          px={2}
+          size="medium"
+          style={
+            Array [
+              Object {
+                "alignItems": "center",
+                "borderRadius": 3,
+                "borderWidth": 1,
+                "justifyContent": "center",
+                "paddingLeft": 20,
+                "paddingRight": 20,
+                "position": "relative",
+                "width": "100%",
+              },
+              Object {
+                "backgroundColor": "rgba(255, 255, 255, 1)",
+                "borderColor": "rgba(229, 229, 229, 1)",
+                "color": "rgba(0, 0, 0, 1)",
+                "height": 41,
+                "opacity": 1,
+              },
+            ]
+          }
+          theme={
+            Object {
+              "borders": Array [
+                "1px solid",
+                "2px solid",
+              ],
+              "breakpoints": Array [
+                768,
+                900,
+                1024,
+                1192,
+              ],
+              "colors": Object {
+                "black10": "#E5E5E5",
+                "black100": "#000",
+                "black30": "#C2C2C2",
+                "black5": "#F8F8F8",
+                "black60": "#666",
+                "black80": "#333",
+                "green100": "#0EDA83",
+                "purple100": "#6E1EFF",
+                "purple30": "#D3BBFF",
+                "purple5": "#F8F3FF",
+                "red100": "#F7625A",
+                "white100": "#FFF",
+                "yellow10": "#FDF7E8",
+                "yellow100": "#F1AF1B",
+                "yellow30": "#FAE7BA",
+              },
+              "fontFamily": Object {
+                "display": Object {
+                  "regular": "AvantGardeGothicITC",
+                },
+                "sans": Object {
+                  "italic": "Unica77LL-Italic",
+                  "medium": "Unica77LL-Medium",
+                  "mediumItalic": "Unica77LL-MediumItalic",
+                  "regular": "Unica77LL-Regular",
+                },
+                "serif": Object {
+                  "italic": "ReactNativeAGaramondPro-Italic",
+                  "regular": "ReactNativeAGaramondPro-Regular",
+                  "semibold": "ReactNativeAGaramondPro-Semibold",
+                },
+              },
+              "grid": Object {
+                "breakpoints": Object {
+                  "lg": 1024,
+                  "md": 900,
+                  "sm": 768,
+                  "xl": 1192,
+                  "xs": 767,
+                },
+                "col": Object {
+                  "padding": 0,
+                },
+                "container": Object {
+                  "padding": 0,
+                },
+                "row": Object {
+                  "padding": 0,
+                },
+              },
+              "mediaQueries": Object {
+                "hover": "not all and (pointer: coarse), not all and (-moz-touch-enabled: 1)",
+                "lg": "(min-width: 1024px) and (max-width: 1191px)",
+                "md": "(min-width: 900px) and (max-width: 1023px)",
+                "sm": "(min-width: 768px) and (max-width: 899px)",
+                "xl": "(min-width: 1192px)",
+                "xs": "(max-width: 767px)",
+              },
+              "space": Object {
+                "0.3": 3,
+                "0.5": 5,
+                "1": 10,
+                "12": 120,
+                "18": 180,
+                "2": 20,
+                "3": 30,
+                "4": 40,
+                "6": 60,
+                "9": 90,
+              },
+              "typeSizes": Object {
+                "display": Object {
+                  "2": Object {
+                    "fontSize": 10,
+                    "lineHeight": 12,
+                  },
+                  "3t": Object {
+                    "fontSize": 12,
+                    "lineHeight": 16,
+                  },
+                  "4t": Object {
+                    "fontSize": 14,
+                    "lineHeight": 18,
+                  },
+                  "5t": Object {
+                    "fontSize": 16,
+                    "lineHeight": 20,
+                  },
+                  "6": Object {
+                    "fontSize": 18,
+                    "lineHeight": 22,
+                  },
+                  "8": Object {
+                    "fontSize": 22,
+                    "lineHeight": 24,
+                  },
+                },
+                "sans": Object {
+                  "0": Object {
+                    "fontSize": 8,
+                    "lineHeight": 8,
+                  },
+                  "1": Object {
+                    "fontSize": 10,
+                    "lineHeight": 14,
+                  },
+                  "10": Object {
+                    "fontSize": 42,
+                    "lineHeight": 50,
+                  },
+                  "12": Object {
+                    "fontSize": 60,
+                    "lineHeight": 66,
+                  },
+                  "14": Object {
+                    "fontSize": 80,
+                    "lineHeight": 84,
+                  },
+                  "16": Object {
+                    "fontSize": 100,
+                    "lineHeight": 104,
+                  },
+                  "2": Object {
+                    "fontSize": 12,
+                    "lineHeight": 16,
+                  },
+                  "3": Object {
+                    "fontSize": 14,
+                    "lineHeight": 24,
+                  },
+                  "3t": Object {
+                    "fontSize": 14,
+                    "lineHeight": 20,
+                  },
+                  "4": Object {
+                    "fontSize": 16,
+                    "lineHeight": 26,
+                  },
+                  "4t": Object {
+                    "fontSize": 16,
+                    "lineHeight": 22,
+                  },
+                  "5": Object {
+                    "fontSize": 18,
+                    "lineHeight": 30,
+                  },
+                  "5t": Object {
+                    "fontSize": 18,
+                    "lineHeight": 26,
+                  },
+                  "6": Object {
+                    "fontSize": 22,
+                    "lineHeight": 30,
+                  },
+                  "8": Object {
+                    "fontSize": 28,
+                    "lineHeight": 36,
+                  },
+                },
+                "serif": Object {
+                  "1": Object {
+                    "fontSize": 12,
+                    "lineHeight": 16,
+                  },
+                  "10": Object {
+                    "fontSize": 44,
+                    "lineHeight": 50,
+                  },
+                  "12": Object {
+                    "fontSize": 60,
+                    "lineHeight": 70,
+                  },
+                  "2": Object {
+                    "fontSize": 14,
+                    "lineHeight": 18,
+                  },
+                  "3": Object {
+                    "fontSize": 16,
+                    "lineHeight": 24,
+                  },
+                  "3t": Object {
+                    "fontSize": 16,
+                    "lineHeight": 20,
+                  },
+                  "4": Object {
+                    "fontSize": 18,
+                    "lineHeight": 26,
+                  },
+                  "4t": Object {
+                    "fontSize": 18,
+                    "lineHeight": 22,
+                  },
+                  "5": Object {
+                    "fontSize": 22,
+                    "lineHeight": 32,
+                  },
+                  "5t": Object {
+                    "fontSize": 22,
+                    "lineHeight": 28,
+                  },
+                  "6": Object {
+                    "fontSize": 26,
+                    "lineHeight": 32,
+                  },
+                  "8": Object {
+                    "fontSize": 32,
+                    "lineHeight": 38,
+                  },
+                },
+              },
+            }
+          }
+          variant="secondaryOutline"
+          width={100}
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flexDirection": "row",
+                  "height": "100%",
+                  "justifyContent": "center",
+                  "position": "absolute",
+                  "width": "100%",
+                },
+              ]
+            }
+          >
+            <Text
+              color="#000"
+              fontFamily="Unica77LL-Medium"
+              fontSize="14px"
+              lineHeight="20px"
+              style={
+                Array [
+                  Object {
+                    "color": "#000",
+                    "fontFamily": "Unica77LL-Medium",
+                    "fontSize": 14,
+                    "lineHeight": 20,
+                  },
+                  Object {},
+                ]
+              }
+            >
+              Ok
+            </Text>
+          </View>
+          <Text
+            fontFamily="Unica77LL-Medium"
+            fontSize="14px"
+            lineHeight="20px"
+            role="presentation"
+            style={
+              Array [
+                Object {
+                  "fontFamily": "Unica77LL-Medium",
+                  "fontSize": 14,
+                  "lineHeight": 20,
+                },
+                Object {
+                  "opacity": 0,
+                },
+              ]
+            }
+          >
+            Ok
+          </Text>
+        </View>
+      </View>
+    </View>
+  </View>
+</Modal>
+`;

--- a/src/lib/Scenes/Artwork/Components/ArtworkActions.tsx
+++ b/src/lib/Scenes/Artwork/Components/ArtworkActions.tsx
@@ -12,6 +12,7 @@ import {
 } from "@artsy/palette"
 import { ArtworkActions_artwork } from "__generated__/ArtworkActions_artwork.graphql"
 import { ArtworkActionsSaveMutation } from "__generated__/ArtworkActionsSaveMutation.graphql"
+import { FilterModal } from "lib/Components/FilterModal"
 import Events from "lib/NativeModules/Events"
 import { Schema, track } from "lib/utils/track"
 import { take } from "lodash"
@@ -26,6 +27,10 @@ const ApiModule = NativeModules.ARTemporaryAPIModule
 interface ArtworkActionsProps {
   artwork: ArtworkActions_artwork
   relay?: RelayProp
+}
+
+interface State {
+  isModalVisible: boolean
 }
 
 export const shareContent = (title, href, artists: ArtworkActions_artwork["artists"]) => {
@@ -44,7 +49,11 @@ export const shareContent = (title, href, artists: ArtworkActions_artwork["artis
 }
 
 @track()
-export class ArtworkActions extends React.Component<ArtworkActionsProps> {
+export class ArtworkActions extends React.Component<ArtworkActionsProps, State> {
+  state = {
+    isModalVisible: false,
+  }
+
   @track((props: ArtworkActionsProps) => {
     return {
       action_name: props.artwork.is_saved ? Schema.ActionNames.ArtworkUnsave : Schema.ActionNames.ArtworkSave,
@@ -53,6 +62,10 @@ export class ArtworkActions extends React.Component<ArtworkActionsProps> {
     }
   })
   handleArtworkSave() {
+    console.log("Hello!")
+    this.setState({ isModalVisible: !this.state.isModalVisible })
+
+    return
     const { artwork, relay } = this.props
     commitMutation<ArtworkActionsSaveMutation>(relay.environment, {
       mutation: graphql`
@@ -109,6 +122,9 @@ export class ArtworkActions extends React.Component<ArtworkActionsProps> {
 
     return (
       <View>
+        <FilterModal visible={this.state.isModalVisible} closeModal={this.handleArtworkSave.bind(this)}>
+          <Sans size="3t">Hello, modal!</Sans>
+        </FilterModal>
         <Flex flexDirection="row">
           {isOpenSale ? (
             <TouchableWithoutFeedback onPress={() => this.handleArtworkSave()}>
@@ -130,17 +146,16 @@ export class ArtworkActions extends React.Component<ArtworkActionsProps> {
             </TouchableWithoutFeedback>
           )}
 
-          {Constants.AREnabled &&
-            is_hangable && (
-              <TouchableWithoutFeedback onPress={() => this.openViewInRoom()}>
-                <UtilButton pr={3}>
-                  <Box mr={0.5}>
-                    <EyeOpenedIcon />
-                  </Box>
-                  <Sans size="3">View in Room</Sans>
-                </UtilButton>
-              </TouchableWithoutFeedback>
-            )}
+          {Constants.AREnabled && is_hangable && (
+            <TouchableWithoutFeedback onPress={() => this.openViewInRoom()}>
+              <UtilButton pr={3}>
+                <Box mr={0.5}>
+                  <EyeOpenedIcon />
+                </Box>
+                <Sans size="3">View in Room</Sans>
+              </UtilButton>
+            </TouchableWithoutFeedback>
+          )}
           <TouchableWithoutFeedback onPress={() => this.handleArtworkShare()}>
             <UtilButton>
               <Box mr={0.5}>

--- a/src/lib/Scenes/Artwork/Components/ArtworkActions.tsx
+++ b/src/lib/Scenes/Artwork/Components/ArtworkActions.tsx
@@ -51,7 +51,7 @@ export const shareContent = (title, href, artists: ArtworkActions_artwork["artis
 @track()
 export class ArtworkActions extends React.Component<ArtworkActionsProps, State> {
   state = {
-    isModalVisible: false,
+    isModalVisible: true,
   }
 
   @track((props: ArtworkActionsProps) => {

--- a/src/lib/Scenes/Artwork/Components/ArtworkActions.tsx
+++ b/src/lib/Scenes/Artwork/Components/ArtworkActions.tsx
@@ -12,7 +12,6 @@ import {
 } from "@artsy/palette"
 import { ArtworkActions_artwork } from "__generated__/ArtworkActions_artwork.graphql"
 import { ArtworkActionsSaveMutation } from "__generated__/ArtworkActionsSaveMutation.graphql"
-import { FilterModal } from "lib/Components/FilterModal"
 import Events from "lib/NativeModules/Events"
 import { Schema, track } from "lib/utils/track"
 import { take } from "lodash"
@@ -27,10 +26,6 @@ const ApiModule = NativeModules.ARTemporaryAPIModule
 interface ArtworkActionsProps {
   artwork: ArtworkActions_artwork
   relay?: RelayProp
-}
-
-interface State {
-  isModalVisible: boolean
 }
 
 export const shareContent = (title, href, artists: ArtworkActions_artwork["artists"]) => {
@@ -49,11 +44,7 @@ export const shareContent = (title, href, artists: ArtworkActions_artwork["artis
 }
 
 @track()
-export class ArtworkActions extends React.Component<ArtworkActionsProps, State> {
-  state = {
-    isModalVisible: true,
-  }
-
+export class ArtworkActions extends React.Component<ArtworkActionsProps> {
   @track((props: ArtworkActionsProps) => {
     return {
       action_name: props.artwork.is_saved ? Schema.ActionNames.ArtworkUnsave : Schema.ActionNames.ArtworkSave,
@@ -62,10 +53,6 @@ export class ArtworkActions extends React.Component<ArtworkActionsProps, State> 
     }
   })
   handleArtworkSave() {
-    console.log("Hello!")
-    this.setState({ isModalVisible: !this.state.isModalVisible })
-
-    return
     const { artwork, relay } = this.props
     commitMutation<ArtworkActionsSaveMutation>(relay.environment, {
       mutation: graphql`
@@ -122,9 +109,6 @@ export class ArtworkActions extends React.Component<ArtworkActionsProps, State> 
 
     return (
       <View>
-        <FilterModal visible={this.state.isModalVisible} closeModal={this.handleArtworkSave.bind(this)}>
-          <Sans size="3t">Hello, modal!</Sans>
-        </FilterModal>
         <Flex flexDirection="row">
           {isOpenSale ? (
             <TouchableWithoutFeedback onPress={() => this.handleArtworkSave()}>

--- a/src/lib/Scenes/Collection/Collection.tsx
+++ b/src/lib/Scenes/Collection/Collection.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Flex, Sans, Separator, Spacer, Theme } from "@artsy/palette"
+import { Box, Button, Flex, Separator, Spacer, Theme } from "@artsy/palette"
 import { Collection_collection } from "__generated__/Collection_collection.graphql"
 import { FilterModal } from "lib/Components/FilterModal"
 import { CollectionArtworksFragmentContainer as CollectionArtworks } from "lib/Scenes/Collection/Screens/CollectionArtworks"
@@ -73,9 +73,7 @@ export class Collection extends Component<CollectionProps, CollectionState> {
             <FilterModal
               visible={this.state.isFilterArtworksModalVisible}
               closeModal={this.handleFilterArtworksModal.bind(this)}
-            >
-              <Sans size="3t">Hello, modal!</Sans>
-            </FilterModal>
+            />
           </>
         )
       default:

--- a/src/lib/Scenes/Collection/Collection.tsx
+++ b/src/lib/Scenes/Collection/Collection.tsx
@@ -7,7 +7,7 @@ import { Schema, screenTrack } from "lib/utils/track"
 import React, { Component } from "react"
 import { FlatList, NativeModules, View } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
-import styled from "styled-components"
+import styled from "styled-components/native"
 import { CollectionFeaturedArtistsContainer as CollectionFeaturedArtists } from "./Components/FeaturedArtists"
 
 interface CollectionProps {
@@ -84,9 +84,11 @@ export class Collection extends Component<CollectionProps, CollectionState> {
     ;(viewableItems || []).map(viewableItem => {
       const artworksRenderItem = viewableItem?.item?.type || ""
       const artworksRenderItemViewable = viewableItem?.isViewable || false
+
       if (artworksRenderItem === "collectionArtworks" && artworksRenderItemViewable) {
         return this.setState(_prevState => ({ isArtworkGridVisible: true }))
       }
+
       return this.setState(_prevState => ({ isArtworkGridVisible: false }))
     })
   }
@@ -147,7 +149,7 @@ export class Collection extends Component<CollectionProps, CollectionState> {
   }
 }
 
-const FilterArtworkButtonContainer = styled(Flex)`
+export const FilterArtworkButtonContainer = styled(Flex)`
   position: absolute;
   bottom: 50;
   flex: 1;
@@ -156,7 +158,7 @@ const FilterArtworkButtonContainer = styled(Flex)`
   flex-direction: row;
 `
 
-const FilterArtworkButton = styled(Button)`
+export const FilterArtworkButton = styled(Button)`
   border-radius: 100;
   width: 110px;
 `

--- a/src/lib/Scenes/Collection/Collection.tsx
+++ b/src/lib/Scenes/Collection/Collection.tsx
@@ -5,7 +5,7 @@ import { CollectionArtworksFragmentContainer as CollectionArtworks } from "lib/S
 import { CollectionHeaderContainer as CollectionHeader } from "lib/Scenes/Collection/Screens/CollectionHeader"
 import { Schema, screenTrack } from "lib/utils/track"
 import React, { Component } from "react"
-import { FlatList, View } from "react-native"
+import { FlatList, NativeModules, View } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
 import { CollectionFeaturedArtistsContainer as CollectionFeaturedArtists } from "./Components/FeaturedArtists"
@@ -117,6 +117,7 @@ export class Collection extends Component<CollectionProps, CollectionState> {
   }
   render() {
     const { isArtworkGridVisible, sections } = this.state
+    const isArtworkFilterEnabled = NativeModules.Emission?.options?.AROptionsFilterCollectionsArtworks
 
     return (
       <Theme>
@@ -133,13 +134,13 @@ export class Collection extends Component<CollectionProps, CollectionState> {
               </Box>
             )}
           />
-          {isArtworkGridVisible ? (
+          {isArtworkGridVisible && isArtworkFilterEnabled && (
             <FilterArtworkButtonContainer>
               <FilterArtworkButton variant="primaryBlack" onPress={this.handleFilterArtworksModal.bind(this)}>
                 Filter
               </FilterArtworkButton>
             </FilterArtworkButtonContainer>
-          ) : null}
+          )}
         </View>
       </Theme>
     )

--- a/src/lib/Scenes/Collection/__tests__/Collection-tests.tsx
+++ b/src/lib/Scenes/Collection/__tests__/Collection-tests.tsx
@@ -3,7 +3,7 @@ import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
 import ReactTestRenderer from "react-test-renderer"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
-import { CollectionContainer } from "../Collection"
+import { CollectionContainer, FilterArtworkButton, FilterArtworkButtonContainer } from "../Collection"
 
 jest.unmock("react-relay")
 
@@ -44,5 +44,21 @@ describe("Collection", () => {
       return MockPayloadGenerator.generate(operation)
     })
     expect(renderer.toJSON()).toMatchSnapshot()
+  })
+
+  it("does not display a filter artworks button by default", () => {
+    const root = ReactTestRenderer.create(<TestRenderer />).root
+
+    expect(root.findAllByType(FilterArtworkButtonContainer)).toHaveLength(0)
+    expect(root.findAllByType(FilterArtworkButton)).toHaveLength(0)
+  })
+
+  /**  TODO: Pair with MX to complete get these assertions to pass
+   * How do we mock an update to the state object and the Native Emission Module to
+   * get these components to render
+   */
+  xit("does display a filter artworks button when artworks grid when artworks grid is in view", () => {
+    // expect(root.findAllByType(FilterArtworkButtonContainer)).toHaveLength(1)
+    // expect(root.findAllByType(FilterArtworkButton)).toHaveLength(1)
   })
 })

--- a/src/lib/Scenes/Collection/__tests__/__snapshots__/Collection-tests.tsx.snap
+++ b/src/lib/Scenes/Collection/__tests__/__snapshots__/Collection-tests.tsx.snap
@@ -1211,7 +1211,7 @@ exports[`Collection renders a snapshot 1`] = `
     updateCellsBatchingPeriod={50}
     viewabilityConfig={
       Object {
-        "viewAreaCoveragePercentThreshold": 10,
+        "viewAreaCoveragePercentThreshold": 30,
       }
     }
     viewabilityConfigCallbackPairs={
@@ -1219,7 +1219,7 @@ exports[`Collection renders a snapshot 1`] = `
         Object {
           "onViewableItemsChanged": [Function],
           "viewabilityConfig": Object {
-            "viewAreaCoveragePercentThreshold": 10,
+            "viewAreaCoveragePercentThreshold": 30,
           },
         },
       ]
@@ -1419,7 +1419,7 @@ exports[`Collection renders a snapshot 1`] = `
           >
             <View
               accessible={true}
-              focusable={true}
+              focusable={false}
               onClick={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
@@ -1440,10 +1440,16 @@ exports[`Collection renders a snapshot 1`] = `
               }
             >
               <View
+                onTouchStart={[Function]}
                 style={
-                  Object {
-                    "flexGrow": 1,
-                  }
+                  Array [
+                    Object {
+                      "display": "flex",
+                    },
+                    Object {
+                      "flexGrow": 1,
+                    },
+                  ]
                 }
               />
               <View
@@ -1465,23 +1471,204 @@ exports[`Collection renders a snapshot 1`] = `
                 }
                 visible={false}
               >
-                <Text
-                  fontFamily="Unica77LL-Regular"
-                  fontSize="14px"
-                  lineHeight="20px"
+                <View
+                  flexDirection="row"
+                  justifyContent="space-between"
                   style={
                     Array [
                       Object {
-                        "fontFamily": "Unica77LL-Regular",
-                        "fontSize": 14,
-                        "lineHeight": 20,
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "justifyContent": "space-between",
                       },
-                      Object {},
                     ]
                   }
                 >
-                  Hello, modal!
-                </Text>
+                  <View
+                    alignItems="flex-end"
+                    mb={2}
+                    mt={0.5}
+                    style={
+                      Array [
+                        Object {
+                          "alignItems": "flex-end",
+                          "display": "flex",
+                          "marginBottom": 20,
+                          "marginTop": 5,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      onTouchStart={[Function]}
+                      style={
+                        Array [
+                          Object {},
+                        ]
+                      }
+                    >
+                      <RNSVGSvgView
+                        align="xMidYMid"
+                        bbHeight="18px"
+                        bbWidth="18px"
+                        className="Iconios__Icon-z4d8jr-0 cjvLsm"
+                        fill="black100"
+                        focusable={false}
+                        height="18px"
+                        meetOrSlice={0}
+                        minX={0}
+                        minY={0}
+                        style={
+                          Array [
+                            Object {
+                              "backgroundColor": "transparent",
+                              "borderWidth": 0,
+                            },
+                            undefined,
+                            Object {
+                              "opacity": 1,
+                            },
+                            Object {
+                              "flex": 0,
+                              "height": 18,
+                              "width": 18,
+                            },
+                          ]
+                        }
+                        vbHeight={18}
+                        vbWidth={18}
+                        width="18px"
+                      >
+                        <RNSVGGroup
+                          fill={
+                            Array [
+                              0,
+                              4278190080,
+                            ]
+                          }
+                          fillOpacity={1}
+                          fillRule={1}
+                          font={Object {}}
+                          matrix={
+                            Array [
+                              1,
+                              0,
+                              0,
+                              1,
+                              0,
+                              0,
+                            ]
+                          }
+                          opacity={1}
+                          originX={0}
+                          originY={0}
+                          propList={
+                            Array [
+                              "fill",
+                            ]
+                          }
+                          rotation={0}
+                          scaleX={1}
+                          scaleY={1}
+                          skewX={0}
+                          skewY={0}
+                          stroke={null}
+                          strokeDasharray={null}
+                          strokeDashoffset={null}
+                          strokeLinecap={0}
+                          strokeLinejoin={0}
+                          strokeMiterlimit={4}
+                          strokeOpacity={1}
+                          strokeWidth={1}
+                          vectorEffect={0}
+                          x={0}
+                          y={0}
+                        >
+                          <RNSVGPath
+                            d="M9.88 9l4.56 4.56-.88.88L9 9.88l-4.56 4.56-.88-.88L8.12 9 3.56 4.44l.88-.88L9 8.12l4.56-4.56.88.88z"
+                            fill={
+                              Array [
+                                0,
+                                4278190080,
+                              ]
+                            }
+                            fillOpacity={1}
+                            fillRule={0}
+                            matrix={
+                              Array [
+                                1,
+                                0,
+                                0,
+                                1,
+                                0,
+                                0,
+                              ]
+                            }
+                            opacity={1}
+                            originX={0}
+                            originY={0}
+                            propList={
+                              Array [
+                                "fill",
+                                "fillRule",
+                              ]
+                            }
+                            rotation={0}
+                            scaleX={1}
+                            scaleY={1}
+                            skewX={0}
+                            skewY={0}
+                            stroke={null}
+                            strokeDasharray={null}
+                            strokeDashoffset={null}
+                            strokeLinecap={0}
+                            strokeLinejoin={0}
+                            strokeMiterlimit={4}
+                            strokeOpacity={1}
+                            strokeWidth={1}
+                            vectorEffect={0}
+                            x={0}
+                            y={0}
+                          />
+                        </RNSVGGroup>
+                      </RNSVGSvgView>
+                    </View>
+                  </View>
+                  <Text
+                    fontFamily="Unica77LL-Medium"
+                    fontSize="16px"
+                    lineHeight="26px"
+                    style={
+                      Array [
+                        Object {
+                          "fontFamily": "Unica77LL-Medium",
+                          "fontSize": 16,
+                          "lineHeight": 26,
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    Filter
+                  </Text>
+                  <Text
+                    fontFamily="Unica77LL-Regular"
+                    fontSize="16px"
+                    lineHeight="26px"
+                    style={
+                      Array [
+                        Object {
+                          "fontFamily": "Unica77LL-Regular",
+                          "fontSize": 16,
+                          "lineHeight": 26,
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    Clear all
+                  </Text>
+                </View>
                 <View
                   accessible={true}
                   flexDirection="row"

--- a/src/lib/Scenes/Collection/__tests__/__snapshots__/Collection-tests.tsx.snap
+++ b/src/lib/Scenes/Collection/__tests__/__snapshots__/Collection-tests.tsx.snap
@@ -3,9 +3,9 @@
 exports[`Collection renders a snapshot 1`] = `
 <View
   style={
-    Array [
-      Object {},
-    ]
+    Object {
+      "flex": 1,
+    }
   }
 >
   <RCTScrollView
@@ -1203,12 +1203,27 @@ exports[`Collection renders a snapshot 1`] = `
     onScroll={[Function]}
     onScrollBeginDrag={[Function]}
     onScrollEndDrag={[Function]}
+    onViewableItemsChanged={[Function]}
     removeClippedSubviews={false}
     renderItem={[Function]}
     scrollEventThrottle={50}
     stickyHeaderIndices={Array []}
     updateCellsBatchingPeriod={50}
-    viewabilityConfigCallbackPairs={Array []}
+    viewabilityConfig={
+      Object {
+        "viewAreaCoveragePercentThreshold": 5,
+      }
+    }
+    viewabilityConfigCallbackPairs={
+      Array [
+        Object {
+          "onViewableItemsChanged": [Function],
+          "viewabilityConfig": Object {
+            "viewAreaCoveragePercentThreshold": 5,
+          },
+        },
+      ]
+    }
     windowSize={21}
   >
     <View>

--- a/src/lib/Scenes/Collection/__tests__/__snapshots__/Collection-tests.tsx.snap
+++ b/src/lib/Scenes/Collection/__tests__/__snapshots__/Collection-tests.tsx.snap
@@ -1211,7 +1211,7 @@ exports[`Collection renders a snapshot 1`] = `
     updateCellsBatchingPeriod={50}
     viewabilityConfig={
       Object {
-        "viewAreaCoveragePercentThreshold": 5,
+        "viewAreaCoveragePercentThreshold": 10,
       }
     }
     viewabilityConfigCallbackPairs={
@@ -1219,7 +1219,7 @@ exports[`Collection renders a snapshot 1`] = `
         Object {
           "onViewableItemsChanged": [Function],
           "viewabilityConfig": Object {
-            "viewAreaCoveragePercentThreshold": 5,
+            "viewAreaCoveragePercentThreshold": 10,
           },
         },
       ]
@@ -1411,6 +1411,411 @@ exports[`Collection renders a snapshot 1`] = `
               </View>
             </View>
           </RCTScrollView>
+          <Modal
+            animationType="fade"
+            hardwareAccelerated={false}
+            transparent={true}
+            visible={false}
+          >
+            <View
+              accessible={true}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Array [
+                  Object {
+                    "backgroundColor": "#00000099",
+                    "flexBasis": 0,
+                    "flexDirection": "column",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                ]
+              }
+            >
+              <View
+                style={
+                  Object {
+                    "flexGrow": 1,
+                  }
+                }
+              />
+              <View
+                style={
+                  Array [
+                    Object {
+                      "backgroundColor": "white",
+                      "borderTopLeftRadius": 10,
+                      "borderTopRightRadius": 10,
+                      "flexDirection": "column",
+                      "height": 0,
+                      "paddingBottom": 0,
+                      "paddingLeft": 0,
+                      "paddingRight": 0,
+                      "paddingTop": 0,
+                      "width": "100%",
+                    },
+                  ]
+                }
+                visible={false}
+              >
+                <Text
+                  fontFamily="Unica77LL-Regular"
+                  fontSize="14px"
+                  lineHeight="20px"
+                  style={
+                    Array [
+                      Object {
+                        "fontFamily": "Unica77LL-Regular",
+                        "fontSize": 14,
+                        "lineHeight": 20,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Hello, modal!
+                </Text>
+                <View
+                  accessible={true}
+                  flexDirection="row"
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    Array [
+                      Object {
+                        "display": "flex",
+                        "flexDirection": "row",
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    block={true}
+                    onPress={[Function]}
+                    px={2}
+                    size="medium"
+                    style={
+                      Array [
+                        Object {
+                          "alignItems": "center",
+                          "borderRadius": 3,
+                          "borderWidth": 1,
+                          "justifyContent": "center",
+                          "paddingLeft": 20,
+                          "paddingRight": 20,
+                          "position": "relative",
+                          "width": "100%",
+                        },
+                        Object {
+                          "backgroundColor": "rgba(255, 255, 255, 1)",
+                          "borderColor": "rgba(229, 229, 229, 1)",
+                          "color": "rgba(0, 0, 0, 1)",
+                          "height": 41,
+                          "opacity": 1,
+                        },
+                      ]
+                    }
+                    theme={
+                      Object {
+                        "borders": Array [
+                          "1px solid",
+                          "2px solid",
+                        ],
+                        "breakpoints": Array [
+                          768,
+                          900,
+                          1024,
+                          1192,
+                        ],
+                        "colors": Object {
+                          "black10": "#E5E5E5",
+                          "black100": "#000",
+                          "black30": "#C2C2C2",
+                          "black5": "#F8F8F8",
+                          "black60": "#666",
+                          "black80": "#333",
+                          "green100": "#0EDA83",
+                          "purple100": "#6E1EFF",
+                          "purple30": "#D3BBFF",
+                          "purple5": "#F8F3FF",
+                          "red100": "#F7625A",
+                          "white100": "#FFF",
+                          "yellow10": "#FDF7E8",
+                          "yellow100": "#F1AF1B",
+                          "yellow30": "#FAE7BA",
+                        },
+                        "fontFamily": Object {
+                          "display": Object {
+                            "regular": "AvantGardeGothicITC",
+                          },
+                          "sans": Object {
+                            "italic": "Unica77LL-Italic",
+                            "medium": "Unica77LL-Medium",
+                            "mediumItalic": "Unica77LL-MediumItalic",
+                            "regular": "Unica77LL-Regular",
+                          },
+                          "serif": Object {
+                            "italic": "ReactNativeAGaramondPro-Italic",
+                            "regular": "ReactNativeAGaramondPro-Regular",
+                            "semibold": "ReactNativeAGaramondPro-Semibold",
+                          },
+                        },
+                        "grid": Object {
+                          "breakpoints": Object {
+                            "lg": 1024,
+                            "md": 900,
+                            "sm": 768,
+                            "xl": 1192,
+                            "xs": 767,
+                          },
+                          "col": Object {
+                            "padding": 0,
+                          },
+                          "container": Object {
+                            "padding": 0,
+                          },
+                          "row": Object {
+                            "padding": 0,
+                          },
+                        },
+                        "mediaQueries": Object {
+                          "hover": "not all and (pointer: coarse), not all and (-moz-touch-enabled: 1)",
+                          "lg": "(min-width: 1024px) and (max-width: 1191px)",
+                          "md": "(min-width: 900px) and (max-width: 1023px)",
+                          "sm": "(min-width: 768px) and (max-width: 899px)",
+                          "xl": "(min-width: 1192px)",
+                          "xs": "(max-width: 767px)",
+                        },
+                        "space": Object {
+                          "0.3": 3,
+                          "0.5": 5,
+                          "1": 10,
+                          "12": 120,
+                          "18": 180,
+                          "2": 20,
+                          "3": 30,
+                          "4": 40,
+                          "6": 60,
+                          "9": 90,
+                        },
+                        "typeSizes": Object {
+                          "display": Object {
+                            "2": Object {
+                              "fontSize": 10,
+                              "lineHeight": 12,
+                            },
+                            "3t": Object {
+                              "fontSize": 12,
+                              "lineHeight": 16,
+                            },
+                            "4t": Object {
+                              "fontSize": 14,
+                              "lineHeight": 18,
+                            },
+                            "5t": Object {
+                              "fontSize": 16,
+                              "lineHeight": 20,
+                            },
+                            "6": Object {
+                              "fontSize": 18,
+                              "lineHeight": 22,
+                            },
+                            "8": Object {
+                              "fontSize": 22,
+                              "lineHeight": 24,
+                            },
+                          },
+                          "sans": Object {
+                            "0": Object {
+                              "fontSize": 8,
+                              "lineHeight": 8,
+                            },
+                            "1": Object {
+                              "fontSize": 10,
+                              "lineHeight": 14,
+                            },
+                            "10": Object {
+                              "fontSize": 42,
+                              "lineHeight": 50,
+                            },
+                            "12": Object {
+                              "fontSize": 60,
+                              "lineHeight": 66,
+                            },
+                            "14": Object {
+                              "fontSize": 80,
+                              "lineHeight": 84,
+                            },
+                            "16": Object {
+                              "fontSize": 100,
+                              "lineHeight": 104,
+                            },
+                            "2": Object {
+                              "fontSize": 12,
+                              "lineHeight": 16,
+                            },
+                            "3": Object {
+                              "fontSize": 14,
+                              "lineHeight": 24,
+                            },
+                            "3t": Object {
+                              "fontSize": 14,
+                              "lineHeight": 20,
+                            },
+                            "4": Object {
+                              "fontSize": 16,
+                              "lineHeight": 26,
+                            },
+                            "4t": Object {
+                              "fontSize": 16,
+                              "lineHeight": 22,
+                            },
+                            "5": Object {
+                              "fontSize": 18,
+                              "lineHeight": 30,
+                            },
+                            "5t": Object {
+                              "fontSize": 18,
+                              "lineHeight": 26,
+                            },
+                            "6": Object {
+                              "fontSize": 22,
+                              "lineHeight": 30,
+                            },
+                            "8": Object {
+                              "fontSize": 28,
+                              "lineHeight": 36,
+                            },
+                          },
+                          "serif": Object {
+                            "1": Object {
+                              "fontSize": 12,
+                              "lineHeight": 16,
+                            },
+                            "10": Object {
+                              "fontSize": 44,
+                              "lineHeight": 50,
+                            },
+                            "12": Object {
+                              "fontSize": 60,
+                              "lineHeight": 70,
+                            },
+                            "2": Object {
+                              "fontSize": 14,
+                              "lineHeight": 18,
+                            },
+                            "3": Object {
+                              "fontSize": 16,
+                              "lineHeight": 24,
+                            },
+                            "3t": Object {
+                              "fontSize": 16,
+                              "lineHeight": 20,
+                            },
+                            "4": Object {
+                              "fontSize": 18,
+                              "lineHeight": 26,
+                            },
+                            "4t": Object {
+                              "fontSize": 18,
+                              "lineHeight": 22,
+                            },
+                            "5": Object {
+                              "fontSize": 22,
+                              "lineHeight": 32,
+                            },
+                            "5t": Object {
+                              "fontSize": 22,
+                              "lineHeight": 28,
+                            },
+                            "6": Object {
+                              "fontSize": 26,
+                              "lineHeight": 32,
+                            },
+                            "8": Object {
+                              "fontSize": 32,
+                              "lineHeight": 38,
+                            },
+                          },
+                        },
+                      }
+                    }
+                    variant="secondaryOutline"
+                    width={100}
+                  >
+                    <View
+                      style={
+                        Array [
+                          Object {
+                            "alignItems": "center",
+                            "display": "flex",
+                            "flexDirection": "row",
+                            "height": "100%",
+                            "justifyContent": "center",
+                            "position": "absolute",
+                            "width": "100%",
+                          },
+                        ]
+                      }
+                    >
+                      <Text
+                        color="#000"
+                        fontFamily="Unica77LL-Medium"
+                        fontSize="14px"
+                        lineHeight="20px"
+                        style={
+                          Array [
+                            Object {
+                              "color": "#000",
+                              "fontFamily": "Unica77LL-Medium",
+                              "fontSize": 14,
+                              "lineHeight": 20,
+                            },
+                            Object {},
+                          ]
+                        }
+                      >
+                        Ok
+                      </Text>
+                    </View>
+                    <Text
+                      fontFamily="Unica77LL-Medium"
+                      fontSize="14px"
+                      lineHeight="20px"
+                      role="presentation"
+                      style={
+                        Array [
+                          Object {
+                            "fontFamily": "Unica77LL-Medium",
+                            "fontSize": 14,
+                            "lineHeight": 20,
+                          },
+                          Object {
+                            "opacity": 0,
+                          },
+                        ]
+                      }
+                    >
+                      Ok
+                    </Text>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </Modal>
         </View>
       </View>
       <View


### PR DESCRIPTION
This PR combines #2067 and #2068 into a single branch to support building the collections artwork filter container as outlined in [FX-1474](https://artsyproduct.atlassian.net/browse/FX-1474)

Includes:
- [Modal overlay](https://artsyproduct.atlassian.net/browse/FX-1765)
- [Conditionally rendering filter button](https://artsyproduct.atlassian.net/browse/FX-1763)
- [Modal overlay closes by selecting Close icon + when clicking outside of the modal area](https://artsyproduct.atlassian.net/browse/FX-1766)
- [Hides filter button + modal overlay behind feature flag](https://artsyproduct.atlassian.net/browse/FX-1796)

**With Feature Flag Enabled (Modal Visible)**
![Kapture 2020-02-06 at 17 52 01](https://user-images.githubusercontent.com/10385964/73985539-6cf8cf00-4909-11ea-99b2-d17db1e903f6.gif)


**With Feature Flag Disabled (Modal Not Visible)**
![Kapture 2020-02-06 at 17 57 46](https://user-images.githubusercontent.com/10385964/73985842-3c656500-490a-11ea-8f3a-2e227a6e4f7e.gif)






