### PR TITLE
[FX-1789] Add right margin to collection title

### DIFF
--- a/src/lib/Scenes/Collection/Screens/CollectionHeader.tsx
+++ b/src/lib/Scenes/Collection/Screens/CollectionHeader.tsx
@@ -26,7 +26,7 @@ export const CollectionHeader: React.SFC<CollectionHeaderProps> = props => {
         <OpaqueImageView imageURL={url} height={HEADER_IMAGE_HEIGHT} width={screenWidth} />
       </Box>
       <Box mb={collectionTitleMargin}>
-        <Serif size="8" color={color("black100")} ml={2}>
+        <Serif size="8" color={color("black100")} mx={2}>
           {title}
         </Serif>
       </Box>

--- a/src/lib/Scenes/Collection/__tests__/__snapshots__/Collection-tests.tsx.snap
+++ b/src/lib/Scenes/Collection/__tests__/__snapshots__/Collection-tests.tsx.snap
@@ -1240,7 +1240,7 @@ exports[`Collection renders a snapshot 1`] = `
             fontFamily="ReactNativeAGaramondPro-Regular"
             fontSize="32px"
             lineHeight="38px"
-            ml={2}
+            mx={2}
             style={
               Array [
                 Object {
@@ -1249,6 +1249,7 @@ exports[`Collection renders a snapshot 1`] = `
                   "fontSize": 32,
                   "lineHeight": 38,
                   "marginLeft": 20,
+                  "marginRight": 20,
                 },
                 Object {},
               ]


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/FX-1789 by specifying a right margin on the title of the collection screen.

Before this change: 
![image](https://user-images.githubusercontent.com/1627089/73873746-caacee80-4817-11ea-9570-b477e2f68cd6.png)

After this change: 

![image](https://user-images.githubusercontent.com/1627089/73873789-e3b59f80-4817-11ea-8919-e32ff4124f43.png)
