### PR TITLE
Preserve changes made manually to the MP query map

### DIFF
--- a/scripts/update-metaphysics-and-eigen.js
+++ b/scripts/update-metaphysics-and-eigen.js
@@ -19,6 +19,9 @@ async function main() {
       message: "Update emission query map",
       update: dir => {
         log.step("Merging complete.queryMap.json")
+        // merge metaphysics into emission map first, to preserve any manual edits made in MP
+        mergeJson("data/complete.queryMap.json", path.join(dir, "src/data/complete.queryMap.json"))
+        // then merge back into metaphysics to update
         mergeJson(path.join(dir, "src/data/complete.queryMap.json"), "data/complete.queryMap.json")
       },
     })


### PR DESCRIPTION
yesterday we needed to manually edit an existing query in MP's persisted query map. Unfortunately after deploying emission it overwrote that manual change because that's how emission updates the MP query map during it's deploy job on CI.

here we change the logic so that it preserves the MP version as the source of truth.

see artsy/metaphysics#2160 #2075 and https://artsy.slack.com/archives/CN8S32FJR/p1581001886215700 for context