### PR TITLE
[MX-158] add placeholder loading state for artwork page

### DIFF
--- a/src/lib/AppRegistry.tsx
+++ b/src/lib/AppRegistry.tsx
@@ -51,6 +51,7 @@ import renderWithLoadProgress from "./utils/renderWithLoadProgress"
 import { Schema, screenTrack as track } from "./utils/track"
 
 YellowBox.ignoreWarnings([
+  "Warning: RelayResponseNormalizer: Payload did not contain a value for field `id: id`. Check that you are parsing with the same query that was used to fetch the payload.",
   // Deprecated, we'll transition when it's removed.
   "Warning: ListView is deprecated and will be removed in a future release. See https://fb.me/nolistview for more information",
 

--- a/src/lib/Scenes/Artwork/Artwork.tsx
+++ b/src/lib/Scenes/Artwork/Artwork.tsx
@@ -367,6 +367,9 @@ export const ArtworkRenderer: React.SFC<{ artworkID: string; safeAreaInsets: Saf
 }
 
 const ArtworkPlaceholder: React.FC<{}> = ({}) => {
+  if (process?.env?.NODE_ENV === "test") {
+    return <View />
+  }
   const screenDimensions = useScreenDimensions()
   // The logic for artworkHeight comes from the zeplin spec https://zpl.io/25JLX0Q
   const artworkHeight = screenDimensions.width >= 375 ? 340 : 290

--- a/src/lib/Scenes/Artwork/Artwork.tsx
+++ b/src/lib/Scenes/Artwork/Artwork.tsx
@@ -1,9 +1,8 @@
-import { Box, space, Spacer, Theme } from "@artsy/palette"
+import { Box, Separator, space, Spacer, Theme } from "@artsy/palette"
 import { Artwork_artwork } from "__generated__/Artwork_artwork.graphql"
 import { ArtworkMarkAsRecentlyViewedQuery } from "__generated__/ArtworkMarkAsRecentlyViewedQuery.graphql"
 import { ArtworkQuery } from "__generated__/ArtworkQuery.graphql"
 import { RetryErrorBoundary } from "lib/Components/RetryErrorBoundary"
-import Separator from "lib/Components/Separator"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { SafeAreaInsets } from "lib/types/SafeAreaInsets"
 import { Placeholder, RaggedText } from "lib/utils/placeholders"
@@ -381,6 +380,7 @@ const ArtworkPlaceholder: React.FC<{}> = ({}) => {
       <View style={{ flexDirection: "row", justifyContent: "center" }}>
         <Placeholder width={50} height={space(2)} marginHorizontal={space(1)} />
         <Placeholder width={50} height={space(2)} marginHorizontal={space(1)} />
+        <Placeholder width={50} height={space(2)} marginHorizontal={space(1)} />
       </View>
       <Spacer mb={2} />
       {/* Artist name */}
@@ -388,13 +388,13 @@ const ArtworkPlaceholder: React.FC<{}> = ({}) => {
       <Spacer mb={2} />
       {/* Artwork tombstone details */}
       <View style={{ width: 130 }}>
-        <RaggedText numLines={5} />
+        <RaggedText numLines={4} />
       </View>
-      <Spacer mb={2} />
+      <Spacer mb={3} />
       {/* more junk */}
-      <Placeholder width={190} height={space(1)} marginBottom={5} />
-      <Spacer mb={2} />
-      <RaggedText numLines={6} />
+      <Separator />
+      <Spacer mb={3} />
+      <RaggedText numLines={3} />
       <Spacer mb={2} />
       {/* commerce button */}
       <Placeholder height={60} />

--- a/src/lib/Scenes/Artwork/Artwork.tsx
+++ b/src/lib/Scenes/Artwork/Artwork.tsx
@@ -367,9 +367,6 @@ export const ArtworkRenderer: React.SFC<{ artworkID: string; safeAreaInsets: Saf
 }
 
 const ArtworkPlaceholder: React.FC<{}> = ({}) => {
-  if (process?.env?.NODE_ENV === "test") {
-    return <View />
-  }
   const screenDimensions = useScreenDimensions()
   // The logic for artworkHeight comes from the zeplin spec https://zpl.io/25JLX0Q
   const artworkHeight = screenDimensions.width >= 375 ? 340 : 290

--- a/src/lib/Scenes/Artwork/Artwork.tsx
+++ b/src/lib/Scenes/Artwork/Artwork.tsx
@@ -5,7 +5,7 @@ import { ArtworkQuery } from "__generated__/ArtworkQuery.graphql"
 import { RetryErrorBoundary } from "lib/Components/RetryErrorBoundary"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { SafeAreaInsets } from "lib/types/SafeAreaInsets"
-import { Placeholder, RaggedText } from "lib/utils/placeholders"
+import { PlaceholderBox, PlaceholderRaggedText, PlaceholderText } from "lib/utils/placeholders"
 import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
 import { Schema, screenTrack } from "lib/utils/track"
 import { ProvideScreenDimensions, useScreenDimensions } from "lib/utils/useScreenDimensions"
@@ -377,30 +377,30 @@ const ArtworkPlaceholder: React.FC<{}> = ({}) => {
   return (
     <View style={{ flex: 1, padding: space(2) }}>
       {/* Artwork thumbnail */}
-      <Placeholder height={artworkHeight} />
+      <PlaceholderBox height={artworkHeight} />
       <Spacer mb={2} />
       {/* save/share buttons */}
       <View style={{ flexDirection: "row", justifyContent: "center" }}>
-        <Placeholder width={50} height={space(2)} marginHorizontal={space(1)} />
-        <Placeholder width={50} height={space(2)} marginHorizontal={space(1)} />
-        <Placeholder width={50} height={space(2)} marginHorizontal={space(1)} />
+        <PlaceholderText width={50} marginHorizontal={space(1)} />
+        <PlaceholderText width={50} marginHorizontal={space(1)} />
+        <PlaceholderText width={50} marginHorizontal={space(1)} />
       </View>
       <Spacer mb={2} />
       {/* Artist name */}
-      <Placeholder width={100} height={space(1)} />
+      <PlaceholderText width={100} />
       <Spacer mb={2} />
       {/* Artwork tombstone details */}
       <View style={{ width: 130 }}>
-        <RaggedText numLines={4} />
+        <PlaceholderRaggedText numLines={4} />
       </View>
       <Spacer mb={3} />
       {/* more junk */}
       <Separator />
       <Spacer mb={3} />
-      <RaggedText numLines={3} />
+      <PlaceholderRaggedText numLines={3} />
       <Spacer mb={2} />
       {/* commerce button */}
-      <Placeholder height={60} />
+      <PlaceholderBox height={60} />
     </View>
   )
 }

--- a/src/lib/Scenes/Artwork/Artwork.tsx
+++ b/src/lib/Scenes/Artwork/Artwork.tsx
@@ -1,4 +1,4 @@
-import { Box, Theme } from "@artsy/palette"
+import { Box, space, Spacer, Theme } from "@artsy/palette"
 import { Artwork_artwork } from "__generated__/Artwork_artwork.graphql"
 import { ArtworkMarkAsRecentlyViewedQuery } from "__generated__/ArtworkMarkAsRecentlyViewedQuery.graphql"
 import { ArtworkQuery } from "__generated__/ArtworkQuery.graphql"
@@ -6,11 +6,12 @@ import { RetryErrorBoundary } from "lib/Components/RetryErrorBoundary"
 import Separator from "lib/Components/Separator"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { SafeAreaInsets } from "lib/types/SafeAreaInsets"
-import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
+import { Placeholder, RaggedText } from "lib/utils/placeholders"
+import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
 import { Schema, screenTrack } from "lib/utils/track"
-import { ProvideScreenDimensions } from "lib/utils/useScreenDimensions"
+import { ProvideScreenDimensions, useScreenDimensions } from "lib/utils/useScreenDimensions"
 import React from "react"
-import { FlatList } from "react-native"
+import { FlatList, View } from "react-native"
 import { RefreshControl } from "react-native"
 import { commitMutation, createRefetchContainer, graphql, QueryRenderer, RelayRefetchProp } from "react-relay"
 import { AboutArtistFragmentContainer as AboutArtist } from "./Components/AboutArtist"
@@ -224,24 +225,20 @@ export class Artwork extends React.Component<Props, State> {
 
   render() {
     return (
-      <Theme>
-        <ProvideScreenDimensions>
-          <FlatList
-            data={this.sections()}
-            ItemSeparatorComponent={() => (
-              <Box px={2} mx={2} my={3}>
-                <Separator />
-              </Box>
-            )}
-            refreshControl={<RefreshControl refreshing={this.state.refreshing} onRefresh={this.onRefresh} />}
-            contentInset={{ bottom: 40 }}
-            keyExtractor={(item, index) => item.type + String(index)}
-            renderItem={item =>
-              item.item === "header" ? this.renderItem(item) : <Box px={2}>{this.renderItem(item)}</Box>
-            }
-          />
-        </ProvideScreenDimensions>
-      </Theme>
+      <FlatList
+        data={this.sections()}
+        ItemSeparatorComponent={() => (
+          <Box px={2} mx={2} my={3}>
+            <Separator />
+          </Box>
+        )}
+        refreshControl={<RefreshControl refreshing={this.state.refreshing} onRefresh={this.onRefresh} />}
+        contentInset={{ bottom: 40 }}
+        keyExtractor={(item, index) => item.type + String(index)}
+        renderItem={item =>
+          item.item === "header" ? this.renderItem(item) : <Box px={2}>{this.renderItem(item)}</Box>
+        }
+      />
     )
   }
 }
@@ -340,24 +337,67 @@ export const ArtworkRenderer: React.SFC<{ artworkID: string; safeAreaInsets: Saf
     <RetryErrorBoundary
       render={({ isRetry }) => {
         return (
-          <QueryRenderer<ArtworkQuery>
-            environment={defaultEnvironment}
-            query={graphql`
-              query ArtworkQuery($artworkID: String!) {
-                artwork(id: $artworkID) {
-                  ...Artwork_artwork
-                }
-              }
-            `}
-            variables={{ artworkID }}
-            cacheConfig={{
-              // Bypass Relay cache on retries.
-              ...(isRetry && { force: true }),
-            }}
-            render={renderWithLoadProgress(ArtworkContainer, others)}
-          />
+          <Theme>
+            <ProvideScreenDimensions>
+              <QueryRenderer<ArtworkQuery>
+                environment={defaultEnvironment}
+                query={graphql`
+                  query ArtworkQuery($artworkID: String!) {
+                    artwork(id: $artworkID) {
+                      ...Artwork_artwork
+                    }
+                  }
+                `}
+                variables={{ artworkID }}
+                cacheConfig={{
+                  // Bypass Relay cache on retries.
+                  ...(isRetry && { force: true }),
+                }}
+                render={renderWithPlaceholder({
+                  Container: ArtworkContainer,
+                  initialProps: others,
+                  renderPlaceholder: () => <ArtworkPlaceholder />,
+                })}
+              />
+            </ProvideScreenDimensions>
+          </Theme>
         )
       }}
     />
+  )
+}
+
+const ArtworkPlaceholder: React.FC<{}> = ({}) => {
+  const screenDimensions = useScreenDimensions()
+  // The logic for artworkHeight comes from the zeplin spec https://zpl.io/25JLX0Q
+  const artworkHeight = screenDimensions.width >= 375 ? 340 : 290
+
+  return (
+    <View style={{ flex: 1, padding: space(2) }}>
+      {/* Artwork thumbnail */}
+      <Placeholder height={artworkHeight} />
+      <Spacer mb={2} />
+      {/* save/share buttons */}
+      <View style={{ flexDirection: "row", justifyContent: "center" }}>
+        <Placeholder width={50} height={space(2)} marginHorizontal={space(1)} />
+        <Placeholder width={50} height={space(2)} marginHorizontal={space(1)} />
+      </View>
+      <Spacer mb={2} />
+      {/* Artist name */}
+      <Placeholder width={100} height={space(1)} />
+      <Spacer mb={2} />
+      {/* Artwork tombstone details */}
+      <View style={{ width: 130 }}>
+        <RaggedText numLines={5} />
+      </View>
+      <Spacer mb={2} />
+      {/* more junk */}
+      <Placeholder width={190} height={space(1)} marginBottom={5} />
+      <Spacer mb={2} />
+      <RaggedText numLines={6} />
+      <Spacer mb={2} />
+      {/* commerce button */}
+      <Placeholder height={60} />
+    </View>
   )
 }

--- a/src/lib/Scenes/Artwork/Components/ImageCarousel/ImageWithLoadingState.tsx
+++ b/src/lib/Scenes/Artwork/Components/ImageCarousel/ImageWithLoadingState.tsx
@@ -1,9 +1,6 @@
-import { color } from "@artsy/palette"
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
-import Spinner from "lib/Components/Spinner"
-import React, { useEffect, useState } from "react"
-import { Animated, TouchableWithoutFeedback, View, ViewProps } from "react-native"
-import { useSpringValue } from "./useSpringValue"
+import React from "react"
+import { TouchableWithoutFeedback, View, ViewProps } from "react-native"
 
 interface ImageWithLoadingStateProps {
   width: number
@@ -22,64 +19,27 @@ interface ImageWithLoadingStateProps {
  * @param param0 same as RN's Image props
  */
 export const ImageWithLoadingState = React.forwardRef<View, ImageWithLoadingStateProps>((props, ref) => {
-  const [isLoading, setIsLoading] = useState(true)
-
   // When the image has loaded we want to fade it in, so we have a white overlay
   // this assumes the image will be on a white backdrop. This component will
   // need to be significantly refactored if it ever needs to be used with other
   // color backgrounds
-  const overlayOpacity = useSpringValue(isLoading ? 1 : 0)
-
   // show a loading spinner only after a short delay, if the image is taking a while to load
-  const [showingSpinner, setShowingSpinner] = useState(false)
-  const spinnerOpacity = useSpringValue(showingSpinner ? 1 : 0)
-  useEffect(() => {
-    setTimeout(() => setShowingSpinner(true), 1000)
-  }, [])
   const { width, height, imageURL, onPress } = props
   return (
     <TouchableWithoutFeedback onPress={onPress}>
       <View style={[{ width, height }, props.style]} ref={ref}>
-        <View style={{ position: "absolute", width, height }}>
-          <OpaqueImageView
-            noAnimation
-            useRawURL
-            onLoad={() => {
-              setIsLoading(false)
-              if (props.onLoad) {
-                props.onLoad()
-              }
-            }}
-            imageURL={imageURL}
-            aspectRatio={width / height}
-            style={{ width, height }}
-            highPriority={props.highPriority}
-          />
-        </View>
-        <Animated.View
-          style={{
-            position: "absolute",
-            width,
-            height,
-            opacity: overlayOpacity,
-            backgroundColor: "white",
-            flex: 1,
+        <OpaqueImageView
+          useRawURL
+          onLoad={() => {
+            if (props.onLoad) {
+              props.onLoad()
+            }
           }}
-        >
-          <Animated.View
-            style={{
-              opacity: spinnerOpacity,
-              // give the image a subtle silhouette while the spinner is displaying
-              // to keep the balance of the page and set an appropriate user expectation
-              backgroundColor: color("black5"),
-              alignItems: "center",
-              justifyContent: "center",
-              flex: 1,
-            }}
-          >
-            <Spinner />
-          </Animated.View>
-        </Animated.View>
+          imageURL={imageURL}
+          aspectRatio={width / height}
+          style={{ width, height }}
+          highPriority={props.highPriority}
+        />
       </View>
     </TouchableWithoutFeedback>
   )

--- a/src/lib/Scenes/Artwork/__tests__/Artwork-tests.tsx
+++ b/src/lib/Scenes/Artwork/__tests__/Artwork-tests.tsx
@@ -1,3 +1,4 @@
+import { Theme } from "@artsy/palette"
 import { ArtworkTestsQuery } from "__generated__/ArtworkTestsQuery.graphql"
 import {
   ArtworkFromLiveAuctionRegistrationClosed,
@@ -8,6 +9,7 @@ import {
 import { ArtworkFixture } from "lib/__fixtures__/ArtworkFixture"
 import { Countdown } from "lib/Components/Bidding/Components/Timer"
 import { extractText } from "lib/tests/extractText"
+import { ProvidePlaceholderContext } from "lib/utils/placeholders"
 import { merge } from "lodash"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
@@ -26,24 +28,28 @@ jest.unmock("react-relay")
 describe("Artwork", () => {
   let environment: ReturnType<typeof createMockEnvironment>
   const TestRenderer = ({ isVisible = true }) => (
-    <QueryRenderer<ArtworkTestsQuery>
-      environment={environment}
-      query={graphql`
-        query ArtworkTestsQuery @relay_test_operation {
-          artwork(id: "doesn't matter") {
-            ...Artwork_artwork
-          }
-        }
-      `}
-      variables={{ hello: true }}
-      render={({ props, error }) => {
-        if (props) {
-          return <ArtworkContainer artwork={props.artwork} isVisible={isVisible} />
-        } else if (error) {
-          console.log(error)
-        }
-      }}
-    />
+    <Theme>
+      <ProvidePlaceholderContext>
+        <QueryRenderer<ArtworkTestsQuery>
+          environment={environment}
+          query={graphql`
+            query ArtworkTestsQuery @relay_test_operation {
+              artwork(id: "doesn't matter") {
+                ...Artwork_artwork
+              }
+            }
+          `}
+          variables={{ hello: true }}
+          render={({ props, error }) => {
+            if (props) {
+              return <ArtworkContainer artwork={props.artwork} isVisible={isVisible} />
+            } else if (error) {
+              console.log(error)
+            }
+          }}
+        />
+      </ProvidePlaceholderContext>
+    </Theme>
   )
 
   beforeEach(() => {

--- a/src/lib/Scenes/Artwork/__tests__/__snapshots__/Artwork-tests.tsx.snap
+++ b/src/lib/Scenes/Artwork/__tests__/__snapshots__/Artwork-tests.tsx.snap
@@ -895,14 +895,15 @@ exports[`Artwork renders a snapshot 1`] = `
           style={
             Array [
               Object {
-                "backgroundColor": "#e5e5e5",
-                "height": 1,
-                "marginLeft": -40,
-                "marginRight": -40,
+                "borderBottomWidth": 0,
+                "borderColor": "#E5E5E5",
+                "borderStyle": "solid",
+                "borderWidth": 1,
+                "width": "100%",
               },
-              undefined,
             ]
           }
+          width="100%"
         />
       </View>
     </View>
@@ -1006,14 +1007,15 @@ exports[`Artwork renders a snapshot 1`] = `
           style={
             Array [
               Object {
-                "backgroundColor": "#e5e5e5",
-                "height": 1,
-                "marginLeft": -40,
-                "marginRight": -40,
+                "borderBottomWidth": 0,
+                "borderColor": "#E5E5E5",
+                "borderStyle": "solid",
+                "borderWidth": 1,
+                "width": "100%",
               },
-              undefined,
             ]
           }
+          width="100%"
         />
       </View>
     </View>
@@ -1160,14 +1162,15 @@ exports[`Artwork renders a snapshot 1`] = `
           style={
             Array [
               Object {
-                "backgroundColor": "#e5e5e5",
-                "height": 1,
-                "marginLeft": -40,
-                "marginRight": -40,
+                "borderBottomWidth": 0,
+                "borderColor": "#E5E5E5",
+                "borderStyle": "solid",
+                "borderWidth": 1,
+                "width": "100%",
               },
-              undefined,
             ]
           }
+          width="100%"
         />
       </View>
     </View>
@@ -1656,14 +1659,15 @@ exports[`Artwork renders a snapshot 1`] = `
           style={
             Array [
               Object {
-                "backgroundColor": "#e5e5e5",
-                "height": 1,
-                "marginLeft": -40,
-                "marginRight": -40,
+                "borderBottomWidth": 0,
+                "borderColor": "#E5E5E5",
+                "borderStyle": "solid",
+                "borderWidth": 1,
+                "width": "100%",
               },
-              undefined,
             ]
           }
+          width="100%"
         />
       </View>
     </View>
@@ -1862,14 +1866,15 @@ exports[`Artwork renders a snapshot 1`] = `
           style={
             Array [
               Object {
-                "backgroundColor": "#e5e5e5",
-                "height": 1,
-                "marginLeft": -40,
-                "marginRight": -40,
+                "borderBottomWidth": 0,
+                "borderColor": "#E5E5E5",
+                "borderStyle": "solid",
+                "borderWidth": 1,
+                "width": "100%",
               },
-              undefined,
             ]
           }
+          width="100%"
         />
       </View>
     </View>
@@ -2432,14 +2437,15 @@ exports[`Artwork renders a snapshot 1`] = `
           style={
             Array [
               Object {
-                "backgroundColor": "#e5e5e5",
-                "height": 1,
-                "marginLeft": -40,
-                "marginRight": -40,
+                "borderBottomWidth": 0,
+                "borderColor": "#E5E5E5",
+                "borderStyle": "solid",
+                "borderWidth": 1,
+                "width": "100%",
               },
-              undefined,
             ]
           }
+          width="100%"
         />
       </View>
     </View>
@@ -2951,14 +2957,15 @@ exports[`Artwork renders a snapshot 1`] = `
           style={
             Array [
               Object {
-                "backgroundColor": "#e5e5e5",
-                "height": 1,
-                "marginLeft": -40,
-                "marginRight": -40,
+                "borderBottomWidth": 0,
+                "borderColor": "#E5E5E5",
+                "borderStyle": "solid",
+                "borderWidth": 1,
+                "width": "100%",
               },
-              undefined,
             ]
           }
+          width="100%"
         />
       </View>
     </View>

--- a/src/lib/Scenes/Artwork/__tests__/__snapshots__/Artwork-tests.tsx.snap
+++ b/src/lib/Scenes/Artwork/__tests__/__snapshots__/Artwork-tests.tsx.snap
@@ -179,56 +179,19 @@ exports[`Artwork renders a snapshot 1`] = `
                     ]
                   }
                 >
-                  <View
+                  <AROpaqueImageView
+                    aspectRatio={1}
+                    highPriority={true}
+                    imageURL="https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=84&height=84&quality=80&src=%3Cmock-value-for-field-%22url%22%3E"
+                    onLoad={[Function]}
                     style={
                       Object {
                         "height": 42,
-                        "position": "absolute",
                         "width": 42,
                       }
                     }
-                  >
-                    <AROpaqueImageView
-                      aspectRatio={1}
-                      highPriority={true}
-                      imageURL="https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&width=84&height=84&quality=80&src=%3Cmock-value-for-field-%22url%22%3E"
-                      noAnimation={true}
-                      onLoad={[Function]}
-                      style={
-                        Object {
-                          "height": 42,
-                          "width": 42,
-                        }
-                      }
-                      useRawURL={true}
-                    />
-                  </View>
-                  <View
-                    style={
-                      Object {
-                        "backgroundColor": "white",
-                        "flex": 1,
-                        "height": 42,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "width": 42,
-                      }
-                    }
-                  >
-                    <View
-                      style={
-                        Object {
-                          "alignItems": "center",
-                          "backgroundColor": "#F8F8F8",
-                          "flex": 1,
-                          "justifyContent": "center",
-                          "opacity": 0,
-                        }
-                      }
-                    >
-                      <ARSpinner />
-                    </View>
-                  </View>
+                    useRawURL={true}
+                  />
                 </View>
               </View>
             </View>

--- a/src/lib/utils/__tests__/placeholders-tests.tsx
+++ b/src/lib/utils/__tests__/placeholders-tests.tsx
@@ -1,0 +1,29 @@
+import React from "react"
+import ReactTestRenderer from "react-test-renderer"
+import { Placeholder, ProvidePlaceholderContext, RaggedText } from "../placeholders"
+
+describe(Placeholder, () => {
+  it(`requires a placeholder context`, async () => {
+    expect(() => {
+      ReactTestRenderer.create(<Placeholder width={400} />)
+    }).toThrowErrorMatchingInlineSnapshot(`"You're using a Placeholder outside of a PlaceholderContext"`)
+
+    ReactTestRenderer.create(
+      <ProvidePlaceholderContext>
+        <Placeholder width={400} />
+      </ProvidePlaceholderContext>
+    )
+  })
+})
+
+describe(RaggedText, () => {
+  it(`creates the right number of placeholders matching the given number of lines`, () => {
+    const tree = ReactTestRenderer.create(
+      <ProvidePlaceholderContext>
+        <RaggedText numLines={4} />
+      </ProvidePlaceholderContext>
+    )
+
+    expect(tree.root.findAllByType(Placeholder)).toHaveLength(4)
+  })
+})

--- a/src/lib/utils/__tests__/placeholders-tests.tsx
+++ b/src/lib/utils/__tests__/placeholders-tests.tsx
@@ -1,29 +1,29 @@
 import React from "react"
 import ReactTestRenderer from "react-test-renderer"
-import { Placeholder, ProvidePlaceholderContext, RaggedText } from "../placeholders"
+import { PlaceholderBox, PlaceholderRaggedText, ProvidePlaceholderContext } from "../placeholders"
 
-describe(Placeholder, () => {
+describe(PlaceholderBox, () => {
   it(`requires a placeholder context`, async () => {
     expect(() => {
-      ReactTestRenderer.create(<Placeholder width={400} />)
+      ReactTestRenderer.create(<PlaceholderBox width={400} />)
     }).toThrowErrorMatchingInlineSnapshot(`"You're using a Placeholder outside of a PlaceholderContext"`)
 
     ReactTestRenderer.create(
       <ProvidePlaceholderContext>
-        <Placeholder width={400} />
+        <PlaceholderBox width={400} />
       </ProvidePlaceholderContext>
     )
   })
 })
 
-describe(RaggedText, () => {
+describe(PlaceholderRaggedText, () => {
   it(`creates the right number of placeholders matching the given number of lines`, () => {
     const tree = ReactTestRenderer.create(
       <ProvidePlaceholderContext>
-        <RaggedText numLines={4} />
+        <PlaceholderRaggedText numLines={4} />
       </ProvidePlaceholderContext>
     )
 
-    expect(tree.root.findAllByType(Placeholder)).toHaveLength(4)
+    expect(tree.root.findAllByType(PlaceholderBox)).toHaveLength(4)
   })
 })

--- a/src/lib/utils/__tests__/renderWithLoadProgress-tests.tsx
+++ b/src/lib/utils/__tests__/renderWithLoadProgress-tests.tsx
@@ -1,63 +1,26 @@
-import { mount } from "enzyme"
-import * as React from "react"
-import { Image, Text, View } from "react-native"
-import { Artwork, badQuery, query, renderToString } from "../../tests/__tests__/MockRelayRendererFixtures"
-import { MockRelayRenderer } from "../../tests/MockRelayRenderer"
-import { renderUntil } from "../../tests/renderUntil"
+import Spinner from "lib/Components/Spinner"
+import { extractText } from "lib/tests/extractText"
+import React from "react"
+import { Text } from "react-native"
+import ReactTestRenderer from "react-test-renderer"
+import renderWithLoadProgress from "../renderWithLoadProgress"
 
-jest.unmock("react-relay")
+describe(renderWithLoadProgress, () => {
+  it(`renders a spinner while the graphqls are loaeding`, () => {
+    const result = renderWithLoadProgress(() => null, {})({ error: null, props: null, retry: () => null })
 
-describe("MockRelayRenderer", () => {
-  it("renders a Relay tree", async () => {
-    const tree = await renderUntil(
-      wrapper => wrapper.text().includes("Mona Lisa"),
-      <MockRelayRenderer
-        Component={Artwork}
-        query={query}
-        mockResolvers={{
-          Artwork: () => ({
-            title: "Mona Lisa",
-            image: {
-              url: "http://test/image.jpg",
-            },
-            artist: null,
-          }),
-        }}
-      />
-    )
-    expect(tree.html()).toEqual(
-      renderToString(
-        <View>
-          <Image source={{ uri: "http://test/image.jpg" }} />
-          <Text>Mona Lisa</Text>
-        </View>
-      )
-    )
+    expect(React.isValidElement(result)).toBeTruthy()
+
+    const tree = ReactTestRenderer.create(result)
+    expect(tree.root.findByType(Spinner)).toBeTruthy()
   })
-
-  it("renders an error when child components throw", () => {
-    console.log = () => null // MockRelayRenderer prints out error info to the console, let's silence it.
-    const tree = mount(
-      <MockRelayRenderer
-        Component={Artwork}
-        query={badQuery}
-        mockResolvers={{
-          Artwork: () => ({
-            title: "Mona Lisa",
-            image: {
-              url: "http://test/image.jpg",
-            },
-            artist: null,
-          }),
-        }}
-      />
-    )
-    tree.setState({
-      caughtError: {
-        error: new Error("Hey it's an error!"),
-        errorInfo: {},
-      },
-    })
-    expect(tree.update().text()).toEqual("Error occurred while rendering Relay component: Error: Hey it's an error!")
+  it(`renders the real content when the graphqls are done`, () => {
+    const result = renderWithLoadProgress(
+      () => <Text>the real content</Text>,
+      {}
+    )({ error: null, props: {}, retry: () => null })
+    expect(React.isValidElement(result)).toBeTruthy()
+    const tree = ReactTestRenderer.create(result)
+    expect(extractText(tree.root)).toBe("the real content")
   })
 })

--- a/src/lib/utils/__tests__/renderWithPlaceholder-tests.tsx
+++ b/src/lib/utils/__tests__/renderWithPlaceholder-tests.tsx
@@ -1,0 +1,28 @@
+import { extractText } from "lib/tests/extractText"
+import React from "react"
+import { Text } from "react-native"
+import ReactTestRenderer from "react-test-renderer"
+import { renderWithPlaceholder } from "../renderWithPlaceholder"
+
+describe(renderWithPlaceholder, () => {
+  it(`renders the placeholder while the graphqls are loading`, () => {
+    const result = renderWithPlaceholder({
+      Container: () => null,
+      renderPlaceholder: () => <Text>this is the placeholder</Text>,
+    })({ error: null, props: null, retry: () => null })
+
+    expect(React.isValidElement(result)).toBeTruthy()
+
+    const tree = ReactTestRenderer.create(result)
+    expect(extractText(tree.root)).toBe("this is the placeholder")
+  })
+  it(`renders the real content when the graphqls are done`, () => {
+    const result = renderWithPlaceholder({
+      Container: () => <Text>the real content</Text>,
+      renderPlaceholder: () => <Text>this is the placeholder</Text>,
+    })({ error: null, props: {}, retry: () => null })
+    expect(React.isValidElement(result)).toBeTruthy()
+    const tree = ReactTestRenderer.create(result)
+    expect(extractText(tree.root)).toBe("the real content")
+  })
+})

--- a/src/lib/utils/placeholders.tsx
+++ b/src/lib/utils/placeholders.tsx
@@ -67,13 +67,20 @@ export const PlaceholderText: React.FC<ViewStyle> = ({ ...props }) => {
   return <PlaceholderBox height={TEXT_HEIGHT} marginBottom={TEXT_MARGIN} {...props} />
 }
 
-export const PlaceholderRaggedText: React.FC<{ numLines: number }> = ({ numLines }) => {
+export const PlaceholderRaggedText: React.FC<{ numLines: number; seed?: number }> = ({ numLines, seed = 10 }) => {
   const lengths = useMemo(() => {
+    // create our own little deterministic math.random() to avoid snapshot churn
+    let x = seed
+    function random() {
+      const y = Math.sin(x++) * 10000
+      return y - Math.floor(y)
+    }
+
     const result = []
     for (let i = 0; i < numLines - 1; i++) {
-      result.push(Math.random() * 0.15 + 0.85)
+      result.push(random() * 0.15 + 0.85)
     }
-    result.push(Math.random() * 0.3 + 0.2)
+    result.push(random() * 0.3 + 0.2)
     return result
   }, [numLines])
 

--- a/src/lib/utils/placeholders.tsx
+++ b/src/lib/utils/placeholders.tsx
@@ -50,7 +50,7 @@ export const Placeholder: React.FC<ViewStyle> = styles => {
   return (
     <Animated.View
       ref={ref}
-      style={[styles, { opacity, backgroundColor: color("black10") }] as any}
+      style={[{ borderRadius: 2 }, styles, { opacity, backgroundColor: color("black10") }] as any}
       onLayout={() => {
         ref.current.getNode().measureInWindow((_w, h, _x, y) => {
           verticalOffset.setValue(-y + h / 2)

--- a/src/lib/utils/placeholders.tsx
+++ b/src/lib/utils/placeholders.tsx
@@ -1,4 +1,4 @@
-import { color, space } from "@artsy/palette"
+import { color } from "@artsy/palette"
 import React, { useContext, useEffect, useMemo, useRef } from "react"
 import { View, ViewStyle } from "react-native"
 import Animated from "react-native-reanimated"
@@ -61,6 +61,8 @@ export const Placeholder: React.FC<ViewStyle> = styles => {
 }
 
 export const RaggedText: React.FC<{ numLines: number }> = ({ numLines }) => {
+  const marginHeight = 7
+  const textHeight = 12
   const lengths = useMemo(() => {
     const result = []
     for (let i = 0; i < numLines - 1; i++) {
@@ -71,9 +73,11 @@ export const RaggedText: React.FC<{ numLines: number }> = ({ numLines }) => {
   }, [numLines])
 
   return (
-    <View style={{ flexDirection: "column", justifyContent: "flex-start", height: (space(0.5) + space(1)) * numLines }}>
+    <View
+      style={{ flexDirection: "column", justifyContent: "flex-start", height: (marginHeight + textHeight) * numLines }}
+    >
       {lengths.map((length, key) => (
-        <View key={key} style={{ flexDirection: "row", marginBottom: space(0.5), height: space(1) }}>
+        <View key={key} style={{ flexDirection: "row", marginBottom: marginHeight, height: textHeight }}>
           <Placeholder flex={length} />
         </View>
       ))}

--- a/src/lib/utils/placeholders.tsx
+++ b/src/lib/utils/placeholders.tsx
@@ -31,7 +31,7 @@ export const ProvidePlaceholderContext: React.FC<{}> = ({ children }) => {
   return <PlaceholderContext.Provider value={{ clock }} children={children} />
 }
 
-export const Placeholder: React.FC<ViewStyle> = styles => {
+export const PlaceholderBox: React.FC<ViewStyle> = styles => {
   const ctx = useContext(PlaceholderContext)
   if (!ctx) {
     throw new Error("You're using a Placeholder outside of a PlaceholderContext")
@@ -60,9 +60,14 @@ export const Placeholder: React.FC<ViewStyle> = styles => {
   )
 }
 
-export const RaggedText: React.FC<{ numLines: number }> = ({ numLines }) => {
-  const marginHeight = 7
-  const textHeight = 12
+const TEXT_HEIGHT = 12
+const TEXT_MARGIN = 7
+
+export const PlaceholderText: React.FC<ViewStyle> = ({ ...props }) => {
+  return <PlaceholderBox height={TEXT_HEIGHT} marginBottom={TEXT_MARGIN} {...props} />
+}
+
+export const PlaceholderRaggedText: React.FC<{ numLines: number }> = ({ numLines }) => {
   const lengths = useMemo(() => {
     const result = []
     for (let i = 0; i < numLines - 1; i++) {
@@ -73,12 +78,10 @@ export const RaggedText: React.FC<{ numLines: number }> = ({ numLines }) => {
   }, [numLines])
 
   return (
-    <View
-      style={{ flexDirection: "column", justifyContent: "flex-start", height: (marginHeight + textHeight) * numLines }}
-    >
+    <View style={{ justifyContent: "flex-start" }}>
       {lengths.map((length, key) => (
-        <View key={key} style={{ flexDirection: "row", marginBottom: marginHeight, height: textHeight }}>
-          <Placeholder flex={length} />
+        <View style={{ flexDirection: "row" }}>
+          <PlaceholderText flex={length} key={key}></PlaceholderText>
         </View>
       ))}
     </View>

--- a/src/lib/utils/placeholders.tsx
+++ b/src/lib/utils/placeholders.tsx
@@ -1,0 +1,82 @@
+import { color, space } from "@artsy/palette"
+import React, { useContext, useEffect, useMemo, useRef } from "react"
+import { View, ViewStyle } from "react-native"
+import Animated from "react-native-reanimated"
+
+const PlaceholderContext = React.createContext<{ clock: Animated.Clock }>(null)
+
+function useCurrentTime() {
+  const isMounted = useMemo(() => {
+    return new Animated.Value(1 as number)
+  }, [])
+  const clock = useMemo(() => {
+    return new Animated.Clock()
+  }, [])
+  useEffect(() => {
+    // isMounted starts as true so nothing to do here
+    return () => {
+      // this is called when the component unmounts
+      isMounted.setValue(0)
+    }
+  }, [])
+  Animated.useCode(
+    () => Animated.onChange(isMounted, Animated.cond(isMounted, Animated.startClock(clock), Animated.stopClock(clock))),
+    []
+  )
+  return clock
+}
+
+export const ProvidePlaceholderContext: React.FC<{}> = ({ children }) => {
+  const clock = useCurrentTime()
+  return <PlaceholderContext.Provider value={{ clock }} children={children} />
+}
+
+export const Placeholder: React.FC<ViewStyle> = styles => {
+  const ctx = useContext(PlaceholderContext)
+  if (!ctx) {
+    throw new Error("You're using a Placeholder outside of a PlaceholderContext")
+  }
+  const { clock } = ctx
+  const verticalOffset = useMemo(() => {
+    return new Animated.Value(0 as number)
+  }, [])
+  const { opacity } = useMemo(() => {
+    const offsetClock = Animated.sub(clock, Animated.divide(verticalOffset, 2))
+    const scaledClock = Animated.divide(offsetClock, 230)
+    const pulse = Animated.sin(scaledClock)
+    return { opacity: Animated.sub(1, Animated.divide(pulse, 3)) }
+  }, [])
+  const ref = useRef<Animated.View>()
+  return (
+    <Animated.View
+      ref={ref}
+      style={[styles, { opacity, backgroundColor: color("black10") }] as any}
+      onLayout={() => {
+        ref.current.getNode().measureInWindow((_w, h, _x, y) => {
+          verticalOffset.setValue(-y + h / 2)
+        })
+      }}
+    />
+  )
+}
+
+export const RaggedText: React.FC<{ numLines: number }> = ({ numLines }) => {
+  const lengths = useMemo(() => {
+    const result = []
+    for (let i = 0; i < numLines - 1; i++) {
+      result.push(Math.random() * 0.15 + 0.85)
+    }
+    result.push(Math.random() * 0.3 + 0.2)
+    return result
+  }, [numLines])
+
+  return (
+    <View style={{ flexDirection: "column", justifyContent: "flex-start", height: (space(0.5) + space(1)) * numLines }}>
+      {lengths.map((length, key) => (
+        <View key={key} style={{ flexDirection: "row", marginBottom: space(0.5), height: space(1) }}>
+          <Placeholder flex={length} />
+        </View>
+      ))}
+    </View>
+  )
+}

--- a/src/lib/utils/renderWithLoadProgress.tsx
+++ b/src/lib/utils/renderWithLoadProgress.tsx
@@ -1,8 +1,7 @@
+import Spinner from "lib/Components/Spinner"
 import React from "react"
 import { Container as RelayContainer, QueryRenderer } from "react-relay"
-
-import LoadFailureView from "lib/Components/LoadFailureView"
-import Spinner from "lib/Components/Spinner"
+import { renderWithPlaceholder } from "./renderWithPlaceholder"
 
 type ReadyState = Parameters<React.ComponentProps<typeof QueryRenderer>["render"]>[0]
 
@@ -12,42 +11,9 @@ export default function<T extends RelayContainer<any>>(
   Container: T,
   initialProps: object = {}
 ): (readyState: ReadyState) => React.ReactElement<T> | null {
-  let retrying = false
-  return ({ error, props, retry }) => {
-    if (error) {
-      // In tests we want errors to clearly bubble up.
-      if (typeof jest !== "undefined") {
-        throw error
-      } else {
-        console.error(error)
-      }
-
-      const networkError = error as any
-      if (networkError.response && networkError.response._bodyInit) {
-        let data = networkError.response._bodyInit || "{}"
-        try {
-          data = JSON.parse(data)
-          // tslint:disable-next-line:no-empty
-        } catch (e) {}
-        console.error("Error data", data)
-      }
-
-      if (retrying) {
-        retrying = false
-        // TODO: Even though this code path is reached, the retry button keeps spinning. iirc it _should_ disappear when
-        //      `onRetry` on the instance is unset.
-        //
-        // This will re-use the native view first created in the renderFailure callback, which means it can
-        // continue its ‘retry’ animation.
-        return <LoadFailureView style={{ flex: 1 }} />
-      } else {
-        retrying = true
-        return <LoadFailureView onRetry={retry} style={{ flex: 1 }} />
-      }
-    } else if (props) {
-      return <Container {...initialProps} {...props as any} />
-    } else {
-      return <Spinner testID={LoadingTestID} style={{ flex: 1 }} />
-    }
-  }
+  return renderWithPlaceholder({
+    Container,
+    initialProps,
+    renderPlaceholder: () => <Spinner testID={LoadingTestID} style={{ flex: 1 }} />,
+  })
 }

--- a/src/lib/utils/renderWithPlaceholder.tsx
+++ b/src/lib/utils/renderWithPlaceholder.tsx
@@ -1,0 +1,56 @@
+import React from "react"
+import { Container as RelayContainer, QueryRenderer } from "react-relay"
+
+import LoadFailureView from "lib/Components/LoadFailureView"
+import { ProvidePlaceholderContext } from "./placeholders"
+
+type ReadyState = Parameters<React.ComponentProps<typeof QueryRenderer>["render"]>[0]
+
+export function renderWithPlaceholder<T extends RelayContainer<any>>({
+  Container,
+  renderPlaceholder,
+  initialProps = {},
+}: {
+  Container: T
+  renderPlaceholder: () => React.ReactChild
+  initialProps?: object
+}): (readyState: ReadyState) => React.ReactElement<T> | null {
+  let retrying = false
+  return ({ error, props, retry }) => {
+    if (error) {
+      // In tests we want errors to clearly bubble up.
+      if (typeof jest !== "undefined") {
+        throw error
+      } else {
+        console.error(error)
+      }
+
+      const networkError = error as any
+      if (networkError.response && networkError.response._bodyInit) {
+        let data = networkError.response._bodyInit || "{}"
+        try {
+          data = JSON.parse(data)
+          // tslint:disable-next-line:no-empty
+        } catch (e) {}
+        console.error("Error data", data)
+      }
+
+      if (retrying) {
+        retrying = false
+        // TODO: Even though this code path is reached, the retry button keeps spinning. iirc it _should_ disappear when
+        //      `onRetry` on the instance is unset.
+        //
+        // This will re-use the native view first created in the renderFailure callback, which means it can
+        // continue its ‘retry’ animation.
+        return <LoadFailureView style={{ flex: 1 }} />
+      } else {
+        retrying = true
+        return <LoadFailureView onRetry={retry} style={{ flex: 1 }} />
+      }
+    } else if (props) {
+      return <Container {...initialProps} {...(props as any)} />
+    } else {
+      return <ProvidePlaceholderContext>{renderPlaceholder()}</ProvidePlaceholderContext>
+    }
+  }
+}


### PR DESCRIPTION
first part of https://artsyproduct.atlassian.net/browse/MX-158, adding a placeholder loading screen for the artwork page.

next task is to spike on splitting the page query into above-the-fold and below-the-fold content.

![improved-artwork-placeholder](https://user-images.githubusercontent.com/1242537/74050791-9f203480-49ce-11ea-9aad-fef8a23f5f97.gif)
