### PR TITLE
[FX-1748] Fix line-height in ReadMore component

### DIFF
--- a/src/lib/Components/ReadMore.tsx
+++ b/src/lib/Components/ReadMore.tsx
@@ -31,7 +31,7 @@ export const ReadMore = React.memo(
         ...basicRules.paragraph,
         react: (node, output, state) => {
           return (
-            <TextComponent size="3t" color={color || "black100"} key={state.key}>
+            <TextComponent size="3" color={color || "black100"} key={state.key}>
               {!isExpanded && Number(state.key) > 0 ? "⁠ — " : null}
               {output(node.content, state)}
             </TextComponent>

--- a/src/lib/Scenes/Artwork/__tests__/__snapshots__/Artwork-tests.tsx.snap
+++ b/src/lib/Scenes/Artwork/__tests__/__snapshots__/Artwork-tests.tsx.snap
@@ -1100,14 +1100,14 @@ exports[`Artwork renders a snapshot 1`] = `
           color="black100"
           fontFamily="ReactNativeAGaramondPro-Regular"
           fontSize="16px"
-          lineHeight="20px"
+          lineHeight="24px"
           style={
             Array [
               Object {
                 "color": "#000",
                 "fontFamily": "ReactNativeAGaramondPro-Regular",
                 "fontSize": 16,
-                "lineHeight": 20,
+                "lineHeight": 24,
               },
               Object {},
             ]
@@ -1159,14 +1159,14 @@ exports[`Artwork renders a snapshot 1`] = `
             color="black100"
             fontFamily="ReactNativeAGaramondPro-Regular"
             fontSize="16px"
-            lineHeight="20px"
+            lineHeight="24px"
             style={
               Array [
                 Object {
                   "color": "#000",
                   "fontFamily": "ReactNativeAGaramondPro-Regular",
                   "fontSize": 16,
-                  "lineHeight": 20,
+                  "lineHeight": 24,
                 },
                 Object {},
               ]
@@ -1279,14 +1279,14 @@ exports[`Artwork renders a snapshot 1`] = `
             color="black60"
             fontFamily="Unica77LL-Regular"
             fontSize="14px"
-            lineHeight="20px"
+            lineHeight="24px"
             style={
               Array [
                 Object {
                   "color": "#666",
                   "fontFamily": "Unica77LL-Regular",
                   "fontSize": 14,
-                  "lineHeight": 20,
+                  "lineHeight": 24,
                 },
                 Object {},
               ]
@@ -1326,14 +1326,14 @@ exports[`Artwork renders a snapshot 1`] = `
             color="black60"
             fontFamily="Unica77LL-Regular"
             fontSize="14px"
-            lineHeight="20px"
+            lineHeight="24px"
             style={
               Array [
                 Object {
                   "color": "#666",
                   "fontFamily": "Unica77LL-Regular",
                   "fontSize": 14,
-                  "lineHeight": 20,
+                  "lineHeight": 24,
                 },
                 Object {},
               ]
@@ -1373,14 +1373,14 @@ exports[`Artwork renders a snapshot 1`] = `
             color="black60"
             fontFamily="Unica77LL-Regular"
             fontSize="14px"
-            lineHeight="20px"
+            lineHeight="24px"
             style={
               Array [
                 Object {
                   "color": "#666",
                   "fontFamily": "Unica77LL-Regular",
                   "fontSize": 14,
-                  "lineHeight": 20,
+                  "lineHeight": 24,
                 },
                 Object {},
               ]
@@ -1420,14 +1420,14 @@ exports[`Artwork renders a snapshot 1`] = `
             color="black60"
             fontFamily="Unica77LL-Regular"
             fontSize="14px"
-            lineHeight="20px"
+            lineHeight="24px"
             style={
               Array [
                 Object {
                   "color": "#666",
                   "fontFamily": "Unica77LL-Regular",
                   "fontSize": 14,
-                  "lineHeight": 20,
+                  "lineHeight": 24,
                 },
                 Object {},
               ]
@@ -1467,14 +1467,14 @@ exports[`Artwork renders a snapshot 1`] = `
             color="black60"
             fontFamily="Unica77LL-Regular"
             fontSize="14px"
-            lineHeight="20px"
+            lineHeight="24px"
             style={
               Array [
                 Object {
                   "color": "#666",
                   "fontFamily": "Unica77LL-Regular",
                   "fontSize": 14,
-                  "lineHeight": 20,
+                  "lineHeight": 24,
                 },
                 Object {},
               ]
@@ -1514,14 +1514,14 @@ exports[`Artwork renders a snapshot 1`] = `
             color="black60"
             fontFamily="Unica77LL-Regular"
             fontSize="14px"
-            lineHeight="20px"
+            lineHeight="24px"
             style={
               Array [
                 Object {
                   "color": "#666",
                   "fontFamily": "Unica77LL-Regular",
                   "fontSize": 14,
-                  "lineHeight": 20,
+                  "lineHeight": 24,
                 },
                 Object {},
               ]
@@ -1561,14 +1561,14 @@ exports[`Artwork renders a snapshot 1`] = `
             color="black60"
             fontFamily="Unica77LL-Regular"
             fontSize="14px"
-            lineHeight="20px"
+            lineHeight="24px"
             style={
               Array [
                 Object {
                   "color": "#666",
                   "fontFamily": "Unica77LL-Regular",
                   "fontSize": 14,
-                  "lineHeight": 20,
+                  "lineHeight": 24,
                 },
                 Object {},
               ]
@@ -1608,14 +1608,14 @@ exports[`Artwork renders a snapshot 1`] = `
             color="black60"
             fontFamily="Unica77LL-Regular"
             fontSize="14px"
-            lineHeight="20px"
+            lineHeight="24px"
             style={
               Array [
                 Object {
                   "color": "#666",
                   "fontFamily": "Unica77LL-Regular",
                   "fontSize": 14,
-                  "lineHeight": 20,
+                  "lineHeight": 24,
                 },
                 Object {},
               ]
@@ -1655,14 +1655,14 @@ exports[`Artwork renders a snapshot 1`] = `
             color="black60"
             fontFamily="Unica77LL-Regular"
             fontSize="14px"
-            lineHeight="20px"
+            lineHeight="24px"
             style={
               Array [
                 Object {
                   "color": "#666",
                   "fontFamily": "Unica77LL-Regular",
                   "fontSize": 14,
-                  "lineHeight": 20,
+                  "lineHeight": 24,
                 },
                 Object {},
               ]
@@ -1749,14 +1749,14 @@ exports[`Artwork renders a snapshot 1`] = `
             color="black100"
             fontFamily="ReactNativeAGaramondPro-Regular"
             fontSize="16px"
-            lineHeight="20px"
+            lineHeight="24px"
             style={
               Array [
                 Object {
                   "color": "#000",
                   "fontFamily": "ReactNativeAGaramondPro-Regular",
                   "fontSize": 16,
-                  "lineHeight": 20,
+                  "lineHeight": 24,
                 },
                 Object {},
               ]
@@ -1805,14 +1805,14 @@ exports[`Artwork renders a snapshot 1`] = `
             color="black100"
             fontFamily="ReactNativeAGaramondPro-Regular"
             fontSize="16px"
-            lineHeight="20px"
+            lineHeight="24px"
             style={
               Array [
                 Object {
                   "color": "#000",
                   "fontFamily": "ReactNativeAGaramondPro-Regular",
                   "fontSize": 16,
-                  "lineHeight": 20,
+                  "lineHeight": 24,
                 },
                 Object {},
               ]
@@ -1861,14 +1861,14 @@ exports[`Artwork renders a snapshot 1`] = `
             color="black100"
             fontFamily="ReactNativeAGaramondPro-Regular"
             fontSize="16px"
-            lineHeight="20px"
+            lineHeight="24px"
             style={
               Array [
                 Object {
                   "color": "#000",
                   "fontFamily": "ReactNativeAGaramondPro-Regular",
                   "fontSize": 16,
-                  "lineHeight": 20,
+                  "lineHeight": 24,
                 },
                 Object {},
               ]
@@ -2431,14 +2431,14 @@ exports[`Artwork renders a snapshot 1`] = `
             color="black100"
             fontFamily="ReactNativeAGaramondPro-Regular"
             fontSize="16px"
-            lineHeight="20px"
+            lineHeight="24px"
             style={
               Array [
                 Object {
                   "color": "#000",
                   "fontFamily": "ReactNativeAGaramondPro-Regular",
                   "fontSize": 16,
-                  "lineHeight": 20,
+                  "lineHeight": 24,
                 },
                 Object {},
               ]

--- a/src/lib/Scenes/Collection/__tests__/__snapshots__/Collection-tests.tsx.snap
+++ b/src/lib/Scenes/Collection/__tests__/__snapshots__/Collection-tests.tsx.snap
@@ -1281,14 +1281,14 @@ exports[`Collection renders a snapshot 1`] = `
             color="black100"
             fontFamily="ReactNativeAGaramondPro-Regular"
             fontSize="16px"
-            lineHeight="20px"
+            lineHeight="24px"
             style={
               Array [
                 Object {
                   "color": "#000",
                   "fontFamily": "ReactNativeAGaramondPro-Regular",
                   "fontSize": 16,
-                  "lineHeight": 20,
+                  "lineHeight": 24,
                 },
                 Object {},
               ]


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-1748

This simply updates `ReadMore` to use font size `3` instead of `3t` (i.e. the <b>t</b>ightly-spaced variant)

### Phone

<img width="1106" alt="banda" src="https://user-images.githubusercontent.com/140521/74064537-de478900-49c0-11ea-8b16-4979901b753e.png">

### Tablet

![ipadbanda](https://user-images.githubusercontent.com/140521/74065148-38951980-49c2-11ea-91ea-5819e3f94268.png)

### Background

I was curious why this component was spec'd with `3t` size to begin with, so I did the Github and Jira archaeology to find:

- https://github.com/artsy/emission/pull/1654, which implements:

- https://artsyproduct.atlassian.net/browse/PURCHASE-1139, which includes the comp:

- https://app.zeplin.io/project/5ab94282c124db8d58365b47/screen/5cdb43f2b4655d1e7436ca1a

From there I can see that this component was 16/24 serif which does in fact [map to size 3](https://www.notion.so/artsy/Typography-42e0e8e4f4e34ccc84c7de7adcd1b519)

I figure this was an oversight that just persisted till now, so I think this change should be good to go, and @jeffreytr agrees!

