### PR TITLE
[MX-170] Increases Settings icon size

### DIFF
--- a/src/lib/Scenes/Favorites/index.tsx
+++ b/src/lib/Scenes/Favorites/index.tsx
@@ -76,7 +76,7 @@ class Favorites extends React.Component<Props, null> {
                     onPress={() => SwitchBoard.presentNavigationViewController(this, "ios-settings")}
                   >
                     <Box>
-                      <SettingsIcon />
+                      <SettingsIcon width={24} height={24} />
                     </Box>
                   </TouchableWithoutFeedback>
                 </Flex>


### PR DESCRIPTION
I was surprised to have to pass in explicit `width` and `height` props, instead of using CSS. Must be a weird React Native SVG thing.

<img width="630" alt="Screen Shot 2020-02-12 at 13 21 28" src="https://user-images.githubusercontent.com/498212/74364681-98ad0680-4d9a-11ea-9234-c21e52ad070d.png">
